### PR TITLE
Fix #182

### DIFF
--- a/source/Components/AvalonDock.Themes.VS2013/Themes/Generic.xaml
+++ b/source/Components/AvalonDock.Themes.VS2013/Themes/Generic.xaml
@@ -18,28 +18,28 @@
 	xmlns:avalonDockProperties="clr-namespace:AvalonDock.Properties;assembly=AvalonDock"
 	xmlns:reskeys="clr-namespace:AvalonDock.Themes.VS2013.Themes"
 	xmlns:shell="clr-namespace:Microsoft.Windows.Shell;assembly=AvalonDock">
-	<ResourceDictionary.MergedDictionaries>
-		<ResourceDictionary Source="/AvalonDock.Themes.VS2013;component/OverlayButtons.xaml" />
-		<ResourceDictionary Source="/AvalonDock.Themes.VS2013;component/Themes/Menu/MenuItem.xaml" />
-		<ResourceDictionary Source="/AvalonDock.Themes.VS2013;component/Themes/Icons/IconGeometry.xaml" />
-	</ResourceDictionary.MergedDictionaries>
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="/AvalonDock.Themes.VS2013;component/OverlayButtons.xaml" />
+        <ResourceDictionary Source="/AvalonDock.Themes.VS2013;component/Themes/Menu/MenuItem.xaml" />
+        <ResourceDictionary Source="/AvalonDock.Themes.VS2013;component/Themes/Icons/IconGeometry.xaml" />
+    </ResourceDictionary.MergedDictionaries>
 
-	<Style x:Key="DropDownControlArea" TargetType="avalonDockControls:DropDownControlArea" />
+    <Style x:Key="DropDownControlArea" TargetType="avalonDockControls:DropDownControlArea" />
 
-	<!--
+    <!--
 		Re-styling this in AvalonDock since the menu on the drop-down button for more documents is otherwise black
 		BugFix for Issue http://avalondock.codeplex.com/workitem/15743
 	-->
-	<Style TargetType="ToolTip">
-		<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.Background}}" />
-		<Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}" />
-		<Setter Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}" />
-		<Setter Property="BorderThickness" Value="1" />
-		<Setter Property="MaxWidth" Value="246" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="ToolTip">
-					<Border
+    <Style TargetType="ToolTip">
+        <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.Background}}" />
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="MaxWidth" Value="246" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ToolTip">
+                    <Border
 						Padding="5"
 						Background="{TemplateBinding Background}"
 						BorderBrush="{TemplateBinding BorderBrush}"
@@ -47,7 +47,7 @@
 						CornerRadius="2"
 						SnapsToDevicePixels="True"
 						Style="{DynamicResource DarkBorder}">
-						<TextBlock
+                        <TextBlock
 							Margin="0"
 							HorizontalAlignment="Left"
 							VerticalAlignment="Center"
@@ -57,174 +57,174 @@
 							Foreground="{TemplateBinding Foreground}"
 							Text="{TemplateBinding Content}"
 							TextWrapping="Wrap" />
-					</Border>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-	<Style TargetType="{x:Type MenuItem}">
-		<Setter Property="HeaderTemplate" Value="{Binding Path=Root.Manager.DocumentPaneMenuItemHeaderTemplate}" />
-		<Setter Property="HeaderTemplateSelector" Value="{Binding Path=Root.Manager.DocumentPaneMenuItemHeaderTemplateSelector}" />
-		<Setter Property="BorderThickness" Value="0" />
-		<Setter Property="Template" Value="{StaticResource MLibMenuItem}" />
-	</Style>
+    <Style TargetType="{x:Type MenuItem}">
+        <Setter Property="HeaderTemplate" Value="{Binding Path=Root.Manager.DocumentPaneMenuItemHeaderTemplate}" />
+        <Setter Property="HeaderTemplateSelector" Value="{Binding Path=Root.Manager.DocumentPaneMenuItemHeaderTemplateSelector}" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Template" Value="{StaticResource MLibMenuItem}" />
+    </Style>
 
-	<Style BasedOn="{StaticResource {x:Type MenuItem}}" TargetType="{x:Type avalonDockControls:MenuItemEx}">
-		<Setter Property="IconTemplate" Value="{Binding Path=Root.Manager.IconContentTemplate}" />
-		<Setter Property="IconTemplateSelector" Value="{Binding Path=Root.Manager.IconContentTemplateSelector}" />
-		<Setter Property="Command" Value="{Binding Path=., Converter={avalonDockConverters:ActivateCommandLayoutItemFromLayoutModelConverter}}" />
-		<!--
+    <Style BasedOn="{StaticResource {x:Type MenuItem}}" TargetType="{x:Type avalonDockControls:MenuItemEx}">
+        <Setter Property="IconTemplate" Value="{Binding Path=Root.Manager.IconContentTemplate}" />
+        <Setter Property="IconTemplateSelector" Value="{Binding Path=Root.Manager.IconContentTemplateSelector}" />
+        <Setter Property="Command" Value="{Binding Path=., Converter={avalonDockConverters:ActivateCommandLayoutItemFromLayoutModelConverter}}" />
+        <!--
 			Retemplate ControlTemplate of MenuItem to get rid of blue'ish highlighting colors on menu item
 			https://stackoverflow.com/questions/34888636/change-background-color-of-menuitem-on-mouseover
 		-->
-	</Style>
+    </Style>
 
-	<Style BasedOn="{StaticResource {x:Type ContextMenu}}" TargetType="{x:Type ContextMenu}">
-		<Setter Property="TextOptions.TextFormattingMode" Value="Display" />
-		<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.Background}}" />
-		<Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}" />
-		<Setter Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}" />
-		<Setter Property="BorderThickness" Value="1" />
-		<Setter Property="VerticalContentAlignment" Value="Center" />
-		<Setter Property="Padding" Value="0,6,0,6" />
-		<Setter Property="Grid.IsSharedSizeScope" Value="true" />
-		<Setter Property="ScrollViewer.PanningMode" Value="Both" />
-		<Setter Property="Stylus.IsFlicksEnabled" Value="False" />
-		<Setter Property="Focusable" Value="False" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type ContextMenu}">
-					<Grid Margin="4">
-						<Border
+    <Style BasedOn="{StaticResource {x:Type ContextMenu}}" TargetType="{x:Type ContextMenu}">
+        <Setter Property="TextOptions.TextFormattingMode" Value="Display" />
+        <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.Background}}" />
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Padding" Value="0,6,0,6" />
+        <Setter Property="Grid.IsSharedSizeScope" Value="true" />
+        <Setter Property="ScrollViewer.PanningMode" Value="Both" />
+        <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ContextMenu}">
+                    <Grid Margin="4">
+                        <Border
 							x:Name="ContextMenuBorder"
 							Margin="0"
 							Background="{TemplateBinding Background}"
 							BorderBrush="{TemplateBinding BorderBrush}"
 							BorderThickness="1">
-							<ScrollViewer Name="ContextMenuScrollViewer" ScrollViewer.VerticalScrollBarVisibility="Auto">
-								<Grid RenderOptions.ClearTypeHint="Enabled">
-									<Canvas
+                            <ScrollViewer Name="ContextMenuScrollViewer" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas
 										Width="0"
 										Height="0"
 										HorizontalAlignment="Left"
 										VerticalAlignment="Top">
-										<Rectangle
+                                        <Rectangle
 											Name="OpaqueRect"
 											Width="{Binding ElementName=ContextMenuBorder, Path=ActualWidth}"
 											Height="{Binding ElementName=ContextMenuBorder, Path=ActualHeight}"
 											Fill="{Binding ElementName=ContextMenuBorder, Path=Background}" />
-									</Canvas>
-									<ItemsPresenter
+                                    </Canvas>
+                                    <ItemsPresenter
 										Name="ItemsPresenter"
 										KeyboardNavigation.DirectionalNavigation="Contained"
 										SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-								</Grid>
-							</ScrollViewer>
-						</Border>
-					</Grid>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                                </Grid>
+                            </ScrollViewer>
+                        </Border>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-	<Style BasedOn="{StaticResource {x:Type ContextMenu}}" TargetType="{x:Type avalonDockControls:ContextMenuEx}" />
-	<Style x:Key="AvalonDockThemeVs2013ToolButtonStyle" TargetType="ToggleButton">
-		<Setter Property="Background" Value="Transparent" />
-		<Setter Property="BorderThickness" Value="1" />
-		<Setter Property="BorderBrush" Value="Transparent" />
-		<Setter Property="Padding" Value="0" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="ToggleButton">
-					<Border
+    <Style BasedOn="{StaticResource {x:Type ContextMenu}}" TargetType="{x:Type avalonDockControls:ContextMenuEx}" />
+    <Style x:Key="AvalonDockThemeVs2013ToolButtonStyle" TargetType="ToggleButton">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ToggleButton">
+                    <Border
 						Background="{TemplateBinding Background}"
 						BorderBrush="{TemplateBinding BorderBrush}"
 						BorderThickness="{TemplateBinding BorderThickness}">
-						<ContentPresenter />
-					</Border>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
+                        <ContentPresenter />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
 
-		<Style.Triggers>
-			<Trigger Property="IsMouseOver" Value="True">
-				<!--<Setter Property="BorderBrush" Value="{DynamicResource AvalonDock_ThemeMetro_BaseColor31}" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <!--<Setter Property="BorderBrush" Value="{DynamicResource AvalonDock_ThemeMetro_BaseColor31}" />
                 <Setter Property="Background" Value="{DynamicResource AvalonDock_ThemeMetro_BaseColor10}" />-->
-			</Trigger>
-			<Trigger Property="IsChecked" Value="True">
-				<!--<Setter Property="BorderBrush" Value="{DynamicResource AvalonDock_ThemeMetro_BaseColor31}" />
+            </Trigger>
+            <Trigger Property="IsChecked" Value="True">
+                <!--<Setter Property="BorderBrush" Value="{DynamicResource AvalonDock_ThemeMetro_BaseColor31}" />
                 <Setter Property="Background" Value="{DynamicResource AvalonDock_ThemeMetro_BaseColor10}" />-->
-			</Trigger>
-		</Style.Triggers>
-	</Style>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
 
-	<Style x:Key="AvalonDockThemeVs2013ButtonStyle" TargetType="Button">
-		<Setter Property="Background" Value="Transparent" />
-		<Setter Property="BorderThickness" Value="1" />
-		<Setter Property="BorderBrush" Value="Transparent" />
-		<Setter Property="Padding" Value="0" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="Button">
-					<Border
+    <Style x:Key="AvalonDockThemeVs2013ButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border
 						Background="{TemplateBinding Background}"
 						BorderBrush="{TemplateBinding BorderBrush}"
 						BorderThickness="{TemplateBinding BorderThickness}">
-						<ContentPresenter />
-					</Border>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                        <ContentPresenter />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-	<!--  DocumentPaneControlStyle  -->
-	<Style x:Key="AvalonDockThemeVs2013DocumentPaneControlStyle" TargetType="{x:Type avalonDockControls:LayoutDocumentPaneControl}">
-		<Setter Property="BorderBrush" Value="{x:Null}" />
-		<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.TabBackground}}" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type avalonDockControls:LayoutDocumentPaneControl}">
-					<Grid
+    <!--  DocumentPaneControlStyle  -->
+    <Style x:Key="AvalonDockThemeVs2013DocumentPaneControlStyle" TargetType="{x:Type avalonDockControls:LayoutDocumentPaneControl}">
+        <Setter Property="BorderBrush" Value="{x:Null}" />
+        <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.TabBackground}}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutDocumentPaneControl}">
+                    <Grid
 						ClipToBounds="true"
 						KeyboardNavigation.TabNavigation="Local"
 						SnapsToDevicePixels="true">
-						<Grid.RowDefinitions>
-							<RowDefinition Height="Auto" />
-							<RowDefinition Height="*" />
-						</Grid.RowDefinitions>
-						<!--  Following border is required to catch mouse events  -->
-						<Border Grid.RowSpan="2" Background="Transparent" />
-						<Grid
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <!--  Following border is required to catch mouse events  -->
+                        <Border Grid.RowSpan="2" Background="Transparent" />
+                        <Grid
 							Grid.Row="0"
 							Panel.ZIndex="1"
 							Visibility="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type avalonDockControls:LayoutDocumentPaneControl}}, Path=Model.ShowHeader, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
-							<Grid.ColumnDefinitions>
-								<ColumnDefinition />
-								<ColumnDefinition Width="Auto" />
-							</Grid.ColumnDefinitions>
-							<Border
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Border
 								x:Name="BD"
 								Grid.ColumnSpan="2"
 								BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedActiveBackground}}"
 								BorderThickness="0,0,0,2" />
-							<avalonDockControls:DocumentPaneTabPanel
+                            <avalonDockControls:DocumentPaneTabPanel
 								x:Name="HeaderPanel"
 								Grid.Row="0"
 								Grid.Column="0"
 								Margin="0"
 								IsItemsHost="true"
 								KeyboardNavigation.TabIndex="1" />
-							<avalonDockControls:DropDownButton
+                            <avalonDockControls:DropDownButton
 								x:Name="MenuDropDownButton"
 								Grid.Column="1"
 								VerticalAlignment="Center"
 								Focusable="False"
 								Style="{StaticResource AvalonDockThemeVs2013ToolButtonStyle}">
-								<avalonDockControls:DropDownButton.DropDownContextMenu>
-									<avalonDockControls:ContextMenuEx ItemsSource="{Binding Model.ChildrenSorted, RelativeSource={RelativeSource TemplatedParent}}" />
-								</avalonDockControls:DropDownButton.DropDownContextMenu>
-								<Path
+                                <avalonDockControls:DropDownButton.DropDownContextMenu>
+                                    <avalonDockControls:ContextMenuEx ItemsSource="{Binding Model.ChildrenSorted, RelativeSource={RelativeSource TemplatedParent}}" />
+                                </avalonDockControls:DropDownButton.DropDownContextMenu>
+                                <Path
 									x:Name="MenuDropDownButtonImage"
 									Width="10"
 									Height="10"
@@ -233,9 +233,9 @@
 									Data="{DynamicResource PinDocMenu}"
 									Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellOverflowButtonDefaultGlyph}}"
 									Stretch="Uniform" />
-							</avalonDockControls:DropDownButton>
-						</Grid>
-						<Border
+                            </avalonDockControls:DropDownButton>
+                        </Grid>
+                        <Border
 							x:Name="ContentPanel"
 							Grid.Row="1"
 							Grid.Column="0"
@@ -247,163 +247,163 @@
 							KeyboardNavigation.DirectionalNavigation="Contained"
 							KeyboardNavigation.TabIndex="2"
 							KeyboardNavigation.TabNavigation="Cycle">
-							<ContentPresenter
+                            <ContentPresenter
 								x:Name="PART_SelectedContentHost"
 								Margin="0"
 								ContentSource="SelectedContent"
 								SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-						</Border>
-					</Grid>
-					<ControlTemplate.Triggers>
-						<Trigger SourceName="MenuDropDownButton" Property="IsMouseOver" Value="True">
-							<Setter TargetName="MenuDropDownButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellOverflowButtonHoveredBackground}}" />
-							<Setter TargetName="MenuDropDownButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellOverflowButtonHoveredBorder}}" />
-							<Setter TargetName="MenuDropDownButtonImage" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellOverflowButtonHoveredGlyph}}" />
-						</Trigger>
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger SourceName="MenuDropDownButton" Property="IsMouseOver" Value="True">
+                            <Setter TargetName="MenuDropDownButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellOverflowButtonHoveredBackground}}" />
+                            <Setter TargetName="MenuDropDownButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellOverflowButtonHoveredBorder}}" />
+                            <Setter TargetName="MenuDropDownButtonImage" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellOverflowButtonHoveredGlyph}}" />
+                        </Trigger>
 
