### PR TITLE
74 The old NullReferenceException comes back

### DIFF
--- a/source/AutomationTest/Xceed.Wpf.AvalonDock.Test/LayoutAnchorableFloatingWindowControlTest.cs
+++ b/source/AutomationTest/Xceed.Wpf.AvalonDock.Test/LayoutAnchorableFloatingWindowControlTest.cs
@@ -1,0 +1,32 @@
+﻿namespace Xceed.Wpf.AvalonDock.Test
+{
+    using System.Threading.Tasks;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using Xceed.Wpf.AvalonDock.Layout.Serialization;
+    using Xceed.Wpf.AvalonDock.Test.TestHelpers;
+    using Xceed.Wpf.AvalonDock.Test.Views;
+
+    [TestClass]
+    public class LayoutAnchorableFloatingWindowControlTest : AutomationTestBase
+    {
+        [TestMethod]
+        public void CloseWithHiddenFloatingWindowsTest()
+        {
+            TestHost.SwitchToAppThread();
+            Task<LayoutAnchorableFloatingWindowControlTestWindow> taskResult = WindowHelpers.CreateInvisibleWindowAsync<LayoutAnchorableFloatingWindowControlTestWindow>();
+            taskResult.Wait();
+
+            LayoutAnchorableFloatingWindowControlTestWindow window = taskResult.Result;
+            window.Window1.Float();
+            Assert.IsTrue(window.Window1.IsFloating);
+            var layoutSerializer = new XmlLayoutSerializer(window.dockingManager);
+            layoutSerializer.Serialize(@".\AvalonDock.Layout.config");
+            window.tabControl.SelectedIndex = 1;
+            layoutSerializer.Deserialize(@".\AvalonDock.Layout.config");
+            window.tabControl.SelectedIndex = 0;
+            window.Close();
+        }
+    }
+}

--- a/source/AutomationTest/Xceed.Wpf.AvalonDock.Test/Views/LayoutAnchorableFloatingWindowControlTestWindow.xaml
+++ b/source/AutomationTest/Xceed.Wpf.AvalonDock.Test/Views/LayoutAnchorableFloatingWindowControlTestWindow.xaml
@@ -1,0 +1,38 @@
+﻿<Window x:Class="Xceed.Wpf.AvalonDock.Test.Views.LayoutAnchorableFloatingWindowControlTestWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:xcad="http://schemas.xceed.com/wpf/xaml/avalondock"
+        Title="Exception Window" Height="800" Width="1200">
+    <Grid>
+        <TabControl x:Name="tabControl" SelectedIndex="0">
+            <TabItem Header="Tab 1">
+                <xcad:DockingManager x:Name="dockingManager" AllowMixedOrientation="True">
+                    <xcad:LayoutRoot>
+                        <xcad:LayoutPanel Orientation="Horizontal">
+                            <xcad:LayoutAnchorablePaneGroup Orientation="Vertical" DockWidth="40*">
+                                <xcad:LayoutAnchorablePane>
+                                    <xcad:LayoutAnchorable x:Name="Window1" ContentId="Window1" Title="Window 1" CanHide="False" CanAutoHide="False" CanFloat="True">
+                                        <Grid></Grid>
+                                    </xcad:LayoutAnchorable>
+                                </xcad:LayoutAnchorablePane>
+                                <xcad:LayoutAnchorablePane>
+                                    <xcad:LayoutAnchorable x:Name="Window2" ContentId="Window2" Title="Window 2" CanAutoHide="False" CanHide="True" CanClose="True">
+                                        <Grid></Grid>
+                                    </xcad:LayoutAnchorable>
+                                </xcad:LayoutAnchorablePane>
+                            </xcad:LayoutAnchorablePaneGroup>
+                            <xcad:LayoutAnchorablePane DockWidth="60*">
+                                <xcad:LayoutAnchorable ContentId="Window3" Title="Window 3" CanHide="True" CanAutoHide="False" CanClose="True">
+                                    <Grid></Grid>
+                                </xcad:LayoutAnchorable>
+                            </xcad:LayoutAnchorablePane>
+                        </xcad:LayoutPanel>
+                    </xcad:LayoutRoot>
+                </xcad:DockingManager>
+            </TabItem>
+            <TabItem Header="Tab 2"/>
+            <xcad:DockingManager x:Name="dockingManager2" AllowMixedOrientation="True">
+            </xcad:DockingManager>
+        </TabControl>
+    </Grid>
+</Window>

--- a/source/AutomationTest/Xceed.Wpf.AvalonDock.Test/Views/LayoutAnchorableFloatingWindowControlTestWindow.xaml.cs
+++ b/source/AutomationTest/Xceed.Wpf.AvalonDock.Test/Views/LayoutAnchorableFloatingWindowControlTestWindow.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows;
+
+namespace Xceed.Wpf.AvalonDock.Test.Views
+{
+    /// <summary>
+    /// Interaction logic for LayoutAnchorableFloatingWindowControlTestWindow.xaml
+    /// </summary>
+    public partial class LayoutAnchorableFloatingWindowControlTestWindow : Window
+    {
+        public LayoutAnchorableFloatingWindowControlTestWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/source/AutomationTest/Xceed.Wpf.AvalonDock.Test/Xceed.Wpf.AvalonDock.Test.csproj
+++ b/source/AutomationTest/Xceed.Wpf.AvalonDock.Test/Xceed.Wpf.AvalonDock.Test.csproj
@@ -56,6 +56,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LayoutAnchorableFloatingWindowControlTest.cs" />
     <Compile Include="AnchorablePaneTest.cs" />
     <Compile Include="DockingUtilitiesTest.cs" />
     <Compile Include="LayoutAnchorableTest.cs" />
@@ -70,6 +71,9 @@
     <Compile Include="TestHelpers\WindowHelpers.cs" />
     <Compile Include="Views\AnchorablePaneTestWindow.xaml.cs">
       <DependentUpon>AnchorablePaneTestWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\LayoutAnchorableFloatingWindowControlTestWindow.xaml.cs">
+      <DependentUpon>LayoutAnchorableFloatingWindowControlTestWindow.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
@@ -90,6 +94,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\AnchorablePaneTestWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\LayoutAnchorableFloatingWindowControlTestWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/source/Components/Xceed.Wpf.AvalonDock/DockingManager.cs
+++ b/source/Components/Xceed.Wpf.AvalonDock/DockingManager.cs
@@ -147,6 +147,13 @@ namespace Xceed.Wpf.AvalonDock
 
       _fwList.Clear();
 
+      foreach (var fwc in _fwHiddenList.ToArray())
+      {
+         fwc.InternalClose();
+      }
+
+      _fwHiddenList.Clear();
+
       DetachDocumentsSource( oldLayout, DocumentsSource );
       DetachAnchorablesSource( oldLayout, AnchorablesSource );
 
@@ -177,7 +184,7 @@ namespace Xceed.Wpf.AvalonDock
             _fwList.Add( CreateUIElementForModel( fw ) as LayoutFloatingWindowControl );
         }
 
-        foreach( var fw in _fwList )
+        foreach( var fw in _fwList.ToArray())
         {
           var window = fw.Model as LayoutAnchorableFloatingWindow;
           if (window != null && window.RootPanel.IsMaximized)


### PR DESCRIPTION
Hello, 
I've seen LayoutAnchorableFloatingWindowControl.OnClosed() crash because of root.Manager is null for the hidden LayoutFloatingWindowControl:
root.Manager.RemoveFloatingWindow( this );
Please, take a look to the proposed PR that clears list of hidden floating windows