### PR TITLE
Fix reopening of Floating windows after they were closed from Unload …

### DIFF
--- a/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -403,9 +403,9 @@ namespace Xceed.Wpf.AvalonDock.Controls
       return IntPtr.Zero;
     }
 
-    internal void InternalClose()
+    internal void InternalClose(bool closeInitiatedByUser = false)
     {
-      _internalCloseFlag = true;
+      _internalCloseFlag = !closeInitiatedByUser;
       if( !_isClosing )
       {
         _isClosing = true;

--- a/source/Components/Xceed.Wpf.AvalonDock/DockingManager.cs
+++ b/source/Components/Xceed.Wpf.AvalonDock/DockingManager.cs
@@ -2425,7 +2425,7 @@ namespace Xceed.Wpf.AvalonDock
           fw.SetParentWindowToNull();
           fw.KeepContentVisibleOnClose = true;
           // To avoid calling Close method multiple times.
-          fw.InternalClose();
+          fw.InternalClose(true);
         }
          _fwList.Clear();
 


### PR DESCRIPTION
…handler of DockingManager

In PR #36 I did not take into account that InternalClose of LayoutFloatingWindowControl sets _internalCloseFlag flag to true. It's become cause of issue when floating window not reopens after we unload and load the main window (and docking manager as well).
This bug can be represented in MLibTest project by next steps:

1. Add TabControl to MainWindow.xaml, by next template:
```
<TabControl Grid.Row="1">
    <TabItem Name="tab1" Header="tab 1">
        <avalonDock:DockingManager x:Name="dockManager"
            ...
        </avalonDock:DockingManager>
    </TabItem>
    <TabItem Name="tab2" Header="tab 2">
        <TextBlock Text="tab2"></TextBlock>
    </TabItem>
</TabControl>
```
2. Start application and undock any panel;
3. Switch to the tab 2
4. Switch back to the tab 1
As result the floating window with undocked panel will not appear