-						<Trigger SourceName="MenuDropDownButton" Property="IsChecked" Value="True">
-							<Setter TargetName="MenuDropDownButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellOverflowButtonPressedBackground}}" />
-							<Setter TargetName="MenuDropDownButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellOverflowButtonPressedBorder}}" />
-							<Setter TargetName="MenuDropDownButtonImage" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellOverflowButtonPressedGlyph}}" />
-						</Trigger>
+                        <Trigger SourceName="MenuDropDownButton" Property="IsChecked" Value="True">
+                            <Setter TargetName="MenuDropDownButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellOverflowButtonPressedBackground}}" />
+                            <Setter TargetName="MenuDropDownButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellOverflowButtonPressedBorder}}" />
+                            <Setter TargetName="MenuDropDownButtonImage" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellOverflowButtonPressedGlyph}}" />
+                        </Trigger>
 
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding SelectedItem.IsActive, RelativeSource={RelativeSource Self}}" Value="False" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="BD" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedInactiveBackground}}" />
-						</MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding SelectedItem.IsActive, RelativeSource={RelativeSource Self}}" Value="False" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="BD" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedInactiveBackground}}" />
+                        </MultiDataTrigger>
 
-						<Trigger Property="IsEnabled" Value="false">
-							<Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
-						</Trigger>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                        </Trigger>
 
-						<DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Model.ChildrenCount}" Value="0">
-							<Setter TargetName="BD" Property="BorderBrush" Value="Transparent" />
-							<Setter TargetName="ContentPanel" Property="Visibility" Value="Collapsed" />
-							<Setter TargetName="MenuDropDownButton" Property="Visibility" Value="Collapsed" />
-						</DataTrigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-		<Setter Property="ItemContainerStyle">
-			<Setter.Value>
-				<Style TargetType="{x:Type TabItem}">
-					<Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
-					<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabUnselectedBackground}}" />
-					<Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabUnselectedText}}" />
-					<Setter Property="BorderBrush" Value="Transparent" />
-					<Setter Property="ToolTip" Value="{Binding ToolTip}" />
-					<Setter Property="Padding" Value="6,1" />
-					<Setter Property="Margin" Value="0" />
-					<Setter Property="Template">
-						<Setter.Value>
-							<ControlTemplate TargetType="{x:Type TabItem}">
-								<Grid SnapsToDevicePixels="true">
-									<Border
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Model.ChildrenCount}" Value="0">
+                            <Setter TargetName="BD" Property="BorderBrush" Value="Transparent" />
+                            <Setter TargetName="ContentPanel" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="MenuDropDownButton" Property="Visibility" Value="Collapsed" />
+                        </DataTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="ItemContainerStyle">
+            <Setter.Value>
+                <Style TargetType="{x:Type TabItem}">
+                    <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
+                    <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabUnselectedBackground}}" />
+                    <Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabUnselectedText}}" />
+                    <Setter Property="BorderBrush" Value="Transparent" />
+                    <Setter Property="ToolTip" Value="{Binding ToolTip}" />
+                    <Setter Property="Padding" Value="6,1" />
+                    <Setter Property="Margin" Value="0" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type TabItem}">
+                                <Grid SnapsToDevicePixels="true">
+                                    <Border
 										x:Name="Bd"
 										Background="{TemplateBinding Background}"
 										BorderBrush="{Binding Background, RelativeSource={RelativeSource Self}}"
 										BorderThickness="0,0,0,2" />
-									<ContentPresenter
+                                    <ContentPresenter
 										x:Name="Content"
 										HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
 										VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
 										ContentSource="Header"
 										RecognizesAccessKey="True"
 										SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-								</Grid>
-								<ControlTemplate.Triggers>
-									<Trigger Property="Selector.IsSelected" Value="true">
-										<Setter Property="Panel.ZIndex" Value="1" />
-									</Trigger>
+                                </Grid>
+                                <ControlTemplate.Triggers>
+                                    <Trigger Property="Selector.IsSelected" Value="true">
+                                        <Setter Property="Panel.ZIndex" Value="1" />
+                                    </Trigger>
 
-									<!--  Document Well : Tab / Selected, active  -->
-									<DataTrigger Binding="{Binding IsActive}" Value="True">
-										<Setter TargetName="Bd" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedActiveBackground}}" />
-										<Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedActiveText}}" />
-										<Setter Property="Panel.ZIndex" Value="1" />
-									</DataTrigger>
+                                    <!--  Document Well : Tab / Selected, active  -->
+                                    <DataTrigger Binding="{Binding IsActive}" Value="True">
+                                        <Setter TargetName="Bd" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedActiveBackground}}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedActiveText}}" />
+                                        <Setter Property="Panel.ZIndex" Value="1" />
+                                    </DataTrigger>
 
-									<!--  Document Well : Tab / Selected, inactive  -->
-									<MultiDataTrigger>
-										<MultiDataTrigger.Conditions>
-											<Condition Binding="{Binding IsActive}" Value="False" />
-											<Condition Binding="{Binding IsSelected}" Value="True" />
-										</MultiDataTrigger.Conditions>
-										<Setter TargetName="Bd" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedInactiveBackground}}" />
-										<Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedInactiveText}}" />
-									</MultiDataTrigger>
+                                    <!--  Document Well : Tab / Selected, inactive  -->
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding IsActive}" Value="False" />
+                                            <Condition Binding="{Binding IsSelected}" Value="True" />
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter TargetName="Bd" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedInactiveBackground}}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedInactiveText}}" />
+                                    </MultiDataTrigger>
 
-									<!--  Document Well : Tab / Unselected  -->
-									<MultiDataTrigger>
-										<MultiDataTrigger.Conditions>
-											<Condition Binding="{Binding IsActive}" Value="False" />
-											<Condition Binding="{Binding IsSelected}" Value="False" />
-										</MultiDataTrigger.Conditions>
-										<Setter TargetName="Bd" Property="BorderBrush" Value="Transparent" />
-									</MultiDataTrigger>
+                                    <!--  Document Well : Tab / Unselected  -->
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding IsActive}" Value="False" />
+                                            <Condition Binding="{Binding IsSelected}" Value="False" />
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter TargetName="Bd" Property="BorderBrush" Value="Transparent" />
+                                    </MultiDataTrigger>
 
-									<!--  Document Well : Tab / Unselected, hovered  -->
-									<MultiTrigger>
-										<MultiTrigger.Conditions>
-											<Condition Property="IsMouseOver" Value="true" />
-											<Condition Property="Selector.IsSelected" Value="false" />
-										</MultiTrigger.Conditions>
-										<Setter TargetName="Bd" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabUnselectedHoveredBackground}}" />
-										<Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabUnselectedHoveredText}}" />
-										<Setter Property="Panel.ZIndex" Value="0" />
-									</MultiTrigger>
+                                    <!--  Document Well : Tab / Unselected, hovered  -->
+                                    <MultiTrigger>
+                                        <MultiTrigger.Conditions>
+                                            <Condition Property="IsMouseOver" Value="true" />
+                                            <Condition Property="Selector.IsSelected" Value="false" />
+                                        </MultiTrigger.Conditions>
+                                        <Setter TargetName="Bd" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabUnselectedHoveredBackground}}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabUnselectedHoveredText}}" />
+                                        <Setter Property="Panel.ZIndex" Value="0" />
+                                    </MultiTrigger>
 
-									<Trigger Property="IsEnabled" Value="false">
-										<Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
-									</Trigger>
-								</ControlTemplate.Triggers>
-							</ControlTemplate>
-						</Setter.Value>
-					</Setter>
-				</Style>
-			</Setter.Value>
-		</Setter>
-		<Setter Property="ItemTemplate">
-			<Setter.Value>
-				<DataTemplate>
-					<avalonDockControls:LayoutDocumentTabItem Model="{Binding}" />
-				</DataTemplate>
-			</Setter.Value>
-		</Setter>
+                                    <Trigger Property="IsEnabled" Value="false">
+                                        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                                    </Trigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="ItemTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <avalonDockControls:LayoutDocumentTabItem Model="{Binding}" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
 
-		<Setter Property="ContentTemplate">
-			<Setter.Value>
-				<DataTemplate>
-					<avalonDockControls:LayoutDocumentControl Model="{Binding}" />
-				</DataTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+        <Setter Property="ContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <avalonDockControls:LayoutDocumentControl Model="{Binding}" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-	<!--  AnchorablePaneControlStyle  -->
-	<Style x:Key="AvalonDockThemeVs2013AnchorablePaneControlStyle" TargetType="{x:Type avalonDockControls:LayoutAnchorablePaneControl}">
-		<Setter Property="TabStripPlacement" Value="Bottom" />
-		<Setter Property="Padding" Value="0" />
-		<Setter Property="BorderThickness" Value="0" />
-		<Setter Property="Foreground" Value="{Binding Model.Root.Manager.Foreground, RelativeSource={RelativeSource Self}}" />
-		<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.TabBackground}}" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type avalonDockControls:LayoutAnchorablePaneControl}">
-					<Grid
+    <!--  AnchorablePaneControlStyle  -->
+    <Style x:Key="AvalonDockThemeVs2013AnchorablePaneControlStyle" TargetType="{x:Type avalonDockControls:LayoutAnchorablePaneControl}">
+        <Setter Property="TabStripPlacement" Value="Bottom" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Foreground" Value="{Binding Model.Root.Manager.Foreground, RelativeSource={RelativeSource Self}}" />
+        <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.TabBackground}}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutAnchorablePaneControl}">
+                    <Grid
 						ClipToBounds="true"
 						KeyboardNavigation.TabNavigation="Local"
 						SnapsToDevicePixels="true">
-						<Grid.RowDefinitions>
-							<RowDefinition Height="*" />
-							<RowDefinition Height="Auto" />
-						</Grid.RowDefinitions>
-						<!--  Following border is required to catch mouse events  -->
-						<Border Grid.RowSpan="2" Background="Transparent" />
-						<Border
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <!--  Following border is required to catch mouse events  -->
+                        <Border Grid.RowSpan="2" Background="Transparent" />
+                        <Border
 							x:Name="ContentPanel"
 							Grid.Row="0"
 							Grid.Column="0"
@@ -414,53 +414,53 @@
 							KeyboardNavigation.DirectionalNavigation="Contained"
 							KeyboardNavigation.TabIndex="2"
 							KeyboardNavigation.TabNavigation="Cycle">
-							<ContentPresenter
+                            <ContentPresenter
 								x:Name="PART_SelectedContentHost"
 								Margin="{TemplateBinding Padding}"
 								ContentSource="SelectedContent"
 								SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-						</Border>
-						<avalonDockControls:AnchorablePaneTabPanel
+                        </Border>
+                        <avalonDockControls:AnchorablePaneTabPanel
 							x:Name="HeaderPanel"
 							Grid.Row="1"
 							Margin="0"
 							Panel.ZIndex="1"
 							IsItemsHost="true"
 							KeyboardNavigation.TabIndex="1" />
-					</Grid>
-					<ControlTemplate.Triggers>
-						<Trigger Property="IsEnabled" Value="false">
-							<Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
-						</Trigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
 
-		<Setter Property="ItemContainerStyle">
-			<Setter.Value>
-				<Style TargetType="{x:Type TabItem}">
-					<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabUnselectedBackground}}" />
-					<Setter Property="BorderBrush" Value="Transparent" />
-					<Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabUnselectedText}}" />
-					<Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
-					<Setter Property="ToolTip" Value="{Binding ToolTip}" />
-					<Setter Property="Template">
-						<Setter.Value>
-							<ControlTemplate TargetType="{x:Type TabItem}">
-								<Grid SnapsToDevicePixels="true">
-									<Border
+        <Setter Property="ItemContainerStyle">
+            <Setter.Value>
+                <Style TargetType="{x:Type TabItem}">
+                    <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabUnselectedBackground}}" />
+                    <Setter Property="BorderBrush" Value="Transparent" />
+                    <Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabUnselectedText}}" />
+                    <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
+                    <Setter Property="ToolTip" Value="{Binding ToolTip}" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type TabItem}">
+                                <Grid SnapsToDevicePixels="true">
+                                    <Border
 										x:Name="SelectedBD"
 										Margin="1,-1,1,0"
 										BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabSelectedActiveBackground}}"
 										BorderThickness="0,1,0,0"
 										Visibility="Collapsed" />
-									<Border
+                                    <Border
 										x:Name="Bd"
 										Margin="0"
 										Background="{TemplateBinding Background}"
 										BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}">
-										<ContentPresenter
+                                        <ContentPresenter
 											x:Name="Content"
 											Margin="6,2"
 											HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
@@ -468,146 +468,146 @@
 											ContentSource="Header"
 											RecognizesAccessKey="True"
 											SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-									</Border>
-								</Grid>
-								<ControlTemplate.Triggers>
-									<Trigger Property="Selector.IsSelected" Value="true">
-										<Setter TargetName="SelectedBD" Property="Visibility" Value="Visible" />
-										<Setter TargetName="Bd" Property="BorderThickness" Value="1,0,1,1" />
-										<Setter Property="Panel.ZIndex" Value="1" />
-									</Trigger>
+                                    </Border>
+                                </Grid>
+                                <ControlTemplate.Triggers>
+                                    <Trigger Property="Selector.IsSelected" Value="true">
+                                        <Setter TargetName="SelectedBD" Property="Visibility" Value="Visible" />
+                                        <Setter TargetName="Bd" Property="BorderThickness" Value="1,0,1,1" />
+                                        <Setter Property="Panel.ZIndex" Value="1" />
+                                    </Trigger>
 
-									<!--  Tool Window : Tab / Selected, active  -->
-									<MultiDataTrigger>
-										<MultiDataTrigger.Conditions>
-											<Condition Binding="{Binding IsSelected}" Value="True" />
-											<Condition Binding="{Binding IsActive}" Value="True" />
-										</MultiDataTrigger.Conditions>
-										<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabSelectedActiveBackground}}" />
-										<Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabSelectedActiveText}}" />
-									</MultiDataTrigger>
+                                    <!--  Tool Window : Tab / Selected, active  -->
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding IsSelected}" Value="True" />
+                                            <Condition Binding="{Binding IsActive}" Value="True" />
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabSelectedActiveBackground}}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabSelectedActiveText}}" />
+                                    </MultiDataTrigger>
 
-									<!--  Tool Window : Tab / Selected, inactive  -->
-									<MultiDataTrigger>
-										<MultiDataTrigger.Conditions>
-											<Condition Binding="{Binding IsSelected}" Value="True" />
-											<Condition Binding="{Binding IsActive}" Value="False" />
-										</MultiDataTrigger.Conditions>
-										<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabSelectedInactiveBackground}}" />
-										<Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabSelectedInactiveText}}" />
-									</MultiDataTrigger>
+                                    <!--  Tool Window : Tab / Selected, inactive  -->
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding IsSelected}" Value="True" />
+                                            <Condition Binding="{Binding IsActive}" Value="False" />
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabSelectedInactiveBackground}}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabSelectedInactiveText}}" />
+                                    </MultiDataTrigger>
 
-									<!--  Tool Window : Tab / Unselected, hovered  -->
-									<MultiTrigger>
-										<MultiTrigger.Conditions>
-											<Condition Property="IsMouseOver" Value="true" />
-											<Condition Property="Selector.IsSelected" Value="false" />
-										</MultiTrigger.Conditions>
-										<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabUnselectedHoveredBackground}}" />
-										<Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabUnselectedHoveredText}}" />
-										<Setter Property="Panel.ZIndex" Value="0" />
-									</MultiTrigger>
+                                    <!--  Tool Window : Tab / Unselected, hovered  -->
+                                    <MultiTrigger>
+                                        <MultiTrigger.Conditions>
+                                            <Condition Property="IsMouseOver" Value="true" />
+                                            <Condition Property="Selector.IsSelected" Value="false" />
+                                        </MultiTrigger.Conditions>
+                                        <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabUnselectedHoveredBackground}}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabUnselectedHoveredText}}" />
+                                        <Setter Property="Panel.ZIndex" Value="0" />
+                                    </MultiTrigger>
 
