### PR TITLE
Repeatedly pressing Ctrl-Tab gets stuck at the bottom of the list of LayoutItems

### DIFF
--- a/source/Components/Xceed.Wpf.AvalonDock/Controls/NavigatorWindow.cs
+++ b/source/Components/Xceed.Wpf.AvalonDock/Controls/NavigatorWindow.cs
@@ -257,8 +257,10 @@ namespace Xceed.Wpf.AvalonDock.Controls
           if( this.SelectedDocument != null )
           {
             // Jump to next LayoutDocument
+            // if we are on the last LayoutDocument and we have Anchorables we jump over to the Anchorables list
+            // if there are no Anchorables we call SelectNextDocument which has logic in it to loop back to the top of the list
             var docIndex = this.Documents.IndexOf<LayoutDocumentItem>( this.SelectedDocument );
-            if( docIndex < (this.Documents.Length - 1) )
+            if( docIndex < (this.Documents.Length - 1) || this.Anchorables.Count() == 0)
             {
               this.SelectNextDocument();
               shouldHandle = true;
@@ -288,8 +290,10 @@ namespace Xceed.Wpf.AvalonDock.Controls
           if( this.SelectedAnchorable != null )
           {
             // Jump to next LayoutAnchorable
+            // if we are on the last LayoutAnchorable and we have one or more LayoutDocuments we jump over to the Documents list
+            // if there are no Documents we call SelectNextAnchorable which has logic in it to loop back to the top of the list
             var anchorableIndex = this.Anchorables.ToArray().IndexOf<LayoutAnchorableItem>( this.SelectedAnchorable );
-            if( anchorableIndex < (this.Anchorables.Count() - 1) )
+            if( anchorableIndex < (this.Anchorables.Count() - 1) || this.Documents.Count() == 0)
             {
               this.SelectNextAnchorable();
               shouldHandle = true;


### PR DESCRIPTION
The current logic in the Ctrl-Tab processing in the Navigator window expects there to be a mixture of both LayoutAnchorables and LayoutDocuments. But if you only have a list of one or the other type the Ctrl-Tab selection does not loop to the top of the list, it stays stuck on the last item as it is expecting to jump across to the other list (you can see this behaviour in MLibTest app which only has LayoutAnchorables, once you ctrl-tab to the bottom of the list the blue highlight stays stuck there and that last Anchorable will get focus once you release the ctrl-tab. (note you need to keep the ctrl key held down and tap on the tab key to cycle the selected item)

This pull request adds a check in each set of conditions so that the selected item will loop to the top of the current list (either Anchorables or Documents) if the other list has 0 items.

I had a go at trying to build a Unit Test for this, but I could not see how to make this work. I believe I need to be on the UI thread to interact with the UI elements, but the NavigatorWindow calls ShowDialog which seems to block the test... But in my manual testing this works fine.