### PR TITLE
Fix visibility bindings of undocked panels in specific cases

### DIFF
--- a/source/AutomationTest/Xceed.Wpf.AvalonDock.Test/DockingUtilitiesTest.cs
+++ b/source/AutomationTest/Xceed.Wpf.AvalonDock.Test/DockingUtilitiesTest.cs
@@ -1,0 +1,111 @@
+﻿namespace Xceed.Wpf.AvalonDock.Test
+{
+  using System;
+  using System.Windows.Controls;
+
+  using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+  using Xceed.Wpf.AvalonDock.Layout;
+
+  [TestClass]
+  public sealed class DockingUtilitiesTest
+  {
+    [TestMethod]
+    public void CalculatedDockMinWidthHeightTest()
+    {
+      double defaultDockMinHeight = 25;
+      double defaultDockMinWidth = 25;
+
+      const double documentPaneDockMinHeight = 200;
+      const double documentPaneDockMinWidth = 400;
+      LayoutDocumentPane layoutDocumentPane = new LayoutDocumentPane { DockMinHeight = documentPaneDockMinHeight, DockMinWidth = documentPaneDockMinWidth };
+      layoutDocumentPane.InsertChildAt( 0, new LayoutDocument { ContentId = "Document" } );
+
+      LayoutDocumentPaneGroup layoutDocumentPaneGroup = new LayoutDocumentPaneGroup();
+      layoutDocumentPaneGroup.InsertChildAt( 0, layoutDocumentPane );
+
+      const double anchorablePaneDockMinHeight = 80;
+      const double anchorablePaneDockMinWidth = 160;
+      LayoutAnchorablePane layoutAnchorablePane = new LayoutAnchorablePane { DockMinHeight = anchorablePaneDockMinHeight, DockMinWidth = anchorablePaneDockMinWidth };
+      layoutAnchorablePane.InsertChildAt( 0, new LayoutAnchorable { ContentId = "Anchorable" } );
+
+      LayoutAnchorablePaneGroup layoutAnchorablePaneGroup = new LayoutAnchorablePaneGroup();
+      layoutAnchorablePaneGroup.InsertChildAt( 0, layoutAnchorablePane );
+
+      LayoutPanel layoutPanel = new LayoutPanel();
+      layoutPanel.InsertChildAt( 0, layoutDocumentPaneGroup );
+      layoutPanel.InsertChildAt( 1, layoutAnchorablePaneGroup );
+
+      Assert.AreEqual( defaultDockMinWidth, layoutPanel.DockMinWidth );
+      Assert.AreEqual( defaultDockMinHeight, layoutPanel.DockMinHeight );
+      Assert.AreEqual( documentPaneDockMinWidth + anchorablePaneDockMinWidth, layoutPanel.CalculatedDockMinWidth() );
+      Assert.AreEqual( Math.Max(documentPaneDockMinHeight, anchorablePaneDockMinHeight), layoutPanel.CalculatedDockMinHeight() );
+
+      Assert.AreEqual( documentPaneDockMinWidth, layoutDocumentPane.DockMinWidth );
+      Assert.AreEqual( documentPaneDockMinHeight, layoutDocumentPane.DockMinHeight );
+      Assert.AreEqual( layoutDocumentPane.DockMinWidth, layoutDocumentPane.CalculatedDockMinWidth() );
+      Assert.AreEqual( layoutDocumentPane.DockMinHeight, layoutDocumentPane.CalculatedDockMinHeight() );
+
+      Assert.AreEqual( defaultDockMinWidth, layoutDocumentPaneGroup.DockMinWidth );
+      Assert.AreEqual( defaultDockMinWidth, layoutDocumentPaneGroup.DockMinHeight );
+      Assert.AreEqual( documentPaneDockMinWidth, layoutDocumentPaneGroup.CalculatedDockMinWidth() );
+      Assert.AreEqual( documentPaneDockMinHeight, layoutDocumentPaneGroup.CalculatedDockMinHeight() );
+
+      Assert.AreEqual( anchorablePaneDockMinWidth, layoutAnchorablePane.DockMinWidth );
+      Assert.AreEqual( anchorablePaneDockMinHeight, layoutAnchorablePane.DockMinHeight );
+      Assert.AreEqual( layoutAnchorablePane.DockMinWidth, layoutAnchorablePane.CalculatedDockMinWidth() );
+      Assert.AreEqual( layoutAnchorablePane.DockMinHeight, layoutAnchorablePane.CalculatedDockMinHeight() );
+
+      Assert.AreEqual( defaultDockMinWidth, layoutAnchorablePaneGroup.DockMinWidth );
+      Assert.AreEqual( defaultDockMinWidth, layoutAnchorablePaneGroup.DockMinHeight );
+      Assert.AreEqual( anchorablePaneDockMinWidth, layoutAnchorablePaneGroup.CalculatedDockMinWidth() );
+      Assert.AreEqual( anchorablePaneDockMinHeight, layoutAnchorablePaneGroup.CalculatedDockMinHeight() );
+
+      layoutPanel.RemoveChild( layoutDocumentPaneGroup );
+      Assert.AreEqual( anchorablePaneDockMinWidth, layoutPanel.CalculatedDockMinWidth() );
+      Assert.AreEqual( anchorablePaneDockMinHeight, layoutPanel.CalculatedDockMinHeight() );
+    }
+
+    [TestMethod]
+    public void UpdateDocMinWidthHeightTest()
+    {
+      double documentPaneDockMinHeight = 100;
+      double documentPaneDockMinWidth = 101;
+      LayoutDocumentPane layoutDocumentPane = new LayoutDocumentPane { DockMinHeight = documentPaneDockMinHeight, DockMinWidth = documentPaneDockMinWidth };
+      layoutDocumentPane.InsertChildAt( 0, new LayoutDocument { ContentId = "Document" } );
+
+      LayoutDocumentPaneGroup layoutDocumentPaneGroup = new LayoutDocumentPaneGroup();
+      layoutDocumentPaneGroup.InsertChildAt( 0, layoutDocumentPane );
+
+      double anchorablePane1DockMinHeight = 150;
+      double anchorablePane1DockMinWidth = 151;
+      LayoutAnchorablePane layoutAnchorablePane1 = new LayoutAnchorablePane { DockMinHeight = anchorablePane1DockMinHeight, DockMinWidth = anchorablePane1DockMinWidth };
+      layoutAnchorablePane1.InsertChildAt( 0, new LayoutAnchorable { ContentId = "Anchorable1" } );
+
+      double anchorablePane2DockMinHeight = 200;
+      double anchorablePane2DockMinWidth = 201;
+      LayoutAnchorablePane layoutAnchorablePane2 = new LayoutAnchorablePane { DockMinHeight = anchorablePane2DockMinHeight, DockMinWidth = anchorablePane2DockMinWidth };
+      layoutAnchorablePane2.InsertChildAt( 0, new LayoutAnchorable { ContentId = "Anchorable2" } );
+
+      LayoutAnchorablePaneGroup layoutAnchorablePaneGroup = new LayoutAnchorablePaneGroup { Orientation = Orientation.Horizontal };
+      layoutAnchorablePaneGroup.InsertChildAt( 0, layoutAnchorablePane1 );
+      layoutAnchorablePaneGroup.InsertChildAt( 0, layoutAnchorablePane2 );
+
+      LayoutPanel layoutPanel = new LayoutPanel { Orientation = Orientation.Vertical };
+      layoutPanel.InsertChildAt( 0, layoutDocumentPaneGroup );
+      layoutPanel.InsertChildAt( 1, layoutAnchorablePaneGroup );
+
+      Assert.AreEqual( anchorablePane2DockMinWidth + anchorablePane1DockMinWidth, layoutAnchorablePaneGroup.CalculatedDockMinWidth() );
+      Assert.AreEqual( Math.Max( anchorablePane2DockMinHeight, anchorablePane1DockMinHeight ), layoutAnchorablePaneGroup.CalculatedDockMinHeight() );
+
+      Assert.AreEqual( documentPaneDockMinWidth, layoutDocumentPaneGroup.CalculatedDockMinWidth() );
+      Assert.AreEqual( documentPaneDockMinHeight, layoutDocumentPaneGroup.CalculatedDockMinHeight() );
+
+      Assert.AreEqual(
+          Math.Max( anchorablePane1DockMinWidth + anchorablePane2DockMinWidth, documentPaneDockMinWidth ),
+          layoutPanel.CalculatedDockMinWidth() );
+
+      Assert.AreEqual( documentPaneDockMinHeight + anchorablePane2DockMinHeight, layoutPanel.CalculatedDockMinHeight() );
+    }
+  }
+}