-									<Trigger Property="IsEnabled" Value="false">
-										<Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
-									</Trigger>
-								</ControlTemplate.Triggers>
-							</ControlTemplate>
-						</Setter.Value>
-					</Setter>
-					<Style.Triggers>
-						<DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TabControl}}, Path=Items.Count}" Value="1">
-							<Setter Property="Visibility" Value="Collapsed" />
-						</DataTrigger>
-					</Style.Triggers>
-				</Style>
-			</Setter.Value>
-		</Setter>
+                                    <Trigger Property="IsEnabled" Value="false">
+                                        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                                    </Trigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TabControl}}, Path=Items.Count}" Value="1">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Setter.Value>
+        </Setter>
 
-		<Setter Property="ItemTemplate">
-			<Setter.Value>
-				<DataTemplate>
-					<avalonDockControls:LayoutAnchorableTabItem Model="{Binding}" />
-				</DataTemplate>
-			</Setter.Value>
-		</Setter>
+        <Setter Property="ItemTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <avalonDockControls:LayoutAnchorableTabItem Model="{Binding}" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
 
-		<Setter Property="ContentTemplate">
-			<Setter.Value>
-				<DataTemplate>
-					<avalonDockControls:LayoutAnchorableControl Model="{Binding}" />
-				</DataTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+        <Setter Property="ContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <avalonDockControls:LayoutAnchorableControl Model="{Binding}" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-	<Style TargetType="avalonDockControls:AnchorablePaneTitle">
-		<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveBackground}}" />
-		<Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveText}}" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate>
-					<Border
+    <Style TargetType="avalonDockControls:AnchorablePaneTitle">
+        <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveBackground}}" />
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveText}}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Border
 						Background="{TemplateBinding Background}"
 						BorderBrush="{TemplateBinding BorderBrush}"
 						BorderThickness="{TemplateBinding BorderThickness}">
-						<Grid Margin="2,3">
-							<Grid.ColumnDefinitions>
-								<ColumnDefinition Width="*" />
-								<ColumnDefinition Width="Auto" />
-								<ColumnDefinition Width="Auto" />
-								<ColumnDefinition Width="Auto" />
-							</Grid.ColumnDefinitions>
-							<Rectangle
+                        <Grid Margin="2,3">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Rectangle
 								x:Name="DragHandleGeometryPlaceholder"
 								Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveGrip}}"
 								Visibility="Collapsed" />
-							<Rectangle
+                            <Rectangle
 								x:Name="DragHandleTexture"
 								Height="5"
 								Margin="8,0,4,0"
 								VerticalAlignment="Center">
-								<Rectangle.Fill>
-									<DrawingBrush
+                                <Rectangle.Fill>
+                                    <DrawingBrush
 										TileMode="Tile"
 										Viewbox="0,0,4,5"
 										ViewboxUnits="Absolute"
 										Viewport="0,0,4,5"
 										ViewportUnits="Absolute">
-										<DrawingBrush.Drawing>
-											<GeometryDrawing Brush="{Binding Fill, ElementName=DragHandleGeometryPlaceholder, Mode=OneWay, Converter={avalonDockConverters:NullToDoNothingConverter}}">
-												<GeometryDrawing.Geometry>
-													<GeometryGroup>
-														<GeometryGroup.Children>
-															<RectangleGeometry Rect="0,0,1,1" />
-															<RectangleGeometry Rect="0,4,1,1" />
-															<RectangleGeometry Rect="2,2,1,1" />
-														</GeometryGroup.Children>
-													</GeometryGroup>
-												</GeometryDrawing.Geometry>
-											</GeometryDrawing>
-										</DrawingBrush.Drawing>
-									</DrawingBrush>
-								</Rectangle.Fill>
-							</Rectangle>
-							<Border
+                                        <DrawingBrush.Drawing>
+                                            <GeometryDrawing Brush="{Binding Fill, ElementName=DragHandleGeometryPlaceholder, Mode=OneWay, Converter={avalonDockConverters:NullToDoNothingConverter}}">
+                                                <GeometryDrawing.Geometry>
+                                                    <GeometryGroup>
+                                                        <GeometryGroup.Children>
+                                                            <RectangleGeometry Rect="0,0,1,1" />
+                                                            <RectangleGeometry Rect="0,4,1,1" />
+                                                            <RectangleGeometry Rect="2,2,1,1" />
+                                                        </GeometryGroup.Children>
+                                                    </GeometryGroup>
+                                                </GeometryDrawing.Geometry>
+                                            </GeometryDrawing>
+                                        </DrawingBrush.Drawing>
+                                    </DrawingBrush>
+                                </Rectangle.Fill>
+                            </Rectangle>
+                            <Border
 								Padding="5,0"
 								HorizontalAlignment="Left"
 								Background="{TemplateBinding Background}">
-								<avalonDockControls:DropDownControlArea
+                                <avalonDockControls:DropDownControlArea
 									DropDownContextMenu="{Binding Model.Root.Manager.AnchorableContextMenu, RelativeSource={RelativeSource TemplatedParent}}"
 									DropDownContextMenuDataContext="{Binding Path=LayoutItem, RelativeSource={RelativeSource TemplatedParent}}"
 									Style="{DynamicResource DropDownControlArea}">
-									<ContentPresenter
+                                    <ContentPresenter
 										x:Name="Header"
 										Margin="2,0,0,0"
 										Content="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}"
 										ContentTemplate="{Binding Model.Root.Manager.AnchorableTitleTemplate, RelativeSource={RelativeSource TemplatedParent}}"
 										ContentTemplateSelector="{Binding Model.Root.Manager.AnchorableTitleTemplateSelector, RelativeSource={RelativeSource TemplatedParent}}"
 										TextElement.Foreground="{TemplateBinding Foreground}" />
-								</avalonDockControls:DropDownControlArea>
-							</Border>
-							<avalonDockControls:DropDownButton
+                                </avalonDockControls:DropDownControlArea>
+                            </Border>
+                            <avalonDockControls:DropDownButton
 								x:Name="MenuDropDownButton"
 								Grid.Column="1"
 								Margin="2,0"
@@ -617,16 +617,16 @@
 								Focusable="False"
 								Style="{StaticResource AvalonDockThemeVs2013ToolButtonStyle}"
 								ToolTip="{x:Static avalonDockProperties:Resources.Anchorable_CxMenu_Hint}">
-								<Path
+                                <Path
 									x:Name="PART_ImgMenuPin"
 									Width="10"
 									Height="13"
 									Data="{DynamicResource PinMenu}"
 									Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveGlyph}}"
 									Stretch="Uniform" />
-							</avalonDockControls:DropDownButton>
+                            </avalonDockControls:DropDownButton>
 
-							<Button
+                            <Button
 								x:Name="PART_AutoHidePin"
 								Grid.Column="2"
 								Margin="2,0"
@@ -637,15 +637,15 @@
 								Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
 								ToolTip="{x:Static avalonDockProperties:Resources.Anchorable_BtnAutoHide_Hint}"
 								Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
-								<Path
+                                <Path
 									x:Name="PART_ImgAutoHidePin"
 									Width="10"
 									Height="13"
 									Data="{DynamicResource PinAutoHide}"
 									Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveGlyph}}"
 									Stretch="Uniform" />
-							</Button>
-							<Button
+                            </Button>
+                            <Button
 								x:Name="PART_HidePin"
 								Grid.Column="3"
 								Margin="2,0"
@@ -656,7 +656,7 @@
 								Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
 								ToolTip="{x:Static avalonDockProperties:Resources.Anchorable_BtnClose_Hint}"
 								Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
-								<Path
+                                <Path
 									x:Name="PART_ImgHidePin"
 									Width="10"
 									Height="10"
@@ -664,141 +664,146 @@
 									Data="{DynamicResource PinClose}"
 									Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveGlyph}}"
 									Stretch="Uniform" />
-							</Button>
+                            </Button>
 
-						</Grid>
-					</Border>
-					<ControlTemplate.Triggers>
-						<DataTrigger Binding="{Binding Model.IsAutoHidden, RelativeSource={RelativeSource Mode=Self}}" Value="True">
-							<Setter TargetName="PART_AutoHidePin" Property="LayoutTransform">
-								<Setter.Value>
-									<RotateTransform Angle="90" />
-								</Setter.Value>
-							</Setter>
-						</DataTrigger>
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <DataTrigger Binding="{Binding Model.IsAutoHidden, RelativeSource={RelativeSource Mode=Self}}" Value="True">
+                            <Setter TargetName="PART_AutoHidePin" Property="LayoutTransform">
+                                <Setter.Value>
+                                    <RotateTransform Angle="90" />
+                                </Setter.Value>
+                            </Setter>
+                        </DataTrigger>
 
-						<!--  Tool Window : Caption / Active  -->
-						<DataTrigger Binding="{Binding Model.IsActive, RelativeSource={RelativeSource Mode=Self}}" Value="True">
-							<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveBackground}}" />
-							<Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveText}}" />
-							<Setter TargetName="DragHandleGeometryPlaceholder" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveGrip}}" />
-						</DataTrigger>
+                        <DataTrigger Binding="{Binding Model.CanClose, RelativeSource={RelativeSource Mode=Self}}" Value="True">
+                            <Setter TargetName="PART_HidePin" Property="Command" Value="{Binding Path=LayoutItem.CloseCommand, RelativeSource={RelativeSource TemplatedParent}}" />
+                            <Setter TargetName="PART_HidePin" Property="ToolTip" Value="{x:Static avalonDockProperties:Resources.Document_Close}" />
+                        </DataTrigger>
 
-						<!--  Tool Window : Caption : Button / Active  -->
-						<DataTrigger Binding="{Binding Model.IsActive, RelativeSource={RelativeSource Mode=Self}}" Value="True">
-							<Setter TargetName="PART_ImgMenuPin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveGlyph}}" />
-							<Setter TargetName="PART_ImgAutoHidePin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveGlyph}}" />
-							<Setter TargetName="PART_ImgHidePin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveGlyph}}" />
-						</DataTrigger>
+                        <!--  Tool Window : Caption / Active  -->
+                        <DataTrigger Binding="{Binding Model.IsActive, RelativeSource={RelativeSource Mode=Self}}" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveBackground}}" />
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveText}}" />
+                            <Setter TargetName="DragHandleGeometryPlaceholder" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveGrip}}" />
+                        </DataTrigger>
 
-						<!--  Tool Window : Caption : Button / Active, hovered  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseOver, ElementName=MenuDropDownButton}" Value="True" />
-								<Condition Binding="{Binding Model.IsActive, RelativeSource={RelativeSource Mode=Self}}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="MenuDropDownButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredBackground}}" />
-							<Setter TargetName="MenuDropDownButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgMenuPin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_AutoHidePin}" Value="True" />
-								<Condition Binding="{Binding Model.IsActive, RelativeSource={RelativeSource Mode=Self}}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_AutoHidePin" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredBackground}}" />
-							<Setter TargetName="PART_AutoHidePin" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgAutoHidePin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_HidePin}" Value="True" />
-								<Condition Binding="{Binding Model.IsActive, RelativeSource={RelativeSource Mode=Self}}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_HidePin" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredBackground}}" />
-							<Setter TargetName="PART_HidePin" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgHidePin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Tool Window : Caption : Button / Active  -->
+                        <DataTrigger Binding="{Binding Model.IsActive, RelativeSource={RelativeSource Mode=Self}}" Value="True">
+                            <Setter TargetName="PART_ImgMenuPin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveGlyph}}" />
+                            <Setter TargetName="PART_ImgAutoHidePin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveGlyph}}" />
+                            <Setter TargetName="PART_ImgHidePin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveGlyph}}" />
+                        </DataTrigger>
 
-						<!--  Tool Window : Caption : Button / Inactive, hovered  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseOver, ElementName=MenuDropDownButton}" Value="True" />
-								<Condition Binding="{Binding Model.IsActive, RelativeSource={RelativeSource Mode=Self}}" Value="False" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="MenuDropDownButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredBackground}}" />
-							<Setter TargetName="MenuDropDownButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgMenuPin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_AutoHidePin}" Value="True" />
-								<Condition Binding="{Binding Model.IsActive, RelativeSource={RelativeSource Mode=Self}}" Value="False" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_AutoHidePin" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredBackground}}" />
-							<Setter TargetName="PART_AutoHidePin" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgAutoHidePin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_HidePin}" Value="True" />
-								<Condition Binding="{Binding Model.IsActive, RelativeSource={RelativeSource Mode=Self}}" Value="False" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_HidePin" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredBackground}}" />
-							<Setter TargetName="PART_HidePin" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgHidePin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Tool Window : Caption : Button / Active, hovered  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseOver, ElementName=MenuDropDownButton}" Value="True" />
+                                <Condition Binding="{Binding Model.IsActive, RelativeSource={RelativeSource Mode=Self}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="MenuDropDownButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredBackground}}" />
+                            <Setter TargetName="MenuDropDownButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgMenuPin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_AutoHidePin}" Value="True" />
+                                <Condition Binding="{Binding Model.IsActive, RelativeSource={RelativeSource Mode=Self}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_AutoHidePin" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredBackground}}" />
+                            <Setter TargetName="PART_AutoHidePin" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgAutoHidePin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_HidePin}" Value="True" />
+                                <Condition Binding="{Binding Model.IsActive, RelativeSource={RelativeSource Mode=Self}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_HidePin" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredBackground}}" />
+                            <Setter TargetName="PART_HidePin" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgHidePin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Tool Window : Caption : Button / Active / Inactive, pressed  -->
-						<Trigger SourceName="MenuDropDownButton" Property="IsChecked" Value="True">
-							<Setter TargetName="MenuDropDownButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedBackground}}" />
-							<Setter TargetName="MenuDropDownButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedBorder}}" />
-							<Setter TargetName="PART_ImgMenuPin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedGlyph}}" />
-						</Trigger>
-						<Trigger SourceName="PART_AutoHidePin" Property="IsMouseCaptured" Value="True">
-							<Setter TargetName="PART_AutoHidePin" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedBackground}}" />
-							<Setter TargetName="PART_AutoHidePin" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedBorder}}" />
-							<Setter TargetName="PART_ImgAutoHidePin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedGlyph}}" />
-						</Trigger>
-						<Trigger SourceName="PART_HidePin" Property="IsMouseCaptured" Value="True">
-							<Setter TargetName="PART_HidePin" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedBackground}}" />
-							<Setter TargetName="PART_HidePin" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedBorder}}" />
-							<Setter TargetName="PART_ImgHidePin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedGlyph}}" />
-						</Trigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                        <!--  Tool Window : Caption : Button / Inactive, hovered  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseOver, ElementName=MenuDropDownButton}" Value="True" />
+                                <Condition Binding="{Binding Model.IsActive, RelativeSource={RelativeSource Mode=Self}}" Value="False" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="MenuDropDownButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredBackground}}" />
+                            <Setter TargetName="MenuDropDownButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgMenuPin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_AutoHidePin}" Value="True" />
+                                <Condition Binding="{Binding Model.IsActive, RelativeSource={RelativeSource Mode=Self}}" Value="False" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_AutoHidePin" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredBackground}}" />
+                            <Setter TargetName="PART_AutoHidePin" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgAutoHidePin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_HidePin}" Value="True" />
+                                <Condition Binding="{Binding Model.IsActive, RelativeSource={RelativeSource Mode=Self}}" Value="False" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_HidePin" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredBackground}}" />
+                            <Setter TargetName="PART_HidePin" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgHidePin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
 
