### PR TITLE
Implementations of IXmlSerializable.ReadXml are required to read the …

### DIFF
--- a/source/Components/Xceed.Wpf.AvalonDock/Layout/LayoutRoot.cs
+++ b/source/Components/Xceed.Wpf.AvalonDock/Layout/LayoutRoot.cs
@@ -674,6 +674,9 @@ namespace Xceed.Wpf.AvalonDock.Layout
       {
         this.Hidden.Add( ( LayoutAnchorable )hiddenObject );
       }
+
+      //Read the closing end element of LayoutRoot 
+      reader.ReadEndElement();
     }
 
     public void WriteXml( XmlWriter writer )


### PR DESCRIPTION
…entire element from beginning to end, including all of its contents. Prior to this change it would not read the end element from the reader. This would cause issues if the LayoutRoot was being serialized as part of a parent object's xml serialization as the XmlReader would be left on an unexpected element.

https://github.com/Dirkster99/AvalonDock/issues/88