--- a/source/AutomationTest/Xceed.Wpf.AvalonDock.Test/LayoutAnchorableTest.cs
+++ b/source/AutomationTest/Xceed.Wpf.AvalonDock.Test/LayoutAnchorableTest.cs
@@ -1,0 +1,65 @@
+﻿using System.Linq;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Data;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Xceed.Wpf.AvalonDock.Controls;
+using Xceed.Wpf.AvalonDock.Converters;
+using Xceed.Wpf.AvalonDock.Layout;
+
+namespace Xceed.Wpf.AvalonDock.Test
+{
+  [TestClass]
+  public sealed class LayoutAnchorableTest
+  {
+    [TestMethod]
+    public void ClearBindingOfHiddenWindowTest()
+    {
+      LayoutAnchorable layoutAnchorable = new LayoutAnchorable
+      {
+        FloatingWidth = 50,
+        FloatingHeight = 100,
+        ContentId = "Test"
+      };
+
+      LayoutAnchorablePane layoutAnchorablePane = new LayoutAnchorablePane( layoutAnchorable );
+      LayoutAnchorablePaneGroup layoutAnchorablePaneGroup = new LayoutAnchorablePaneGroup( layoutAnchorablePane );
+      LayoutAnchorableFloatingWindow layoutFloatingWindow = new LayoutAnchorableFloatingWindow
+      {
+        RootPanel = layoutAnchorablePaneGroup
+      };
+
+      var ctor = typeof( LayoutAnchorableFloatingWindowControl )
+        .GetTypeInfo()
+        .GetConstructors( BindingFlags.NonPublic | BindingFlags.Instance )
+        .First( x => x.GetParameters().Length == 1 );
+
+      LayoutAnchorableFloatingWindowControl floatingWindowControl = ctor.Invoke( new object[] {layoutFloatingWindow} ) as LayoutAnchorableFloatingWindowControl;
+      floatingWindowControl.SetBinding(
+        UIElement.VisibilityProperty,
+        new Binding( "IsVisible" )
+        {
+          Source = floatingWindowControl.Model,
+          Converter = new BoolToVisibilityConverter(),
+          Mode = BindingMode.OneWay,
+          ConverterParameter = Visibility.Hidden
+        } );
+
+      BindingExpression visibilityBinding = floatingWindowControl.GetBindingExpression( UIElement.VisibilityProperty );
+      Assert.IsNotNull( visibilityBinding );
+
+      layoutAnchorable.Show();
+      layoutAnchorable.Hide();
+      
+      visibilityBinding = floatingWindowControl.GetBindingExpression( UIElement.VisibilityProperty );
+      Assert.IsNotNull( visibilityBinding );
+
+      floatingWindowControl.Hide();
+
+      visibilityBinding = floatingWindowControl.GetBindingExpression( UIElement.VisibilityProperty );
+      Assert.IsNull( visibilityBinding );
+    }
+  }
+}