-	<ControlTemplate x:Key="AvalonDockThemeVs2013AnchorSideTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorSideControl}">
-		<ItemsControl ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Children}">
-			<ItemsControl.ItemsPanel>
-				<ItemsPanelTemplate>
-					<StackPanel
+                        <!--  Tool Window : Caption : Button / Active / Inactive, pressed  -->
+                        <Trigger SourceName="MenuDropDownButton" Property="IsChecked" Value="True">
+                            <Setter TargetName="MenuDropDownButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedBackground}}" />
+                            <Setter TargetName="MenuDropDownButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgMenuPin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedGlyph}}" />
+                        </Trigger>
+                        <Trigger SourceName="PART_AutoHidePin" Property="IsMouseCaptured" Value="True">
+                            <Setter TargetName="PART_AutoHidePin" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedBackground}}" />
+                            <Setter TargetName="PART_AutoHidePin" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgAutoHidePin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedGlyph}}" />
+                        </Trigger>
+                        <Trigger SourceName="PART_HidePin" Property="IsMouseCaptured" Value="True">
+                            <Setter TargetName="PART_HidePin" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedBackground}}" />
+                            <Setter TargetName="PART_HidePin" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgHidePin" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonActivePressedGlyph}}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <ControlTemplate x:Key="AvalonDockThemeVs2013AnchorSideTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorSideControl}">
+        <ItemsControl ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Children}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <StackPanel
 						MinWidth="4"
 						MinHeight="4"
 						Orientation="{Binding Path=Model.Side, RelativeSource={RelativeSource AncestorType={x:Type avalonDockControls:LayoutAnchorSideControl}, Mode=FindAncestor}, Converter={avalonDockConverters:AnchorSideToOrientationConverter}}" />
-				</ItemsPanelTemplate>
-			</ItemsControl.ItemsPanel>
-		</ItemsControl>
-	</ControlTemplate>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+        </ItemsControl>
+    </ControlTemplate>
 
-	<ControlTemplate x:Key="AvalonDockThemeVs2013AnchorGroupTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorGroupControl}">
-		<ItemsControl ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Children}">
-			<ItemsControl.LayoutTransform>
-				<RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Model.Parent.Side, Converter={avalonDockConverters:AnchorSideToAngleConverter}}" />
-			</ItemsControl.LayoutTransform>
-			<ItemsControl.ItemsPanel>
-				<ItemsPanelTemplate>
-					<StackPanel Orientation="Horizontal" />
-				</ItemsPanelTemplate>
-			</ItemsControl.ItemsPanel>
-		</ItemsControl>
-	</ControlTemplate>
+    <ControlTemplate x:Key="AvalonDockThemeVs2013AnchorGroupTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorGroupControl}">
+        <ItemsControl ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Children}">
+            <ItemsControl.LayoutTransform>
+                <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Model.Parent.Side, Converter={avalonDockConverters:AnchorSideToAngleConverter}}" />
+            </ItemsControl.LayoutTransform>
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal" />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+        </ItemsControl>
+    </ControlTemplate>
 
-	<ControlTemplate x:Key="AvalonDockThemeVs2013AnchorTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorControl}">
-		<Border
+    <ControlTemplate x:Key="AvalonDockThemeVs2013AnchorTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorControl}">
+        <Border
 			x:Name="Bd"
 			Margin="0,0,12,0"
 			Padding="0,3,0,3"
@@ -806,55 +811,55 @@
 			BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.AutoHideTabDefaultBorder}}"
 			BorderThickness="0,0,0,6"
 			TextElement.Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.AutoHideTabDefaultText}}">
-			<ContentPresenter
+            <ContentPresenter
 				Content="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}"
 				ContentTemplate="{Binding AnchorableHeaderTemplate, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}"
 				ContentTemplateSelector="{Binding AnchorableHeaderTemplateSelector, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}" />
-		</Border>
-		<ControlTemplate.Triggers>
-			<Trigger Property="Side" Value="Right">
-				<Setter TargetName="Bd" Property="BorderThickness" Value="0,6,0,0" />
-				<Setter TargetName="Bd" Property="Padding" Value="0,3,0,3" />
-			</Trigger>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="Side" Value="Right">
+                <Setter TargetName="Bd" Property="BorderThickness" Value="0,6,0,0" />
+                <Setter TargetName="Bd" Property="Padding" Value="0,3,0,3" />
+            </Trigger>
 
-			<Trigger Property="Side" Value="Top">
-				<Setter TargetName="Bd" Property="BorderThickness" Value="0,6,0,0" />
-				<Setter TargetName="Bd" Property="Padding" Value="0,3,0,3" />
-			</Trigger>
+            <Trigger Property="Side" Value="Top">
+                <Setter TargetName="Bd" Property="BorderThickness" Value="0,6,0,0" />
+                <Setter TargetName="Bd" Property="Padding" Value="0,3,0,3" />
+            </Trigger>
 
-			<Trigger Property="IsMouseOver" Value="True">
-				<Setter TargetName="Bd" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.AutoHideTabHoveredBackground}}" />
-				<Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.AutoHideTabHoveredBorder}}" />
-				<Setter TargetName="Bd" Property="TextElement.Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.AutoHideTabHoveredText}}" />
-			</Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.AutoHideTabHoveredBackground}}" />
+                <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.AutoHideTabHoveredBorder}}" />
+                <Setter TargetName="Bd" Property="TextElement.Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.AutoHideTabHoveredText}}" />
+            </Trigger>
 
-		</ControlTemplate.Triggers>
-	</ControlTemplate>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
 
-	<Style x:Key="{x:Type avalonDockControls:OverlayWindow}" TargetType="{x:Type avalonDockControls:OverlayWindow}">
-		<Setter Property="UseLayoutRounding" Value="True" />
-		<Setter Property="Background" Value="Transparent" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type avalonDockControls:OverlayWindow}">
-					<Canvas x:Name="PART_DropTargetsContainer" Opacity="0.9">
-						<!--
+    <Style x:Key="{x:Type avalonDockControls:OverlayWindow}" TargetType="{x:Type avalonDockControls:OverlayWindow}">
+        <Setter Property="UseLayoutRounding" Value="True" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type avalonDockControls:OverlayWindow}">
+                    <Canvas x:Name="PART_DropTargetsContainer" Opacity="0.9">
+                        <!--
 							Drop target rectangle that is displayed before a document or tool window
 							is dropped into a drop target location
 						-->
-						<Path
+                        <Path
 							x:Name="PART_PreviewBox"
 							Fill="{DynamicResource {x:Static reskeys:ResourceKeys.PreviewBoxBackgroundBrushKey}}"
 							Stroke="{DynamicResource {x:Static reskeys:ResourceKeys.PreviewBoxBorderBrushKey}}"
 							StrokeThickness="0.5" />
 
-						<!--
+                        <!--
 							Outmost Outter 4 overlay buttons that are displayed at border of MainWindow
 							when user drags tool window over another tool window or document and the
 							AvalonDock air space contains additional document(s) and tool windows (s).
 						-->
-						<Grid x:Name="PART_DockingManagerDropTargets">
-							<ContentControl
+                        <Grid x:Name="PART_DockingManagerDropTargets">
+                            <ContentControl
 								x:Name="PART_DockingManagerDropTargetLeft"
 								Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
 								Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
@@ -867,7 +872,7 @@
 								BorderBrush="Transparent"
 								Content="{StaticResource DockAnchorableLeft}" />
 
-							<ContentControl
+                            <ContentControl
 								x:Name="PART_DockingManagerDropTargetRight"
 								Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
 								Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
@@ -880,7 +885,7 @@
 								BorderBrush="Transparent"
 								Content="{StaticResource DockAnchorableRight}" />
 
-							<ContentControl
+                            <ContentControl
 								x:Name="PART_DockingManagerDropTargetBottom"
 								Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
 								Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
@@ -893,7 +898,7 @@
 								BorderBrush="Transparent"
 								Content="{StaticResource DockAnchorableBottom}" />
 
-							<ContentControl
+                            <ContentControl
 								x:Name="PART_DockingManagerDropTargetTop"
 								Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
 								Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
@@ -906,34 +911,34 @@
 								BorderBrush="Transparent"
 								Content="{StaticResource DockAnchorableTop}" />
 
-						</Grid>
+                        </Grid>
 
-						<!--
+                        <!--
 							Is displayed as center cross with a max of 5 buttons when a toolwindow is
 							dragged over another tool window
 						-->
-						<Grid x:Name="PART_AnchorablePaneDropTargets">
-							<!--  Gray Star Background  -->
-							<Path
+                        <Grid x:Name="PART_AnchorablePaneDropTargets">
+                            <!--  Gray Star Background  -->
+                            <Path
 								Height="122"
 								Data="{DynamicResource DockPaneEmpty}"
 								Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBackgroundBrushKey}}"
 								Stretch="Uniform"
 								Stroke="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBorderBrushKey}}"
 								StrokeThickness="1" />
-							<Grid HorizontalAlignment="Center" VerticalAlignment="Center">
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition />
-									<ColumnDefinition />
-									<ColumnDefinition />
-								</Grid.ColumnDefinitions>
-								<Grid.RowDefinitions>
-									<RowDefinition />
-									<RowDefinition />
-									<RowDefinition />
-								</Grid.RowDefinitions>
-								<!--  Inner 5 buttons of star shapped control  -->
-								<ContentControl
+                            <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition />
+                                    <ColumnDefinition />
+                                    <ColumnDefinition />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                </Grid.RowDefinitions>
+                                <!--  Inner 5 buttons of star shapped control  -->
+                                <ContentControl
 									x:Name="PART_AnchorablePaneDropTargetTop"
 									Grid.Row="0"
 									Grid.Column="1"
@@ -944,7 +949,7 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentAsAnchorableTop}" />
-								<ContentControl
+                                <ContentControl
 									x:Name="PART_AnchorablePaneDropTargetRight"
 									Grid.Row="1"
 									Grid.Column="2"
@@ -955,7 +960,7 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentAsAnchorableRight}" />
-								<ContentControl
+                                <ContentControl
 									x:Name="PART_AnchorablePaneDropTargetBottom"
 									Grid.Row="2"
 									Grid.Column="1"
@@ -966,7 +971,7 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentAsAnchorableBottom}" />
-								<ContentControl
+                                <ContentControl
 									x:Name="PART_AnchorablePaneDropTargetLeft"
 									Grid.Row="1"
 									Grid.Column="0"
@@ -977,8 +982,8 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentAsAnchorableLeft}" />
-								<!--  Center button of star shapped control  -->
-								<ContentControl
+                                <!--  Center button of star shapped control  -->
+                                <ContentControl
 									x:Name="PART_AnchorablePaneDropTargetInto"
 									Grid.Row="1"
 									Grid.Column="1"
@@ -989,14 +994,14 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentInside}" />
-							</Grid>
-						</Grid>
+                            </Grid>
+                        </Grid>
 
-						<!--  Is displayed as center cross with a max of 5 buttons when documents are dragged over the document container.  -->
-						<Grid x:Name="PART_DocumentPaneDropTargets">
+                        <!--  Is displayed as center cross with a max of 5 buttons when documents are dragged over the document container.  -->
+                        <Grid x:Name="PART_DocumentPaneDropTargets">
 
-							<!--  Gray Star Background  -->
-							<Path
+                            <!--  Gray Star Background  -->
+                            <Path
 								Height="122"
 								Data="{DynamicResource DockPaneEmpty}"
 								Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBackgroundBrushKey}}"
@@ -1004,19 +1009,19 @@
 								Stroke="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBorderBrushKey}}"
 								StrokeThickness="1" />
 
-							<Grid HorizontalAlignment="Center" VerticalAlignment="Center">
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition />
-									<ColumnDefinition />
-									<ColumnDefinition />
-								</Grid.ColumnDefinitions>
-								<Grid.RowDefinitions>
-									<RowDefinition />
-									<RowDefinition />
-									<RowDefinition />
-								</Grid.RowDefinitions>
-								<!--  Inner 5 buttons of star shapped control  -->
-								<ContentControl
+                            <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition />
+                                    <ColumnDefinition />
+                                    <ColumnDefinition />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                </Grid.RowDefinitions>
+                                <!--  Inner 5 buttons of star shapped control  -->
+                                <ContentControl
 									x:Name="PART_DocumentPaneDropTargetTop"
 									Grid.Row="0"
 									Grid.Column="1"
@@ -1027,7 +1032,7 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentTop}" />
-								<ContentControl
+                                <ContentControl
 									x:Name="PART_DocumentPaneDropTargetRight"
 									Grid.Row="1"
 									Grid.Column="2"
@@ -1038,7 +1043,7 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentRight}" />
-								<ContentControl
+                                <ContentControl
 									x:Name="PART_DocumentPaneDropTargetBottom"
 									Grid.Row="2"
 									Grid.Column="1"
@@ -1049,7 +1054,7 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentBottom}" />
-								<ContentControl
+                                <ContentControl
 									x:Name="PART_DocumentPaneDropTargetLeft"
 									Grid.Row="1"
 									Grid.Column="0"
@@ -1060,8 +1065,8 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentLeft}" />
-								<!--  Center button of star shapped control  -->
-								<ContentControl
+                                <!--  Center button of star shapped control  -->
+                                <ContentControl
 									x:Name="PART_DocumentPaneDropTargetInto"
 									Grid.Row="1"
 									Grid.Column="1"
@@ -1072,37 +1077,37 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentInside}" />
-							</Grid>
-						</Grid>
+                            </Grid>
+                        </Grid>
 
-						<!--  Center star with a max of 9 buttons shown when tool window is dragged of document container  -->
-						<Grid x:Name="PART_DocumentPaneFullDropTargets">
+                        <!--  Center star with a max of 9 buttons shown when tool window is dragged of document container  -->
+                        <Grid x:Name="PART_DocumentPaneFullDropTargets">
 
-							<!--  Gray Star Background  -->
-							<Path
+                            <!--  Gray Star Background  -->
+                            <Path
 								Width="204"
 								Data="{DynamicResource DockPaneLargeEmpty}"
 								Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBackgroundBrushKey}}"
 								Stretch="Uniform"
 								Stroke="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBorderBrushKey}}"
 								StrokeThickness="1" />
-							<Grid HorizontalAlignment="Center" VerticalAlignment="Center">
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition />
-									<ColumnDefinition />
-									<ColumnDefinition />
-									<ColumnDefinition />
-									<ColumnDefinition />
-								</Grid.ColumnDefinitions>
-								<Grid.RowDefinitions>
-									<RowDefinition />
-									<RowDefinition />
-									<RowDefinition />
-									<RowDefinition />
-									<RowDefinition />
-								</Grid.RowDefinitions>
-								<!--  Inner 5 buttons of star shapped control  -->
-								<ContentControl
+                            <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition />
+                                    <ColumnDefinition />
+                                    <ColumnDefinition />
+                                    <ColumnDefinition />
+                                    <ColumnDefinition />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                </Grid.RowDefinitions>
+                                <!--  Inner 5 buttons of star shapped control  -->
+                                <ContentControl
 									x:Name="PART_DocumentPaneFullDropTargetTop"
 									Grid.Row="1"
 									Grid.Column="2"
@@ -1113,7 +1118,7 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentTop}" />
-								<ContentControl
+                                <ContentControl
 									x:Name="PART_DocumentPaneFullDropTargetRight"
 									Grid.Row="2"
 									Grid.Column="3"
@@ -1124,7 +1129,7 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentRight}" />
-								<ContentControl
+                                <ContentControl
 									x:Name="PART_DocumentPaneFullDropTargetBottom"
 									Grid.Row="3"
 									Grid.Column="2"
@@ -1135,7 +1140,7 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentBottom}" />
-								<ContentControl
+                                <ContentControl
 									x:Name="PART_DocumentPaneFullDropTargetLeft"
 									Grid.Row="2"
 									Grid.Column="1"
@@ -1146,8 +1151,8 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentLeft}" />
-								<!--  Center button of star shapped control  -->
-								<ContentControl
+                                <!--  Center button of star shapped control  -->
+                                <ContentControl
 									x:Name="PART_DocumentPaneFullDropTargetInto"
 									Grid.Row="2"
 									Grid.Column="2"
@@ -1159,8 +1164,8 @@
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentInside}" />
 
-								<!--  Outer 4 buttons of star shapped control  -->
-								<ContentControl
+                                <!--  Outer 4 buttons of star shapped control  -->
+                                <ContentControl
 									x:Name="PART_DocumentPaneDropTargetTopAsAnchorablePane"
 									Grid.Row="0"
 									Grid.Column="2"
@@ -1171,7 +1176,7 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentAsAnchorableTop}" />
-								<ContentControl
+                                <ContentControl
 									x:Name="PART_DocumentPaneDropTargetRightAsAnchorablePane"
 									Grid.Row="2"
 									Grid.Column="4"
