### PR TITLE
The minimum sizes of the floating window are made on the basis of ...

### DIFF
--- a/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -52,6 +52,23 @@ namespace Xceed.Wpf.AvalonDock.Controls
       HideWindowCommand = new RelayCommand( ( p ) => OnExecuteHideWindowCommand( p ), ( p ) => CanExecuteHideWindowCommand( p ) );
       CloseWindowCommand = new RelayCommand( ( p ) => OnExecuteCloseWindowCommand( p ), ( p ) => CanExecuteCloseWindowCommand( p ) );
       UpdateThemeResources();
+      MinWidth = _model.RootPanel.CalculatedDockMinWidth();
+      MinHeight = _model.RootPanel.CalculatedDockMinHeight();
+      
+      LayoutRoot root = _model.Root as LayoutRoot;
+      if (root != null)
+      {
+        root.Updated += OnRootUpdated;
+      }
+    }
+
+    private void OnRootUpdated(object sender, EventArgs e)
+    {
+      if (_model?.RootPanel != null)
+      {
+        MinWidth = _model.RootPanel.CalculatedDockMinWidth();
+        MinHeight = _model.RootPanel.CalculatedDockMinHeight();
+      }
     }
 
     internal LayoutAnchorableFloatingWindowControl( LayoutAnchorableFloatingWindow model)
@@ -146,6 +163,12 @@ namespace Xceed.Wpf.AvalonDock.Controls
       var root = Model.Root;
       if( root != null )
       {
+        LayoutRoot layoutRoot = root as LayoutRoot;
+        if (layoutRoot != null)
+        {
+          layoutRoot.Updated -= OnRootUpdated;
+        }
+
         root.Manager.RemoveFloatingWindow( this );
         root.CollectGarbage();
       }
@@ -228,10 +251,23 @@ namespace Xceed.Wpf.AvalonDock.Controls
 
     private void _model_PropertyChanged( object sender, System.ComponentModel.PropertyChangedEventArgs e )
     {
-      if( e.PropertyName == "RootPanel" &&
-          _model.RootPanel == null )
+      switch (e.PropertyName)
       {
-        InternalClose();
+        case "RootPanel":
+          if (_model.RootPanel == null)
+          {
+            InternalClose();
+          }
+
+          break;
+
+        case "IsVisible":
+          if (_model.IsVisible != IsVisible)
+          {
+            Visibility = _model.IsVisible ? Visibility.Visible : Visibility.Hidden;
+          }
+
+          break;
       }
     }
 


### PR DESCRIPTION
…DockMinSizes children.
Step to reproduce:
1. Open MainWindow.xaml of MLibTest project and set DockMinWidth="250" for LayoutAnchorablePane (Name="ToolsPane").
2. Remove AvalonDock.Layout.config from bin folder.
3. Start MLibTest project.
4. Undock File Stats panel.
5. Decrease width of floating window. It can be set to lower then DockMinWidth, which we set for ToolsPane

Also was fixed issue with showing of floating window in case if it was closed by cross button.
It can be reproduced with previous example:
6. Close floating panel by Cross button on top right corner.
7. Try to open back File Stats panel from menu: Tools -> File Stats.
As result the floating window will not appears. 