### PR TITLE
fix null reference

### DIFF
--- a/source/Components/Xceed.Wpf.AvalonDock/Layout/LayoutContent.cs
+++ b/source/Components/Xceed.Wpf.AvalonDock/Layout/LayoutContent.cs
@@ -869,7 +869,7 @@ namespace Xceed.Wpf.AvalonDock.Layout
           PreviousContainerId = (parentAsGroup as ILayoutPaneSerializable).Id;
           
           // This parentAsGroup will be removed in the GarbageCollection below
-          if (parentAsGroup.Children.Count() == 1 && parentAsGroup.Parent != null)
+          if (parentAsGroup.Children.Count() == 1 && parentAsGroup.Parent != null && Root.Manager != null)
           {
             Parent = Root.Manager.Layout;
             PreviousContainer = parentAsGroup.Parent;


### PR DESCRIPTION
My application is unable to deserialize AvalonDock xml data cause of a null reference: Root.Manager is null during deserializing. This fixes that issue, and deserialization works fine again.