### PR TITLE
Fix Visibility issue on closing LayoutFloatingWindowControl

### DIFF
--- a/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -15,6 +15,7 @@
   ***********************************************************************************/
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Runtime.InteropServices;
@@ -58,6 +59,7 @@ namespace Xceed.Wpf.AvalonDock.Controls
     {
       this.Loaded += new RoutedEventHandler( OnLoaded );
       this.Unloaded += new RoutedEventHandler( OnUnloaded );
+      Closing += OnClosing;
       _model = model;
     }
 
@@ -450,6 +452,19 @@ namespace Xceed.Wpf.AvalonDock.Controls
       {
         _hwndSrc.RemoveHook( _hwndSrcHook );
         InternalClose();
+      }
+    }
+
+    private void OnClosing(object sender, CancelEventArgs e)
+    {
+      Closing -= OnClosing;
+
+      // If this window was Closed not from InternalClose method,
+      // mark it as closing to avoid "InvalidOperationException: : Cannot set Visibility to Visible or call Show, ShowDialog,
+      // Close, or WindowInteropHelper.EnsureHandle while a Window is closing".
+      if (!_isClosing)
+      {
+        _isClosing = true;
       }
     }
 


### PR DESCRIPTION
The Issue is similar to one which we fixed with https://github.com/Dirkster99/AvalonDock/pull/36/files#diff-a23d38de9c85b74a8efe7ef17b582374L2403

The only difference is that at first time of Close of floating window called not from InternalClose but by handling WindowMessage.WM_CLOSE in System.Windows.Window.cs

It has the same call stack:
System.InvalidOperationException: Cannot set Visibility to Visible or call Show, 
ShowDialog, Close, or WindowInteropHelper.EnsureHandle while a Window is closing.
at System.Windows.Window.VerifyNotClosing()
at System.Windows.Window.InternalClose(Boolean shutdown, Boolean ignoreCancel)
at Xceed.Wpf.AvalonDock.DockingManager.DockingManager_Unloaded(Object sender, 
RoutedEventArgs e)
at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs 
args, Boolean reRaised)
at System.Windows.UIElement.RaiseEventImpl(DependencyObject sender, 
RoutedEventArgs args)
at System.Windows.BroadcastEventHelper.BroadcastEvent(DependencyObject root, 
RoutedEvent routedEvent)
at System.Windows.BroadcastEventHelper.BroadcastUnloadedEvent(Object root)
at MS.Internal.LoadedOrUnloadedOperation.DoWork()
at System.Windows.Media.MediaContext.FireLoadedPendingCallbacks()
at System.Windows.Media.MediaContext.FireInvokeOnRenderCallbacks()
at System.Windows.Media.MediaContext.RenderMessageHandlerCore(Object 
resizedCompositionTarget)
at System.Windows.Media.MediaContext.RenderMessageHandler(Object 
resizedCompositionTarget)
at System.Windows.Interop.HwndTarget.OnResize()
at System.Windows.Interop.HwndTarget.HandleMessage(WindowMessage msg, IntPtr 
wparam, IntPtr lparam)
at System.Windows.Interop.HwndSource.HwndTargetFilterMessage(IntPtr hwnd, Int32 
msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr 
lParam, Boolean& handled)
at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback,
Object args, Int32 numArgs)
at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, 
Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