@@ -1182,7 +1187,7 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentAsAnchorableRight}" />
-								<ContentControl
+                                <ContentControl
 									x:Name="PART_DocumentPaneDropTargetBottomAsAnchorablePane"
 									Grid.Row="4"
 									Grid.Column="2"
@@ -1193,7 +1198,7 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentAsAnchorableBottom}" />
-								<ContentControl
+                                <ContentControl
 									x:Name="PART_DocumentPaneDropTargetLeftAsAnchorablePane"
 									Grid.Row="2"
 									Grid.Column="0"
@@ -1204,176 +1209,176 @@
 									Background="Transparent"
 									BorderBrush="Transparent"
 									Content="{StaticResource DockDocumentAsAnchorableLeft}" />
-							</Grid>
-						</Grid>
-					</Canvas>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                            </Grid>
+                        </Grid>
+                    </Canvas>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-	<DataTemplate x:Key="AvalonDockThemeVs2013DocumentHeaderTemplate">
-		<TextBlock Text="{Binding Title}" TextTrimming="CharacterEllipsis" />
-	</DataTemplate>
+    <DataTemplate x:Key="AvalonDockThemeVs2013DocumentHeaderTemplate">
+        <TextBlock Text="{Binding Title}" TextTrimming="CharacterEllipsis" />
+    </DataTemplate>
 
-	<DataTemplate x:Key="AvalonDockThemeVs2013AnchorableHeaderTemplate">
-		<TextBlock
+    <DataTemplate x:Key="AvalonDockThemeVs2013AnchorableHeaderTemplate">
+        <TextBlock
 			Margin="5,0"
 			Text="{Binding Title}"
 			TextTrimming="CharacterEllipsis" />
-	</DataTemplate>
+    </DataTemplate>
 
-	<DataTemplate x:Key="AvalonDockThemeVs2013DocumentTitleTemplate">
-		<TextBlock
+    <DataTemplate x:Key="AvalonDockThemeVs2013DocumentTitleTemplate">
+        <TextBlock
 			VerticalAlignment="Center"
 			Text="{Binding Title}"
 			TextTrimming="CharacterEllipsis" />
-	</DataTemplate>
+    </DataTemplate>
 
-	<DataTemplate x:Key="AvalonDockThemeVs2013AnchorableTitleTemplate">
-		<TextBlock
+    <DataTemplate x:Key="AvalonDockThemeVs2013AnchorableTitleTemplate">
+        <TextBlock
 			VerticalAlignment="Center"
 			Text="{Binding Title}"
 			TextTrimming="CharacterEllipsis" />
-	</DataTemplate>
+    </DataTemplate>
 
-	<DataTemplate x:Key="AvalonDockThemeVs2013IconContentTemplate">
-		<Image Source="{Binding IconSource, Converter={avalonDockConverters:NullToDoNothingConverter}}" Stretch="Uniform" />
-	</DataTemplate>
+    <DataTemplate x:Key="AvalonDockThemeVs2013IconContentTemplate">
+        <Image Source="{Binding IconSource, Converter={avalonDockConverters:NullToDoNothingConverter}}" Stretch="Uniform" />
+    </DataTemplate>
 
-	<ContextMenu x:Key="AvalonDockThemeVs2013AnchorableContextMenu">
-		<MenuItem Command="{Binding Path=FloatCommand}" Header="{x:Static avalonDockProperties:Resources.Anchorable_Float}" />
-		<MenuItem Command="{Binding Path=DockCommand}" Header="{x:Static avalonDockProperties:Resources.Anchorable_Dock}" />
-		<MenuItem Command="{Binding Path=DockAsDocumentCommand}" Header="{x:Static avalonDockProperties:Resources.Anchorable_DockAsDocument}" />
-		<MenuItem Command="{Binding Path=AutoHideCommand}" Header="{x:Static avalonDockProperties:Resources.Anchorable_AutoHide}" />
-		<MenuItem
+    <ContextMenu x:Key="AvalonDockThemeVs2013AnchorableContextMenu">
+        <MenuItem Command="{Binding Path=FloatCommand}" Header="{x:Static avalonDockProperties:Resources.Anchorable_Float}" />
+        <MenuItem Command="{Binding Path=DockCommand}" Header="{x:Static avalonDockProperties:Resources.Anchorable_Dock}" />
+        <MenuItem Command="{Binding Path=DockAsDocumentCommand}" Header="{x:Static avalonDockProperties:Resources.Anchorable_DockAsDocument}" />
+        <MenuItem Command="{Binding Path=AutoHideCommand}" Header="{x:Static avalonDockProperties:Resources.Anchorable_AutoHide}" />
+        <MenuItem
 			Command="{Binding Path=HideCommand}"
 			Header="{x:Static avalonDockProperties:Resources.Anchorable_Hide}"
 			Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}" />
-	</ContextMenu>
+    </ContextMenu>
 
-	<ContextMenu x:Key="AvalonDockThemeVs2013DocumentContextMenu">
-		<MenuItem
+    <ContextMenu x:Key="AvalonDockThemeVs2013DocumentContextMenu">
+        <MenuItem
 			Command="{Binding Path=CloseCommand}"
 			Header="{x:Static avalonDockProperties:Resources.Document_Close}"
 			Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}" />
-		<MenuItem Command="{Binding Path=CloseAllButThisCommand}" Header="{x:Static avalonDockProperties:Resources.Document_CloseAllButThis}" />
-		<MenuItem Command="{Binding Path=CloseAllCommand}" Header="{x:Static avalonDockProperties:Resources.Document_CloseAll}" />
-		<MenuItem Command="{Binding Path=FloatCommand}" Header="{x:Static avalonDockProperties:Resources.Document_Float}" />
-		<MenuItem Command="{Binding Path=DockAsDocumentCommand}" Header="{x:Static avalonDockProperties:Resources.Document_DockAsDocument}" />
-		<MenuItem
+        <MenuItem Command="{Binding Path=CloseAllButThisCommand}" Header="{x:Static avalonDockProperties:Resources.Document_CloseAllButThis}" />
+        <MenuItem Command="{Binding Path=CloseAllCommand}" Header="{x:Static avalonDockProperties:Resources.Document_CloseAll}" />
+        <MenuItem Command="{Binding Path=FloatCommand}" Header="{x:Static avalonDockProperties:Resources.Document_Float}" />
+        <MenuItem Command="{Binding Path=DockAsDocumentCommand}" Header="{x:Static avalonDockProperties:Resources.Document_DockAsDocument}" />
+        <MenuItem
 			Command="{Binding Path=NewHorizontalTabGroupCommand}"
 			Header="{x:Static avalonDockProperties:Resources.Document_NewHorizontalTabGroup}"
 			Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
-			<MenuItem.Icon>
-				<Path
+            <MenuItem.Icon>
+                <Path
 					Width="14"
 					Height="14"
 					VerticalAlignment="Center"
 					Data="{DynamicResource HTabGroup}"
 					Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveGlyph}}"
 					Stretch="Uniform" />
-			</MenuItem.Icon>
-		</MenuItem>
+            </MenuItem.Icon>
+        </MenuItem>
 
-		<MenuItem
+        <MenuItem
 			Command="{Binding Path=NewVerticalTabGroupCommand}"
 			Header="{x:Static avalonDockProperties:Resources.Document_NewVerticalTabGroup}"
 			Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
-			<MenuItem.Icon>
-				<Path
+            <MenuItem.Icon>
+                <Path
 					Width="14"
 					Height="14"
 					VerticalAlignment="Center"
 					Data="{DynamicResource VTabGroup}"
 					Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveGlyph}}"
 					Stretch="Uniform" />
-			</MenuItem.Icon>
-		</MenuItem>
-		<MenuItem
+            </MenuItem.Icon>
+        </MenuItem>
+        <MenuItem
 			Command="{Binding Path=MoveToNextTabGroupCommand}"
 			Header="{x:Static avalonDockProperties:Resources.Document_MoveToNextTabGroup}"
 			Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}" />
-		<MenuItem
+        <MenuItem
 			Command="{Binding Path=MoveToPreviousTabGroupCommand}"
 			Header="{x:Static avalonDockProperties:Resources.Document_MoveToPreviousTabGroup}"
 			Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}" />
-	</ContextMenu>
+    </ContextMenu>
 
-	<!--  DockingManager  -->
-	<Style x:Key="{x:Type avalonDock:DockingManager}" TargetType="{x:Type avalonDock:DockingManager}">
-		<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.Background}}" />
-		<Setter Property="DocumentPaneControlStyle" Value="{StaticResource AvalonDockThemeVs2013DocumentPaneControlStyle}" />
-		<Setter Property="AnchorablePaneControlStyle" Value="{StaticResource AvalonDockThemeVs2013AnchorablePaneControlStyle}" />
-		<Setter Property="AnchorSideTemplate" Value="{StaticResource AvalonDockThemeVs2013AnchorSideTemplate}" />
-		<Setter Property="AnchorGroupTemplate" Value="{StaticResource AvalonDockThemeVs2013AnchorGroupTemplate}" />
-		<Setter Property="AnchorTemplate" Value="{StaticResource AvalonDockThemeVs2013AnchorTemplate}" />
-		<Setter Property="DocumentHeaderTemplate" Value="{StaticResource AvalonDockThemeVs2013DocumentHeaderTemplate}" />
-		<Setter Property="AnchorableHeaderTemplate" Value="{StaticResource AvalonDockThemeVs2013AnchorableHeaderTemplate}" />
-		<Setter Property="DocumentTitleTemplate" Value="{StaticResource AvalonDockThemeVs2013DocumentTitleTemplate}" />
-		<Setter Property="AnchorableTitleTemplate" Value="{StaticResource AvalonDockThemeVs2013AnchorableTitleTemplate}" />
-		<Setter Property="AnchorableContextMenu" Value="{StaticResource AvalonDockThemeVs2013AnchorableContextMenu}" />
-		<Setter Property="DocumentContextMenu" Value="{StaticResource AvalonDockThemeVs2013DocumentContextMenu}" />
-		<Setter Property="DocumentPaneMenuItemHeaderTemplate" Value="{StaticResource AvalonDockThemeVs2013DocumentHeaderTemplate}" />
-		<Setter Property="IconContentTemplate" Value="{StaticResource AvalonDockThemeVs2013IconContentTemplate}" />
-		<Setter Property="GridSplitterWidth" Value="6" />
-		<Setter Property="GridSplitterHeight" Value="6" />
-	</Style>
+    <!--  DockingManager  -->
+    <Style x:Key="{x:Type avalonDock:DockingManager}" TargetType="{x:Type avalonDock:DockingManager}">
+        <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.Background}}" />
+        <Setter Property="DocumentPaneControlStyle" Value="{StaticResource AvalonDockThemeVs2013DocumentPaneControlStyle}" />
+        <Setter Property="AnchorablePaneControlStyle" Value="{StaticResource AvalonDockThemeVs2013AnchorablePaneControlStyle}" />
+        <Setter Property="AnchorSideTemplate" Value="{StaticResource AvalonDockThemeVs2013AnchorSideTemplate}" />
+        <Setter Property="AnchorGroupTemplate" Value="{StaticResource AvalonDockThemeVs2013AnchorGroupTemplate}" />
+        <Setter Property="AnchorTemplate" Value="{StaticResource AvalonDockThemeVs2013AnchorTemplate}" />
+        <Setter Property="DocumentHeaderTemplate" Value="{StaticResource AvalonDockThemeVs2013DocumentHeaderTemplate}" />
+        <Setter Property="AnchorableHeaderTemplate" Value="{StaticResource AvalonDockThemeVs2013AnchorableHeaderTemplate}" />
+        <Setter Property="DocumentTitleTemplate" Value="{StaticResource AvalonDockThemeVs2013DocumentTitleTemplate}" />
+        <Setter Property="AnchorableTitleTemplate" Value="{StaticResource AvalonDockThemeVs2013AnchorableTitleTemplate}" />
+        <Setter Property="AnchorableContextMenu" Value="{StaticResource AvalonDockThemeVs2013AnchorableContextMenu}" />
+        <Setter Property="DocumentContextMenu" Value="{StaticResource AvalonDockThemeVs2013DocumentContextMenu}" />
+        <Setter Property="DocumentPaneMenuItemHeaderTemplate" Value="{StaticResource AvalonDockThemeVs2013DocumentHeaderTemplate}" />
+        <Setter Property="IconContentTemplate" Value="{StaticResource AvalonDockThemeVs2013IconContentTemplate}" />
+        <Setter Property="GridSplitterWidth" Value="6" />
+        <Setter Property="GridSplitterHeight" Value="6" />
+    </Style>
 
-	<!--  LayoutGridResizerControl  -->
-	<Style x:Key="{x:Type avalonDockControls:LayoutGridResizerControl}" TargetType="{x:Type avalonDockControls:LayoutGridResizerControl}">
-		<Setter Property="Background" Value="Transparent" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type avalonDockControls:LayoutGridResizerControl}">
-					<Border Background="Transparent" />
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+    <!--  LayoutGridResizerControl  -->
+    <Style x:Key="{x:Type avalonDockControls:LayoutGridResizerControl}" TargetType="{x:Type avalonDockControls:LayoutGridResizerControl}">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutGridResizerControl}">
+                    <Border Background="Transparent" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-	<Style TargetType="{x:Type avalonDockControls:LayoutDocumentControl}">
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type avalonDockControls:LayoutDocumentControl}">
-					<Border
+    <Style TargetType="{x:Type avalonDockControls:LayoutDocumentControl}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutDocumentControl}">
+                    <Border
 						Background="{TemplateBinding Background}"
 						BorderBrush="{TemplateBinding BorderBrush}"
 						BorderThickness="{TemplateBinding BorderThickness}">
-						<ContentPresenter Content="{Binding LayoutItem.View, RelativeSource={RelativeSource TemplatedParent}}" />
-					</Border>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                        <ContentPresenter Content="{Binding LayoutItem.View, RelativeSource={RelativeSource TemplatedParent}}" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-	<Style TargetType="{x:Type avalonDockControls:LayoutDocumentTabItem}">
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type avalonDockControls:LayoutDocumentTabItem}">
-					<avalonDockControls:DropDownControlArea
+    <Style TargetType="{x:Type avalonDockControls:LayoutDocumentTabItem}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutDocumentTabItem}">
+                    <avalonDockControls:DropDownControlArea
 						DropDownContextMenu="{Binding Root.Manager.DocumentContextMenu}"
 						DropDownContextMenuDataContext="{Binding LayoutItem, RelativeSource={RelativeSource TemplatedParent}}"
 						Style="{DynamicResource DropDownControlArea}">
-						<Border
+                        <Border
 							Margin="0,3,0,3"
 							Background="{TemplateBinding Background}"
 							BorderBrush="{TemplateBinding BorderBrush}"
 							BorderThickness="{TemplateBinding BorderThickness}">
-							<Grid>
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="*" />
-									<ColumnDefinition Width="Auto" />
-								</Grid.ColumnDefinitions>
-								<Border Grid.ColumnSpan="2" Background="Transparent" />
-								<ContentPresenter
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Border Grid.ColumnSpan="2" Background="Transparent" />
+                                <ContentPresenter
 									Margin="4,0"
 									Content="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}"
 									ContentTemplate="{Binding DocumentHeaderTemplate, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}"
 									ContentTemplateSelector="{Binding DocumentHeaderTemplateSelector, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}"
 									TextBlock.Foreground="{Binding Foreground, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=TabItem}}" />
-								<!--  Close button should be moved out to the container style  -->
-								<Button
+                                <!--  Close button should be moved out to the container style  -->
+                                <Button
 									x:Name="DocumentCloseButton"
 									Grid.Column="1"
 									Width="15"
@@ -1384,7 +1389,7 @@
 									Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
 									ToolTip="{x:Static avalonDockProperties:Resources.Document_Close}"
 									Visibility="Hidden">
-									<Path
+                                    <Path
 										x:Name="PART_ImgPinClose"
 										Width="10"
 										Height="10"
@@ -1392,268 +1397,268 @@
 										Data="{DynamicResource PinClose}"
 										Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveText}}"
 										Stretch="Uniform" />