--- a/source/AutomationTest/Xceed.Wpf.AvalonDock.Test/Xceed.Wpf.AvalonDock.Test.csproj
+++ b/source/AutomationTest/Xceed.Wpf.AvalonDock.Test/Xceed.Wpf.AvalonDock.Test.csproj
@@ -52,10 +52,13 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xaml" />
+    <Reference Include="System.XML" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AnchorablePaneTest.cs" />
+    <Compile Include="DockingUtilitiesTest.cs" />
+    <Compile Include="LayoutAnchorableTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestApp.xaml.cs">
       <DependentUpon>TestApp.xaml</DependentUpon>

--- a/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -201,6 +201,8 @@ namespace Xceed.Wpf.AvalonDock.Controls
       BindingOperations.ClearBinding(_model, VisibilityProperty);
 
       _model.PropertyChanged -= new System.ComponentModel.PropertyChangedEventHandler( _model_PropertyChanged );
+
+      Activated -= LayoutAnchorableFloatingWindowControl_Activated;
     }
 
     protected override void OnClosing( System.ComponentModel.CancelEventArgs e )
@@ -329,7 +331,7 @@ namespace Xceed.Wpf.AvalonDock.Controls
     {
       SetBinding(
         VisibilityProperty,
-        new Binding("IsVisible")
+        new Binding( "IsVisible" )
         {
           Source = _model,
           Converter = new BoolToVisibilityConverter(),

--- a/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorableItem.cs
+++ b/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorableItem.cs
@@ -32,6 +32,7 @@ namespace Xceed.Wpf.AvalonDock.Controls
     private ICommand _defaultAutoHideCommand;
     private ICommand _defaultDockCommand;
     private ReentrantFlag _visibilityReentrantFlag = new ReentrantFlag();
+    private ReentrantFlag _anchorableVisibilityReentrantFlag = new ReentrantFlag();
 
     #endregion
 
@@ -377,9 +378,9 @@ namespace Xceed.Wpf.AvalonDock.Controls
     {
       if( _anchorable != null && _anchorable.Root != null )
       {
-        if( _visibilityReentrantFlag.CanEnter )
+        if( _anchorableVisibilityReentrantFlag.CanEnter )
         {
-          using( _visibilityReentrantFlag.Enter() )
+          using( _anchorableVisibilityReentrantFlag.Enter() )
           {
             if( _anchorable.IsVisible )
               Visibility = Visibility.Visible;
@@ -389,12 +390,6 @@ namespace Xceed.Wpf.AvalonDock.Controls
         }
       }
     }
-
-
-
-
-
-
 
     #endregion
   }

--- a/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -310,8 +310,8 @@ namespace Xceed.Wpf.AvalonDock.Controls
         }
       }
 
-      var manager = _model.Root.Manager;
-      if( manager.Theme != null )
+      var manager = _model.Root?.Manager;
+      if( manager?.Theme != null )
       {
         if( manager.Theme is DictionaryTheme )
         {

--- a/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -531,6 +531,14 @@ namespace Xceed.Wpf.AvalonDock.Controls
 
     #endregion
 
+    public virtual void EnableBindings()
+    {
+    }
+
+    public virtual void DisableBindings()
+    {
+    }
+
     #region Internal Classes
 
     protected internal class FloatingWindowContentHost : HwndHost

--- a/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutGridControl.cs
+++ b/source/Components/Xceed.Wpf.AvalonDock/Controls/LayoutGridControl.cs
@@ -641,12 +641,17 @@ namespace Xceed.Wpf.AvalonDock.Controls
     {
       if( Orientation == Orientation.Horizontal )
       {
-        return ColumnDefinitions[index].Width.IsStar || ColumnDefinitions[index].Width.Value > 0;
+        if ( index < ColumnDefinitions.Count )
+        {
+          return ColumnDefinitions[ index ].Width.IsStar || ColumnDefinitions[ index ].Width.Value > 0;
+        }
       }
-      else
+      else if( index < RowDefinitions.Count )
       {
         return RowDefinitions[ index ].Height.IsStar || RowDefinitions[ index ].Height.Value > 0;
       }
+
+      return false;
     }
 
     private void ShowResizerOverlayWindow( LayoutGridResizerControl splitter )

--- a/source/Components/Xceed.Wpf.AvalonDock/Layout/LayoutAnchorable.cs
+++ b/source/Components/Xceed.Wpf.AvalonDock/Layout/LayoutAnchorable.cs
@@ -419,7 +419,7 @@ namespace Xceed.Wpf.AvalonDock.Layout
         PreviousContainer = parentAsGroup;
         PreviousContainerIndex = parentAsGroup.IndexOfChild( this );
       }
-      Root.Hidden.Add( this );
+      Root?.Hidden?.Add( this );
       RaisePropertyChanged( "IsVisible" );
       RaisePropertyChanged( "IsHidden" );
       NotifyIsVisibleChanged();


### PR DESCRIPTION
Fixed two issues:
1) Undocked panel doesn't show after switching between tabs.
2) Undocked panel doesn't hide the first time it's unchecked from the main menu, while hiding/showing on the next attempts.

LayoutAnchorableFloatingWindowControl.cs
Added restoring of visibility binding on "activated" event.
Added possibility to disable/enable visibility bindings when docking manager gets unloaded ("unloaded" fires when switching between tabls).

DockingManager.cs
When "unloaded" fires, instead of closing all floating controls and creating them again when "loaded" fires, we transfer them to the list of hidden controls disabling their visibility bindings and event subscriptions. This solves issue 1).

LayoutAnchorableItem.cs
Added separate visibility reentrant flag for "LayoutAnchorable _anchorable". This solves case 2).

Also additional safety checks were added:
LayoutGridControl.cs - added checks for index bounds
LayoutAnchorableFloatingWindowControl.cs - added null reference check for _model.Descendents().OfType<LayoutAnchorablePane>()