### PR TITLE
Fixed Issue 132

### DIFF
--- a/source/Components/AvalonDock/Controls/DocumentPaneDropTarget.cs
+++ b/source/Components/AvalonDock/Controls/DocumentPaneDropTarget.cs
@@ -257,9 +257,14 @@ namespace AvalonDock.Controls
 					var paneModel = targetModel as LayoutDocumentPane;
 					var layoutDocumentPaneGroup = floatingWindow.RootPanel as LayoutDocumentPaneGroup;
 
+					// A LayoutFloatingDocumentWindow can contain multiple instances of both Anchorables or Documents
+					// and we should drop these back into the DocumentPane if they are available
+					var allowedDropTypes = new[] { typeof(LayoutDocument), typeof(LayoutAnchorable) };
+
 					int i = _tabIndex == -1 ? 0 : _tabIndex;
 					foreach (var anchorableToImport in
-						layoutDocumentPaneGroup.Descendents().OfType<LayoutDocument>().ToArray())
+						layoutDocumentPaneGroup.Descendents().OfType<LayoutContent>()
+							.Where(item => allowedDropTypes.Contains(item.GetType())).ToArray())
 					{
 						paneModel.Children.Insert(i, anchorableToImport);
 						i++;

--- a/source/Components/AvalonDock/Controls/DropTarget.cs
+++ b/source/Components/AvalonDock/Controls/DropTarget.cs
@@ -77,16 +77,28 @@ namespace AvalonDock.Controls
 		#endregion
 
 		#region Overrides
-
+		/// <summary>
+		/// Method is invoked to complete a drag & drop operation with a (new) docking position
+		/// by docking of the LayoutAnchorable <paramref name="floatingWindow"/> into this drop target.
+		/// 
+		/// Inheriting classes should override this method to implement their own custom logic.
+		/// </summary>
+		/// <param name="floatingWindow"></param>
 		protected virtual void Drop(LayoutAnchorableFloatingWindow floatingWindow)
 		{
 		}
 
+		/// <summary>
+		/// Method is invoked to complete a drag & drop operation with a (new) docking position
+		/// by docking of the LayoutDocument <paramref name="floatingWindow"/> into this drop target.
+		/// 
+		/// Inheriting classes should override this method to implement their own custom logic.
+		/// </summary>
+		/// <param name="floatingWindow"></param>
 		protected virtual void Drop(LayoutDocumentFloatingWindow floatingWindow)
 		{
 		}
-
-		#endregion
+		#endregion Overrides
 
 		#region Public Methods
 


### PR DESCRIPTION
Fixing Issue #132 to allow documents with Anchorablea to be dropped back into center of the DocumentPane.