-								</Button>
-							</Grid>
-						</Border>
-					</avalonDockControls:DropDownControlArea>
-					<ControlTemplate.Triggers>
-						<!--  Close button visibility  -->
-						<DataTrigger Binding="{Binding Path=IsSelected}" Value="true">
-							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
-						</DataTrigger>
-						<Trigger Property="IsMouseOver" Value="True">
-							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
-						</Trigger>
-						<DataTrigger Binding="{Binding Path=IsLastFocusedDocument}" Value="true">
-							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
-						</DataTrigger>
-						<DataTrigger Binding="{Binding Path=IsActive}" Value="true">
-							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
-						</DataTrigger>
-						<DataTrigger Binding="{Binding Path=CanClose}" Value="false">
-							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Collapsed" />
-						</DataTrigger>
+                                </Button>
+                            </Grid>
+                        </Border>
+                    </avalonDockControls:DropDownControlArea>
+                    <ControlTemplate.Triggers>
+                        <!--  Close button visibility  -->
+                        <DataTrigger Binding="{Binding Path=IsSelected}" Value="true">
+                            <Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
+                        </DataTrigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                        <DataTrigger Binding="{Binding Path=IsLastFocusedDocument}" Value="true">
+                            <Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Path=IsActive}" Value="true">
+                            <Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Path=CanClose}" Value="false">
+                            <Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Collapsed" />
+                        </DataTrigger>
 
-						<!--  Document Well : Tab : Button / Selected, inactive  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsLastFocusedDocument}" Value="true" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonForegroundArrowBrushKey}}" />
-						</MultiDataTrigger>
+                        <!--  Document Well : Tab : Button / Selected, inactive  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsLastFocusedDocument}" Value="true" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonForegroundArrowBrushKey}}" />
+                        </MultiDataTrigger>
 
-						<!--  Document Well : Tab : Button / Selected, inactive, hovered  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsLastFocusedDocument}" Value="true" />
-								<Condition Binding="{Binding IsMouseOver, ElementName=DocumentCloseButton}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
-							<Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonForegroundArrowBrushKey}}" />
-						</MultiDataTrigger>
+                        <!--  Document Well : Tab : Button / Selected, inactive, hovered  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsLastFocusedDocument}" Value="true" />
+                                <Condition Binding="{Binding IsMouseOver, ElementName=DocumentCloseButton}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
+                            <Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonForegroundArrowBrushKey}}" />
+                        </MultiDataTrigger>
 
-						<!--  Document Well : Tab : Button / Selected, inactive, pressed  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsLastFocusedDocument}" Value="true" />
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=DocumentCloseButton}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
-							<Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Document Well : Tab : Button / Selected, inactive, pressed  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsLastFocusedDocument}" Value="true" />
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=DocumentCloseButton}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
+                            <Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Document Well : Tab : Button / Selected, active  -->
-						<DataTrigger Binding="{Binding IsActive}" Value="true">
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonForegroundArrowBrushKey}}" />
-						</DataTrigger>
+                        <!--  Document Well : Tab : Button / Selected, active  -->
+                        <DataTrigger Binding="{Binding IsActive}" Value="true">
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonForegroundArrowBrushKey}}" />
+                        </DataTrigger>
 
-						<!--  Document Well : Tab : Button / Selected, active, hovered  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsActive}" Value="true" />
-								<Condition Binding="{Binding IsMouseOver, ElementName=DocumentCloseButton}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
-							<Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Document Well : Tab : Button / Selected, active, hovered  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsMouseOver, ElementName=DocumentCloseButton}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
+                            <Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Document Well : Tab : Button / Selected, active, pressed  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsActive}" Value="true" />
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=DocumentCloseButton}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
-							<Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Document Well : Tab : Button / Selected, active, pressed  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=DocumentCloseButton}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
+                            <Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Document Well : Tab : Button / Unselected, tab hovered  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsActive}" Value="False" />
-								<Condition Binding="{Binding IsLastFocusedDocument}" Value="False" />
-								<Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource TemplatedParent}}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Document Well : Tab : Button / Unselected, tab hovered  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsActive}" Value="False" />
+                                <Condition Binding="{Binding IsLastFocusedDocument}" Value="False" />
+                                <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource TemplatedParent}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Document Well : Tab : Button / Unselected, tab hovered, button hovered  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsActive}" Value="False" />
-								<Condition Binding="{Binding IsLastFocusedDocument}" Value="False" />
-								<Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource TemplatedParent}}" Value="True" />
-								<Condition Binding="{Binding IsMouseOver, ElementName=DocumentCloseButton}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonHoveredBackground}}" />
-							<Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonHoveredGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Document Well : Tab : Button / Unselected, tab hovered, button hovered  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsActive}" Value="False" />
+                                <Condition Binding="{Binding IsLastFocusedDocument}" Value="False" />
+                                <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource TemplatedParent}}" Value="True" />
+                                <Condition Binding="{Binding IsMouseOver, ElementName=DocumentCloseButton}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonHoveredBackground}}" />
+                            <Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonHoveredGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Document Well : Tab : Button / Unselected, tab hovered, button pressed  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsActive}" Value="False" />
-								<Condition Binding="{Binding IsLastFocusedDocument}" Value="False" />
-								<Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource TemplatedParent}}" Value="True" />
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=DocumentCloseButton}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonPressedBackground}}" />
-							<Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonPressedBorder}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonPressedGlyph}}" />
-						</MultiDataTrigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                        <!--  Document Well : Tab : Button / Unselected, tab hovered, button pressed  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsActive}" Value="False" />
+                                <Condition Binding="{Binding IsLastFocusedDocument}" Value="False" />
+                                <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource TemplatedParent}}" Value="True" />
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=DocumentCloseButton}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonPressedBackground}}" />
+                            <Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonPressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonPressedGlyph}}" />
+                        </MultiDataTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-	<Style TargetType="{x:Type avalonDockControls:LayoutAnchorableTabItem}">
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type avalonDockControls:LayoutAnchorableTabItem}">
-					<avalonDockControls:DropDownControlArea
+    <Style TargetType="{x:Type avalonDockControls:LayoutAnchorableTabItem}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutAnchorableTabItem}">
+                    <avalonDockControls:DropDownControlArea
 						DropDownContextMenu="{Binding Root.Manager.AnchorableContextMenu}"
 						DropDownContextMenuDataContext="{Binding LayoutItem, RelativeSource={RelativeSource TemplatedParent}}"
 						Style="{DynamicResource DropDownControlArea}">
-						<Border
+                        <Border
 							Background="{TemplateBinding Background}"
 							BorderBrush="{TemplateBinding BorderBrush}"
 							BorderThickness="{TemplateBinding BorderThickness}">
-							<Grid>
-								<ContentPresenter
+                            <Grid>
+                                <ContentPresenter
 									Content="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}"
 									ContentTemplate="{Binding AnchorableHeaderTemplate, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}"
 									ContentTemplateSelector="{Binding AnchorableHeaderTemplateSelector, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}" />
-								<avalonDockControls:DropDownControlArea
+                                <avalonDockControls:DropDownControlArea
 									Grid.Column="0"
 									DropDownContextMenu="{Binding Model.Root.Manager.AnchorableContextMenu, RelativeSource={RelativeSource TemplatedParent}}"
 									DropDownContextMenuDataContext="{Binding Path=Model, RelativeSource={RelativeSource TemplatedParent}}" />
-							</Grid>
-						</Border>
-					</avalonDockControls:DropDownControlArea>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                            </Grid>
+                        </Border>
+                    </avalonDockControls:DropDownControlArea>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-	<Style TargetType="{x:Type avalonDockControls:LayoutAnchorableControl}">
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type avalonDockControls:LayoutAnchorableControl}">
-					<Border
+    <Style TargetType="{x:Type avalonDockControls:LayoutAnchorableControl}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutAnchorableControl}">
+                    <Border
 						x:Name="Bd"
 						Background="{TemplateBinding Background}"
 						BorderBrush="{TemplateBinding BorderBrush}"
 						BorderThickness="{TemplateBinding BorderThickness}">
-						<Grid>
-							<Grid.RowDefinitions>
-								<RowDefinition Height="Auto" />
-								<RowDefinition Height="*" />
-							</Grid.RowDefinitions>
-							<Border x:Name="Header">
-								<avalonDockControls:AnchorablePaneTitle Model="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}" />
-							</Border>
-							<!--
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <Border x:Name="Header">
+                                <avalonDockControls:AnchorablePaneTitle Model="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}" />
+                            </Border>
+                            <!--
 								Added ContentTemplate and ContentTemplateSelector
 								https://github.com/xceedsoftware/wpftoolkit/issues/1525
 							-->
-							<ContentPresenter
+                            <ContentPresenter
 								Grid.Row="1"
 								Content="{Binding LayoutItem.View, RelativeSource={RelativeSource TemplatedParent}}"
 								ContentTemplate="{Binding LayoutItem.View.ContentTemplate, RelativeSource={RelativeSource TemplatedParent}}"
 								ContentTemplateSelector="{Binding LayoutItem.View.ContentTemplateSelector, RelativeSource={RelativeSource TemplatedParent}}"
 								FlowDirection="{TemplateBinding FlowDirection}" />
 
-							<!--
+                            <!--
                                 <ContentPresenter
                                 Content="{Binding Model.Content, RelativeSource={RelativeSource TemplatedParent}}"
                                 ContentTemplate="{Binding LayoutItemTemplate, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}"
                                 ContentTemplateSelector="{Binding LayoutItemTemplateSelector, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}"
                                 Grid.Row="1"/>
 							-->
-						</Grid>
-					</Border>
-					<ControlTemplate.Triggers>
-						<!--
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <!--
 							Hide the title if the control is directly hosted in floating window
 							The floating window control will show the title if there is only one control to host
 							without any other LayoutAnchorableControl
 						-->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.IsFloating}" Value="True" />
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.Parent.IsDirectlyHostedInFloatingWindow}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="Header" Property="Visibility" Value="Collapsed" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<!--
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.IsFloating}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.Parent.IsDirectlyHostedInFloatingWindow}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Header" Property="Visibility" Value="Collapsed" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <!--
 								Also hide the title, if model cannot be bound which can happen when using virtualization
 								See Issue #148 Drop Down Menu for LayoutAnchorables is not correct with Virtualization
 							-->
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model}" Value="{x:Null}" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="Header" Property="Visibility" Value="Collapsed" />
-						</MultiDataTrigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model}" Value="{x:Null}" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Header" Property="Visibility" Value="Collapsed" />
+                        </MultiDataTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-	<Style x:Key="{x:Type avalonDockControls:LayoutDocumentFloatingWindowControl}" TargetType="{x:Type avalonDockControls:LayoutDocumentFloatingWindowControl}">
-		<Setter Property="UseLayoutRounding" Value="True" />
-		<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.FloatingDocumentWindowBackground}}" />
-		<Setter Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.FloatingDocumentWindowBorder}}" />
-		<Setter Property="shell:WindowChrome.WindowChrome">
-			<Setter.Value>
-				<shell:WindowChrome
+    <Style x:Key="{x:Type avalonDockControls:LayoutDocumentFloatingWindowControl}" TargetType="{x:Type avalonDockControls:LayoutDocumentFloatingWindowControl}">
+        <Setter Property="UseLayoutRounding" Value="True" />
+        <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.FloatingDocumentWindowBackground}}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.FloatingDocumentWindowBorder}}" />
+        <Setter Property="shell:WindowChrome.WindowChrome">
+            <Setter.Value>
+                <shell:WindowChrome
 					CaptionHeight="24"
 					CornerRadius="0"
 					GlassFrameThickness="0"
 					ResizeBorderThickness="10"
 					ShowSystemMenu="False" />
-			</Setter.Value>
-		</Setter>
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type avalonDockControls:LayoutDocumentFloatingWindowControl}">
-					<Grid>
-						<Border
+            </Setter.Value>
+        </Setter>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutDocumentFloatingWindowControl}">
+                    <Grid>
+                        <Border
 							x:Name="WindowBorder"
 							Background="{TemplateBinding Background}"
 							BorderBrush="{TemplateBinding BorderBrush}"
 							BorderThickness="1">
-							<Grid>
-								<Grid.RowDefinitions>
-									<RowDefinition Height="Auto" MinHeight="24" />
-									<!--  https://github.com/xceedsoftware/wpftoolkit/issues/1203  -->
-									<RowDefinition Height="*" />
-								</Grid.RowDefinitions>
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" MinHeight="24" />
+                                    <!--  https://github.com/xceedsoftware/wpftoolkit/issues/1203  -->
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
 
-								<Border
+                                <Border
 									x:Name="Header"
 									Padding="2,0,2,0"
 									Background="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedInactiveBackground}}"
 									TextElement.Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedInactiveText}}">
-									<Grid UseLayoutRounding="True">
-										<Grid.ColumnDefinitions>
-											<ColumnDefinition Width="*" />
-											<ColumnDefinition Width="Auto" />
-											<ColumnDefinition Width="Auto" />
-										</Grid.ColumnDefinitions>
-										<ContentPresenter
+                                    <Grid UseLayoutRounding="True">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <ContentPresenter
 											Content="{Binding Model.SinglePane.SelectedContent, RelativeSource={RelativeSource TemplatedParent}}"
 											ContentTemplate="{Binding Model.Root.Manager.DocumentTitleTemplate, RelativeSource={RelativeSource TemplatedParent}}"
 											ContentTemplateSelector="{Binding Model.Root.Manager.DocumentTitleTemplateSelector, RelativeSource={RelativeSource TemplatedParent}}" />
 
-										<Button
+                                        <Button
 											x:Name="PART_PinMaximize"
 											Grid.Column="1"
 											Margin="5,0"
@@ -1666,7 +1671,7 @@
 											Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
 											ToolTip="{x:Static avalonDockProperties:Resources.Window_Maximize}"
 											Visibility="{Binding IsMaximized, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:InverseBoolToVisibilityConverter}}">
-											<Path
+                                            <Path
 												x:Name="PART_ImgPinMaximize"
 												Width="12"
 												Height="12"
@@ -1674,9 +1679,9 @@
 												Data="{DynamicResource PinMaximize}"
 												Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
 												Stretch="Uniform" />
-										</Button>
+                                        </Button>
 
-										<Button
+                                        <Button
 											x:Name="PART_PinRestore"
 											Grid.Column="1"
 											Margin="5,0"
@@ -1689,7 +1694,7 @@
 											Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
 											ToolTip="{x:Static avalonDockProperties:Resources.Window_Restore}"
 											Visibility="{Binding IsMaximized, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
-											<Path
+                                            <Path
 												x:Name="PART_ImgPinRestore"
 												Width="13"
 												Height="13"
@@ -1697,9 +1702,9 @@
 												Data="{DynamicResource PinRestore}"
 												Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
 												Stretch="Uniform" />
-										</Button>
+                                        </Button>
 
-										<Button
+                                        <Button
 											x:Name="PART_PinClose"
 											Grid.Column="2"
 											HorizontalAlignment="Center"
@@ -1710,7 +1715,7 @@
 											Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
 											ToolTip="{x:Static avalonDockProperties:Resources.Document_Close}"
 											Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
-											<Path
+                                            <Path
 												x:Name="PART_ImgPinClose"
 												Width="12"
 												Height="12"
@@ -1718,211 +1723,211 @@
 												Data="{DynamicResource PinClose}"
 												Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
 												Stretch="Uniform" />
-										</Button>
-									</Grid>
-								</Border>
-								<ContentPresenter Grid.Row="1" Content="{TemplateBinding Content}" />
-							</Grid>
-						</Border>
-					</Grid>
-					<ControlTemplate.Triggers>
-						<!--  Show Header Bar (Window Title and Restore/Maximize/Minimize buttons with highlighting color if this IsActive)  -->
-						<Trigger Property="WindowState" Value="Maximized">
-							<Setter TargetName="WindowBorder" Property="Padding" Value="3" />
-						</Trigger>
-						<DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="True">
-							<Setter TargetName="Header" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedActiveBackground}}" />
-							<Setter TargetName="Header" Property="TextElement.Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedActiveText}}" />
-						</DataTrigger>
+                                        </Button>
+                                    </Grid>
+                                </Border>
+                                <ContentPresenter Grid.Row="1" Content="{TemplateBinding Content}" />
+                            </Grid>
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <!--  Show Header Bar (Window Title and Restore/Maximize/Minimize buttons with highlighting color if this IsActive)  -->
+                        <Trigger Property="WindowState" Value="Maximized">
+                            <Setter TargetName="WindowBorder" Property="Padding" Value="3" />
+                        </Trigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="True">
+                            <Setter TargetName="Header" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedActiveBackground}}" />
+                            <Setter TargetName="Header" Property="TextElement.Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedActiveText}}" />
+                        </DataTrigger>
 
