### PR TITLE
Fix Visibility issues in LayoutFloatingWindowControl

### DIFF
--- a/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -162,7 +162,8 @@ namespace Xceed.Wpf.AvalonDock.Controls
         root.FloatingWindows.Remove( _model );
       }
 
-      SetBinding(VisibilityProperty, string.Empty);
+      // We have to clear binding instead of creating a new empty binding.
+      BindingOperations.ClearBinding(_model, VisibilityProperty);
 
       _model.PropertyChanged -= new System.ComponentModel.PropertyChangedEventHandler( _model_PropertyChanged );
     }

--- a/source/Components/Xceed.Wpf.AvalonDock/DockingManager.cs
+++ b/source/Components/Xceed.Wpf.AvalonDock/DockingManager.cs
@@ -2400,7 +2400,8 @@ namespace Xceed.Wpf.AvalonDock
           //fw.Owner = null;
           fw.SetParentWindowToNull();
           fw.KeepContentVisibleOnClose = true;
-          fw.Close();
+          // To avoid calling Close method multiple times.
+          fw.InternalClose();
         }
          _fwList.Clear();
 


### PR DESCRIPTION
In our application when we change the theme we have to reload the application layout. If we have a visible floating window after the theme change we have the following exceptions:

**MyApp.Common.Exceptions.BindingException: System.Windows.Data Error: 5 : Value produced by BindingExpression is not valid for target property.; Value='<null>' BindingExpression:Path=; DataItem=null; target element is 'LayoutAnchorableFloatingWindowControl' (Name=''); target property is 'Visibility' (type 'Visibility')**
at System.Diagnostics.TraceSource.TraceEvent(TraceEventType eventType, Int32 id, String format, Object[] args)
at MS.Internal.AvTrace.Trace(TraceEventType type, Int32 eventId, String message, String[] labels, Object[] parameters)
at MS.Internal.TraceData.Trace(TraceEventType type, AvTraceDetails traceDetails, Object p1, Object p2)
at System.Windows.Data.BindingExpression.TransferValue(Object newValue, Boolean isASubPropertyChange)
at System.Windows.Data.BindingExpression.Activate(Object item)
at System.Windows.Data.BindingExpression.AttachToContext(AttachAttempt attempt)
at System.Windows.Data.BindingExpression.MS.Internal.Data.IDataBindEngineClient.AttachToContext(Boolean lastChance)
at MS.Internal.Data.DataBindEngine.Task.Run(Boolean lastChance)
at MS.Internal.Data.DataBindEngine.Run(Object arg)
at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)

This exception occurs when we have additionally an opened modal window:

**System.InvalidOperationException: Cannot set Visibility to Visible or call Show, ShowDialog, Close, or WindowInteropHelper.EnsureHandle while a Window is closing.**
   at System.Windows.Window.VerifyNotClosing()
   at System.Windows.Window.InternalClose(Boolean shutdown, Boolean ignoreCancel)
   at Xceed.Wpf.AvalonDock.Controls.LayoutFloatingWindowControl.OnUnloaded(Object sender, RoutedEventArgs e)
   at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
   at System.Windows.UIElement.RaiseEventImpl(DependencyObject sender, RoutedEventArgs args)
   at System.Windows.BroadcastEventHelper.BroadcastEvent(DependencyObject root, RoutedEvent routedEvent)
   at System.Windows.BroadcastEventHelper.BroadcastUnloadedEvent(Object root)
   at MS.Internal.LoadedOrUnloadedOperation.DoWork()
   at System.Windows.Media.MediaContext.FireLoadedPendingCallbacks()
   at System.Windows.Media.MediaContext.FireInvokeOnRenderCallbacks()
   at System.Windows.Media.MediaContext.RenderMessageHandlerCore(Object resizedCompositionTarget)
   at System.Windows.Media.MediaContext.RenderMessageHandler(Object resizedCompositionTarget)
   at System.Windows.Interop.HwndTarget.OnResize()
   at System.Windows.Interop.HwndTarget.HandleMessage(WindowMessage msg, IntPtr wparam, IntPtr lparam)
   at System.Windows.Interop.HwndSource.HwndTargetFilterMessage(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
