### PR TITLE
Continue with resizing of floating windows (#146)

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -69,7 +69,10 @@ namespace AvalonDock.Controls
 			Closing += OnClosing;
 			SizeChanged += OnSizeChanged;
 			_model = model;
-		}
+			// Since this control is not part of the visual tree DockingManager the resources (such as styles) are not used in this control.
+			// By manually merging these resources the behaviour is what the user would expect.
+            Resources.MergedDictionaries.Add(model.Root.Manager.Resources);
+        }
 
 		protected LayoutFloatingWindowControl(ILayoutElement model, bool isContentImmutable)
 		  : this(model)


### PR DESCRIPTION
Added resources from DockingManager to the LayoutFloatingWindowControl, this makes the styles work as expected (i.e. as your example [here](https://github.com/Dirkster99/AvalonDock/pull/146#issuecomment-611627840)).

@Dirkster99 Do you think this is a good addition? Personally I think it will really help users, the typical WPF behavior is that resources applied to a control will be will be used. I wonder if there is another way of doing it? Are there more controls that need the same change?