-						<!--  Document Well : Tab : Button / Selected, inactive, hovered  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_PinMaximize}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
-							<Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_PinRestore}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
-							<Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_PinClose}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinClose" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
-							<Setter TargetName="PART_PinClose" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Document Well : Tab : Button / Selected, inactive, hovered  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_PinMaximize}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
+                            <Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_PinRestore}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
+                            <Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_PinClose}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinClose" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
+                            <Setter TargetName="PART_PinClose" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Document Well : Tab : Button / Selected, inactive, pressed  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinMaximize}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
-							<Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinRestore}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
-							<Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinClose}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinClose" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
-							<Setter TargetName="PART_PinClose" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Document Well : Tab : Button / Selected, inactive, pressed  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinMaximize}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
+                            <Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinRestore}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
+                            <Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinClose}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinClose" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
+                            <Setter TargetName="PART_PinClose" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Mark Active Document on CLick in Document Well : Tab : Button / Selected, active  -->
-						<DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="true">
-							<!--  Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" /  -->
-							<Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
-							<Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
-						</DataTrigger>
+                        <!--  Mark Active Document on CLick in Document Well : Tab : Button / Selected, active  -->
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="true">
+                            <!--  Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" /  -->
+                            <Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
+                            <Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
+                        </DataTrigger>
 
-						<!--  Document Well : Tab : Button / Selected, active, hovered  -->
-						<!--  Highlight Maximize Button of Floating Window on MouseOver  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="true" />
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_PinMaximize}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
-							<Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Document Well : Tab : Button / Selected, active, hovered  -->
+                        <!--  Highlight Maximize Button of Floating Window on MouseOver  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_PinMaximize}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
+                            <Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Highlight Restore Button of Floating Window on MouseOver  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="true" />
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_PinRestore}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
-							<Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Highlight Restore Button of Floating Window on MouseOver  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_PinRestore}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
+                            <Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Highlight Close Button of Floating Window on MouseOver  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="true" />
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_PinClose}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinClose" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
-							<Setter TargetName="PART_PinClose" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Highlight Close Button of Floating Window on MouseOver  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_PinClose}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinClose" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
+                            <Setter TargetName="PART_PinClose" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Document Well : Tab : Button / Selected, active, pressed  -->
-						<!--  Highlight Maximize Button of Floating Window on MouseClick and Holding Bottun (even when Mouse is moved away)  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="true" />
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinMaximize}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
-							<Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Document Well : Tab : Button / Selected, active, pressed  -->
+                        <!--  Highlight Maximize Button of Floating Window on MouseClick and Holding Bottun (even when Mouse is moved away)  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinMaximize}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
+                            <Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Highlight Restore Button of Floating Window on MouseClick and Holding Bottun (even when Mouse is moved away)  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="true" />
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinRestore}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
-							<Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Highlight Restore Button of Floating Window on MouseClick and Holding Bottun (even when Mouse is moved away)  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinRestore}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
+                            <Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Highlight Close Button of Floating Window on MouseClick and Holding Bottun (even when Mouse is moved away)  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="true" />
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinClose}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinClose" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
-							<Setter TargetName="PART_PinClose" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
-						</MultiDataTrigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
+                        <!--  Highlight Close Button of Floating Window on MouseClick and Holding Bottun (even when Mouse is moved away)  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinClose}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinClose" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
+                            <Setter TargetName="PART_PinClose" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
+                        </MultiDataTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
 
-			</Setter.Value>
-		</Setter>
-	</Style>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-	<Style x:Key="{x:Type avalonDockControls:LayoutAnchorableFloatingWindowControl}" TargetType="{x:Type avalonDockControls:LayoutAnchorableFloatingWindowControl}">
-		<Setter Property="UseLayoutRounding" Value="True" />
-		<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.FloatingToolWindowBackground}}" />
-		<Setter Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.FloatingToolWindowBorder}}" />
-		<Setter Property="shell:WindowChrome.WindowChrome">
-			<Setter.Value>
-				<shell:WindowChrome
+    <Style x:Key="{x:Type avalonDockControls:LayoutAnchorableFloatingWindowControl}" TargetType="{x:Type avalonDockControls:LayoutAnchorableFloatingWindowControl}">
+        <Setter Property="UseLayoutRounding" Value="True" />
+        <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.FloatingToolWindowBackground}}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.FloatingToolWindowBorder}}" />
+        <Setter Property="shell:WindowChrome.WindowChrome">
+            <Setter.Value>
+                <shell:WindowChrome
 					CaptionHeight="24"
 					CornerRadius="0"
 					GlassFrameThickness="0"
 					ResizeBorderThickness="10" />
-			</Setter.Value>
-		</Setter>
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type avalonDockControls:LayoutAnchorableFloatingWindowControl}">
-					<Grid>
-						<Border
+            </Setter.Value>
+        </Setter>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutAnchorableFloatingWindowControl}">
+                    <Grid>
+                        <Border
 							x:Name="WindowBorder"
 							Background="{TemplateBinding Background}"
 							BorderBrush="{TemplateBinding BorderBrush}"
 							BorderThickness="1">
-							<Grid>
-								<Grid.RowDefinitions>
-									<RowDefinition Height="Auto" MinHeight="24" />
-									<!--  https://github.com/xceedsoftware/wpftoolkit/issues/1203  -->
-									<RowDefinition Height="*" />
-								</Grid.RowDefinitions>
-								<Border
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" MinHeight="24" />
+                                    <!--  https://github.com/xceedsoftware/wpftoolkit/issues/1203  -->
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+                                <Border
 									x:Name="Header"
 									Padding="2,0,2,0"
 									Background="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveBackground}}"
 									TextElement.Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveText}}">
-									<Grid UseLayoutRounding="True">
-										<Grid.ColumnDefinitions>
-											<ColumnDefinition Width="*" />
-											<ColumnDefinition Width="Auto" />
-											<ColumnDefinition Width="Auto" />
-											<ColumnDefinition Width="Auto" />
-										</Grid.ColumnDefinitions>
+                                    <Grid UseLayoutRounding="True">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
 
-										<Border Visibility="{Binding Path=Model.IsSinglePane, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
-											<avalonDockControls:DropDownControlArea
+                                        <Border Visibility="{Binding Path=Model.IsSinglePane, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
+                                            <avalonDockControls:DropDownControlArea
 												DropDownContextMenu="{Binding Model.Root.Manager.AnchorableContextMenu, RelativeSource={RelativeSource TemplatedParent}}"
 												DropDownContextMenuDataContext="{Binding Path=SingleContentLayoutItem, RelativeSource={RelativeSource TemplatedParent}}"
 												Style="{DynamicResource DropDownControlArea}">
-												<ContentPresenter
+                                                <ContentPresenter
 													Content="{Binding Model.SinglePane.SelectedContent, RelativeSource={RelativeSource TemplatedParent}}"
 													ContentTemplate="{Binding Model.Root.Manager.AnchorableTitleTemplate, RelativeSource={RelativeSource TemplatedParent}}"
 													ContentTemplateSelector="{Binding Model.Root.Manager.AnchorableTitleTemplateSelector, RelativeSource={RelativeSource TemplatedParent}}" />
-											</avalonDockControls:DropDownControlArea>
-										</Border>
+                                            </avalonDockControls:DropDownControlArea>
+                                        </Border>
 
-										<avalonDockControls:DropDownButton
+                                        <avalonDockControls:DropDownButton
 											x:Name="SinglePaneContextMenu"
 											Grid.Column="1"
 											Margin="2,0"
@@ -1937,16 +1942,16 @@
 											Style="{StaticResource AvalonDockThemeVs2013ToolButtonStyle}"
 											ToolTip="{x:Static avalonDockProperties:Resources.Anchorable_CxMenu_Hint}"
 											Visibility="{Binding Path=Model.IsSinglePane, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
-											<Path
+                                            <Path
 												x:Name="PART_ImgPinMenu"
 												Width="11"
 												Height="11"
 												Data="{DynamicResource PinMenu}"
 												Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
 												Stretch="Uniform" />
-										</avalonDockControls:DropDownButton>
+                                        </avalonDockControls:DropDownButton>
 
-										<Button
+                                        <Button
 											x:Name="PART_PinMaximize"
 											Grid.Column="2"
 											Margin="2,0"
@@ -1961,7 +1966,7 @@
 											Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
 											ToolTip="{x:Static avalonDockProperties:Resources.Window_Maximize}"
 											Visibility="{Binding IsMaximized, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:InverseBoolToVisibilityConverter}}">
-											<Path
+                                            <Path
 												x:Name="PART_ImgPinMaximize"
 												Width="11"
 												Height="11"
@@ -1969,9 +1974,9 @@
 												Data="{DynamicResource PinMaximize}"
 												Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
 												Stretch="Uniform" />
-										</Button>
+                                        </Button>
 
-										<Button
+                                        <Button
 											x:Name="PART_PinRestore"
 											Grid.Column="2"
 											Margin="2,0"
@@ -1984,7 +1989,7 @@
 											Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
 											ToolTip="{x:Static avalonDockProperties:Resources.Window_Restore}"
 											Visibility="{Binding IsMaximized, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
-											<Path
+                                            <Path
 												x:Name="PART_ImgPinRestore"
 												Width="11"
 												Height="11"
@@ -1992,9 +1997,9 @@
 												Data="{DynamicResource PinRestore}"
 												Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
 												Stretch="Uniform" />
-										</Button>
+                                        </Button>
 
-										<Button
+                                        <Button
 											x:Name="PART_PinClose"
 											Grid.Column="3"
 											Margin="2,0"
@@ -2006,7 +2011,7 @@
 											Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
 											ToolTip="{x:Static avalonDockProperties:Resources.Anchorable_BtnClose_Hint}"
 											Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
-											<Path
+                                            <Path
 												x:Name="PART_ImgPinClose"
 												Width="11"
 												Height="11"
@@ -2014,274 +2019,277 @@
 												Data="{DynamicResource PinClose}"
 												Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
 												Stretch="Uniform" />
-										</Button>
-									</Grid>
-								</Border>
-								<ContentPresenter Grid.Row="1" Content="{TemplateBinding Content}" />
-							</Grid>
-						</Border>
-					</Grid>
-					<ControlTemplate.Triggers>
-						<Trigger Property="WindowState" Value="Maximized">
-							<Setter TargetName="WindowBorder" Property="Padding" Value="3" />
-						</Trigger>
-						<DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="True">
-							<Setter TargetName="Header" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveBackground}}" />
-							<Setter TargetName="Header" Property="TextElement.Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveText}}" />
-						</DataTrigger>
+                                        </Button>
+                                    </Grid>
+                                </Border>
+                                <ContentPresenter Grid.Row="1" Content="{TemplateBinding Content}" />
+                            </Grid>
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="WindowState" Value="Maximized">
+                            <Setter TargetName="WindowBorder" Property="Padding" Value="3" />
+                        </Trigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="True">
+                            <Setter TargetName="Header" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveBackground}}" />
+                            <Setter TargetName="Header" Property="TextElement.Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveText}}" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Model.SinglePane.SelectedContent.CanClose, RelativeSource={RelativeSource Mode=Self}}" Value="True">
+                            <Setter TargetName="PART_PinClose" Property="Command" Value="{Binding CloseWindowCommand, RelativeSource={RelativeSource TemplatedParent}}" />
+                            <Setter TargetName="PART_PinClose" Property="ToolTip" Value="{x:Static avalonDockProperties:Resources.Document_Close}" />
+                        </DataTrigger>
+                        <!--  Document Well : Tab : Button / Selected, inactive, hovered  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseOver, ElementName=SinglePaneContextMenu}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="SinglePaneContextMenu" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
+                            <Setter TargetName="SinglePaneContextMenu" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_PinMaximize}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
+                            <Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_PinRestore}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
+                            <Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_PinClose}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinClose" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
+                            <Setter TargetName="PART_PinClose" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Document Well : Tab : Button / Selected, inactive, hovered  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseOver, ElementName=SinglePaneContextMenu}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="SinglePaneContextMenu" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
-							<Setter TargetName="SinglePaneContextMenu" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_PinMaximize}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
-							<Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_PinRestore}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
-							<Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_PinClose}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinClose" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
-							<Setter TargetName="PART_PinClose" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Document Well : Tab : Button / Selected, inactive, pressed  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=SinglePaneContextMenu}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="SinglePaneContextMenu" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
+                            <Setter TargetName="SinglePaneContextMenu" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsChecked, ElementName=SinglePaneContextMenu}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="SinglePaneContextMenu" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
+                            <Setter TargetName="SinglePaneContextMenu" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinMaximize}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
+                            <Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinRestore}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
+                            <Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinClose}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinClose" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
+                            <Setter TargetName="PART_PinClose" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Document Well : Tab : Button / Selected, inactive, pressed  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=SinglePaneContextMenu}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="SinglePaneContextMenu" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
-							<Setter TargetName="SinglePaneContextMenu" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsChecked, ElementName=SinglePaneContextMenu}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="SinglePaneContextMenu" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
-							<Setter TargetName="SinglePaneContextMenu" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinMaximize}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
-							<Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinRestore}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
-							<Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinClose}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinClose" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
-							<Setter TargetName="PART_PinClose" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Document Well : Tab : Button / Selected, active  -->
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true">
+                            <Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
+                            <Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
+                            <Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
+                        </DataTrigger>
 
-						<!--  Document Well : Tab : Button / Selected, active  -->
-						<DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true">
-							<Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
-							<Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
-							<Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
-						</DataTrigger>
+                        <!--  Document Well : Tab : Button / Selected, active, hovered  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsMouseOver, ElementName=SinglePaneContextMenu}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="SinglePaneContextMenu" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
+                            <Setter TargetName="SinglePaneContextMenu" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_PinMaximize}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
+                            <Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_PinRestore}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
+                            <Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_PinClose}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinClose" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
+                            <Setter TargetName="PART_PinClose" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Document Well : Tab : Button / Selected, active, hovered  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
-								<Condition Binding="{Binding IsMouseOver, ElementName=SinglePaneContextMenu}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="SinglePaneContextMenu" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
-							<Setter TargetName="SinglePaneContextMenu" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_PinMaximize}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
-							<Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_PinRestore}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
-							<Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_PinClose}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinClose" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
-							<Setter TargetName="PART_PinClose" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Document Well : Tab : Button / Selected, active, pressed  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=SinglePaneContextMenu}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="SinglePaneContextMenu" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
+                            <Setter TargetName="SinglePaneContextMenu" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsChecked, ElementName=SinglePaneContextMenu}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="SinglePaneContextMenu" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
+                            <Setter TargetName="SinglePaneContextMenu" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinMaximize}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
+                            <Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinRestore}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
+                            <Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinClose}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_PinClose" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
+                            <Setter TargetName="PART_PinClose" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
+                        </MultiDataTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-						<!--  Document Well : Tab : Button / Selected, active, pressed  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=SinglePaneContextMenu}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="SinglePaneContextMenu" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
-							<Setter TargetName="SinglePaneContextMenu" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
-								<Condition Binding="{Binding IsChecked, ElementName=SinglePaneContextMenu}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="SinglePaneContextMenu" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
-							<Setter TargetName="SinglePaneContextMenu" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinMaximize}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
-							<Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinRestore}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
-							<Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true" />
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinClose}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_PinClose" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
-							<Setter TargetName="PART_PinClose" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
-						</MultiDataTrigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
-
-	<Style x:Key="{x:Type avalonDockControls:LayoutAutoHideWindowControl}" TargetType="{x:Type avalonDockControls:LayoutAutoHideWindowControl}">
-		<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.TabBackground}}" />
-		<Setter Property="AnchorableStyle">
-			<Setter.Value>
-				<Style TargetType="avalonDockControls:LayoutAnchorableControl">
-					<Setter Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}" />
-					<Setter Property="BorderThickness" Value="1" />
-				</Style>
-			</Setter.Value>
-		</Setter>
-	</Style>
+    <Style x:Key="{x:Type avalonDockControls:LayoutAutoHideWindowControl}" TargetType="{x:Type avalonDockControls:LayoutAutoHideWindowControl}">
+        <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.TabBackground}}" />
+        <Setter Property="AnchorableStyle">
+            <Setter.Value>
+                <Style TargetType="avalonDockControls:LayoutAnchorableControl">
+                    <Setter Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}" />
+                    <Setter Property="BorderThickness" Value="1" />
+                </Style>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
 
-	<Style x:Key="AvalonDockThemeVs2013NavigatorWindowListBoxItemFocusVisual">
-		<Setter Property="Control.Template">
-			<Setter.Value>
-				<ControlTemplate>
-					<Rectangle
+    <Style x:Key="AvalonDockThemeVs2013NavigatorWindowListBoxItemFocusVisual">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle
 						RadiusX="2"
 						RadiusY="2"
 						Stroke="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}"
 						StrokeThickness="1" />
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-	<Style x:Key="AvalonDockThemeVs2013NavigatorWindowListBoxItemStyle" TargetType="ListBoxItem">
-		<Setter Property="FocusVisualStyle" Value="{StaticResource AvalonDockThemeVs2013NavigatorWindowListBoxItemFocusVisual}" />
-		<Setter Property="Background" Value="Transparent" />
-		<Setter Property="BorderBrush" Value="Transparent" />
-		<Setter Property="TextElement.Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}" />
-		<Setter Property="BorderThickness" Value="1" />
-		<Setter Property="Padding" Value="5,0,5,0" />
-		<Setter Property="VerticalContentAlignment" Value="Center" />
-		<Setter Property="Cursor" Value="Hand" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="ListBoxItem">
-					<Border
+    <Style x:Key="AvalonDockThemeVs2013NavigatorWindowListBoxItemStyle" TargetType="ListBoxItem">
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AvalonDockThemeVs2013NavigatorWindowListBoxItemFocusVisual}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Padding" Value="5,0,5,0" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ListBoxItem">
+                    <Border
 						Background="{TemplateBinding Background}"
 						BorderBrush="{TemplateBinding BorderBrush}"
 						BorderThickness="{TemplateBinding BorderThickness}"
 						SnapsToDevicePixels="true">
-						<Border x:Name="InnerBorder" BorderThickness="1">
-							<Grid>
-								<Grid.RowDefinitions>
-									<RowDefinition MaxHeight="11" />
-									<RowDefinition />
-								</Grid.RowDefinitions>
-								<Rectangle
+                        <Border x:Name="InnerBorder" BorderThickness="1">
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition MaxHeight="11" />
+                                    <RowDefinition />
+                                </Grid.RowDefinitions>
+                                <Rectangle
 									x:Name="UpperHighlight"
 									Fill="#75FFFFFF"
 									Visibility="Collapsed" />
-								<ContentPresenter
+                                <ContentPresenter
 									Grid.RowSpan="2"
 									VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
 									SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-							</Grid>
-						</Border>
-					</Border>
-					<ControlTemplate.Triggers>
-						<!--<Trigger Property="IsMouseOver" Value="true">
+                            </Grid>
+                        </Border>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <!--<Trigger Property="IsMouseOver" Value="true">
                             <Setter Property="Background" Value="{StaticResource AvalonDockThemeVs2013NavigatorWindowListBoxItemSelectedFill}" />
                             <Setter Property="BorderBrush" Value="#FF98DDFB" />
                             <Setter TargetName="InnerBorder" Property="BorderBrush" Value="#80FFFFFF" />
                             <Setter TargetName="UpperHighlight" Property="Visibility" Value="Visible" />
                             <Setter TargetName="UpperHighlight" Property="Fill" Value="#40FFFFFF" />
                         </Trigger>-->
-						<Trigger Property="IsSelected" Value="true">
-							<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowSelectedBackground}}" />
-							<Setter Property="TextElement.Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowSelectedText}}" />
-							<!--<Setter Property="BorderBrush" Value="#FF98DDFB" />-->
-							<!--<Setter TargetName="InnerBorder" Property="BorderBrush" Value="#80FFFFFF" />-->
-							<!--<Setter TargetName="UpperHighlight" Property="Visibility" Value="Visible" />
+                        <Trigger Property="IsSelected" Value="true">
+                            <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowSelectedBackground}}" />
+                            <Setter Property="TextElement.Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowSelectedText}}" />
+                            <!--<Setter Property="BorderBrush" Value="#FF98DDFB" />-->
+                            <!--<Setter TargetName="InnerBorder" Property="BorderBrush" Value="#80FFFFFF" />-->
+                            <!--<Setter TargetName="UpperHighlight" Property="Visibility" Value="Visible" />
                             <Setter TargetName="UpperHighlight" Property="Fill" Value="#40FFFFFF" />-->
-						</Trigger>
-						<!--
+                        </Trigger>
+                        <!--
                             <MultiTrigger>
                             <MultiTrigger.Conditions>
                             <Condition Property="IsSelected" Value="true"/>
@@ -2291,57 +2299,57 @@
                             <Setter Property="BorderBrush" Value="#FF98DDFB"/>
                             </MultiTrigger>
 						-->
-						<Trigger Property="IsEnabled" Value="false">
-							<Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
-						</Trigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-	<Style x:Key="{x:Type avalonDockControls:NavigatorWindow}" TargetType="{x:Type avalonDockControls:NavigatorWindow}">
-		<Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-		<Setter Property="SizeToContent" Value="WidthAndHeight" />
-		<Setter Property="ResizeMode" Value="NoResize" />
-		<!--<Setter Property="shell:WindowChrome.WindowChrome">
+    <Style x:Key="{x:Type avalonDockControls:NavigatorWindow}" TargetType="{x:Type avalonDockControls:NavigatorWindow}">
+        <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+        <Setter Property="SizeToContent" Value="WidthAndHeight" />
+        <Setter Property="ResizeMode" Value="NoResize" />
+        <!--<Setter Property="shell:WindowChrome.WindowChrome">
             <Setter.Value>
                 <shell:WindowChrome CaptionHeight="16"
                                     GlassFrameThickness="4"
                                     ResizeBorderThickness="10" />
             </Setter.Value>
         </Setter>-->
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type avalonDockControls:NavigatorWindow}">
-					<Grid>
-						<Border
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type avalonDockControls:NavigatorWindow}">
+                    <Grid>
+                        <Border
 							x:Name="WindowBorder"
 							Background="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowBackground}}"
 							BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}"
 							BorderThickness="1">
-							<Grid>
-								<Grid.RowDefinitions>
-									<RowDefinition Height="54" />
-									<RowDefinition Height="*" />
-									<RowDefinition Height="Auto" />
-								</Grid.RowDefinitions>
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="54" />
+                                    <RowDefinition Height="*" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
 
-								<Grid Margin="5">
-									<Grid.RowDefinitions>
-										<RowDefinition />
-										<RowDefinition />
-									</Grid.RowDefinitions>
-									<Grid>
-										<Grid.ColumnDefinitions>
-											<ColumnDefinition Width="Auto" />
-											<ColumnDefinition />
-										</Grid.ColumnDefinitions>
-										<Image
+                                <Grid Margin="5">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                    </Grid.RowDefinitions>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition />
+                                        </Grid.ColumnDefinitions>
+                                        <Image
 											Source="{Binding SelectedDocument.LayoutElement.IconSource, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:NullToDoNothingConverter}}"
 											Stretch="None"
 											Visibility="{Binding SelectedDocument.LayoutElement.IconSource, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:BoolToVisibilityConverter}}" />
-										<TextBlock
+                                        <TextBlock
 											x:Name="selectedElementTitle"
 											Grid.Column="1"
 											Margin="4,0,0,0"
@@ -2350,36 +2358,36 @@
 											Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}"
 											Text="{Binding SelectedDocument.LayoutElement.Title, RelativeSource={RelativeSource TemplatedParent}}"
 											TextTrimming="CharacterEllipsis" />
-									</Grid>
-									<TextBlock
+                                    </Grid>
+                                    <TextBlock
 										x:Name="selectedElementDescription"
 										VerticalAlignment="Center"
 										Text="{Binding SelectedDocument.LayoutElement.Description}"
 										TextTrimming="CharacterEllipsis" />
-								</Grid>
+                                </Grid>
 
-								<Border
+                                <Border
 									Grid.Row="1"
 									MinHeight="200"
 									Background="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowBackground}}"
 									BorderBrush="Transparent"
 									BorderThickness="0,1,0,0">
-									<Grid Margin="5">
-										<Grid.ColumnDefinitions>
-											<ColumnDefinition Width="Auto" />
-											<ColumnDefinition />
-										</Grid.ColumnDefinitions>
-										<Grid Margin="5">
-											<Grid.RowDefinitions>
-												<RowDefinition Height="Auto" />
-												<RowDefinition />
-											</Grid.RowDefinitions>
-											<TextBlock
+                                    <Grid Margin="5">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition />
+                                        </Grid.ColumnDefinitions>
+                                        <Grid Margin="5">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition />
+                                            </Grid.RowDefinitions>
+                                            <TextBlock
 												Margin="0,3,0,4"
 												FontWeight="Bold"
 												Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}"
 												Text="{x:Static avalonDockProperties:Resources.Active_ToolWindows}" />
-											<ListBox
+                                            <ListBox
 												x:Name="PART_AnchorableListBox"
 												Grid.Row="1"
 												MaxHeight="400"
@@ -2387,36 +2395,36 @@
 												ItemContainerStyle="{StaticResource AvalonDockThemeVs2013NavigatorWindowListBoxItemStyle}"
 												ItemsSource="{Binding Anchorables}"
 												SelectedItem="{Binding SelectedAnchorable, Mode=TwoWay}">
-												<ListBox.ItemTemplate>
-													<DataTemplate>
-														<Grid>
-															<Grid.ColumnDefinitions>
-																<ColumnDefinition Width="16" />
-																<ColumnDefinition Width="150" />
-															</Grid.ColumnDefinitions>
-															<Image Source="{Binding LayoutElement.IconSource, Converter={avalonDockConverters:NullToDoNothingConverter}}" Stretch="None" />
-															<TextBlock
+                                                <ListBox.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="16" />
+                                                                <ColumnDefinition Width="150" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <Image Source="{Binding LayoutElement.IconSource, Converter={avalonDockConverters:NullToDoNothingConverter}}" Stretch="None" />
+                                                            <TextBlock
 																Grid.Column="1"
 																Margin="4,0,0,0"
 																Text="{Binding LayoutElement.Title}"
 																TextTrimming="CharacterEllipsis" />
-														</Grid>
-													</DataTemplate>
-												</ListBox.ItemTemplate>
-											</ListBox>
-										</Grid>
-										<Grid Grid.Column="1" Margin="5">
-											<Grid.RowDefinitions>
-												<RowDefinition Height="Auto" />
-												<RowDefinition />
-											</Grid.RowDefinitions>
-											<TextBlock
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ListBox.ItemTemplate>
+                                            </ListBox>
+                                        </Grid>
+                                        <Grid Grid.Column="1" Margin="5">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition />
+                                            </Grid.RowDefinitions>
+                                            <TextBlock
 												Margin="0,3,0,4"
 												FontWeight="Bold"
 												Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}"
 												Text="{x:Static avalonDockProperties:Resources.Active_Files}" />
 
-											<ListBox
+                                            <ListBox
 												x:Name="PART_DocumentListBox"
 												Grid.Row="1"
 												MaxHeight="400"
@@ -2424,50 +2432,50 @@
 												ItemContainerStyle="{StaticResource AvalonDockThemeVs2013NavigatorWindowListBoxItemStyle}"
 												ItemsSource="{Binding Documents}"
 												SelectedItem="{Binding SelectedDocument, Mode=TwoWay}">
-												<ListBox.ItemTemplate>
-													<DataTemplate>
-														<Grid>
-															<Grid.ColumnDefinitions>
-																<ColumnDefinition Width="16" />
-																<ColumnDefinition Width="150" />
-															</Grid.ColumnDefinitions>
-															<Image Source="{Binding LayoutElement.IconSource, Converter={avalonDockConverters:NullToDoNothingConverter}}" Stretch="None" />
-															<TextBlock
+                                                <ListBox.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="16" />
+                                                                <ColumnDefinition Width="150" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <Image Source="{Binding LayoutElement.IconSource, Converter={avalonDockConverters:NullToDoNothingConverter}}" Stretch="None" />
+                                                            <TextBlock
 																Grid.Column="1"
 																Margin="4,0,0,0"
 																Text="{Binding LayoutElement.Title}"
 																TextTrimming="CharacterEllipsis" />
-														</Grid>
-													</DataTemplate>
-												</ListBox.ItemTemplate>
-												<ListBox.ItemsPanel>
-													<ItemsPanelTemplate>
-														<WrapPanel Orientation="Vertical" />
-													</ItemsPanelTemplate>
-												</ListBox.ItemsPanel>
-											</ListBox>
-										</Grid>
-									</Grid>
-								</Border>
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ListBox.ItemTemplate>
+                                                <ListBox.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <WrapPanel Orientation="Vertical" />
+                                                    </ItemsPanelTemplate>
+                                                </ListBox.ItemsPanel>
+                                            </ListBox>
+                                        </Grid>
+                                    </Grid>
+                                </Border>
 
-								<Grid Grid.Row="2" Margin="5">
-									<TextBlock
+                                <Grid Grid.Row="2" Margin="5">
+                                    <TextBlock
 										VerticalAlignment="Center"
 										Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}"
 										Text="{Binding SelectedDocument.LayoutElement.ToolTip, RelativeSource={RelativeSource TemplatedParent}}" />
-								</Grid>
-							</Grid>
-						</Border>
-					</Grid>
-					<ControlTemplate.Triggers>
-						<Trigger Property="SelectedDocument" Value="{x:Null}">
-							<Setter TargetName="selectedElementTitle" Property="Text" Value="{Binding SelectedAnchorable.LayoutElement.Title}" />
-							<Setter TargetName="selectedElementDescription" Property="Text" Value="{x:Null}" />
-						</Trigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                                </Grid>
+                            </Grid>
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="SelectedDocument" Value="{x:Null}">
+                            <Setter TargetName="selectedElementTitle" Property="Text" Value="{Binding SelectedAnchorable.LayoutElement.Title}" />
+                            <Setter TargetName="selectedElementDescription" Property="Text" Value="{x:Null}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
 </ResourceDictionary>

--- a/source/Components/AvalonDock/Controls/LayoutAnchorableItem.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorableItem.cs
@@ -40,7 +40,12 @@ namespace AvalonDock.Controls
 		#endregion fields
 
 		#region Constructors
-
+		static LayoutAnchorableItem()
+		{
+			// #182: LayoutAnchorable initializes with CanClose == false. We therefore also override the metadata for LayoutAnchorableItem to match this.
+			// Only the default value will be overriden. PropertyChangedCallbacks, etc should be unaffected.
+			CanCloseProperty.OverrideMetadata(typeof(LayoutAnchorableItem), new FrameworkPropertyMetadata(false));
+		}
 		/// <summary>Class constructor</summary>
 		internal LayoutAnchorableItem()
 		{


### PR DESCRIPTION
The proposed fix overrides the metadata of LayoutAnchorableItem.CanCloseProperty to match the default value of False with its LayoutAnchorable. The fix also includes adding missing triggers on the VS2013 theme for showing the Close button on the LayoutAnchorableTitlePane and LayoutAnchorableFloatingWindow. 

Visual Studio apparently replaced the tabs with spaces, resulting in the unnecessarily large addition/removal which I unfortunately can't do anything about. The actual changes in Generic.xaml are lines 680-683 and 2037-2040.