### PR TITLE
Fix ObservableCollection Reset notification handling

### DIFF
--- a/source/AutomationTest/AvalonDockTest/AnchorablePaneTest.cs
+++ b/source/AutomationTest/AvalonDockTest/AnchorablePaneTest.cs
@@ -1,15 +1,16 @@
 ﻿namespace AvalonDockTest
 {
 	using Microsoft.VisualStudio.TestTools.UnitTesting;
+	using Microsoft.VisualStudio.TestTools.UnitTesting.STAExtensions;
 	using System.Threading.Tasks;
 	using AvalonDock.Layout;
 	using AvalonDockTest.TestHelpers;
 	using AvalonDockTest.views;
 
-	[TestClass]
+	[STATestClass]
 	public class AnchorablePaneTest : AutomationTestBase
 	{
-		[TestMethod]
+		[STATestMethod]
 		public void AnchorablePaneHideCloseTest()
 		{
 			TestHost.SwitchToAppThread();

--- a/source/AutomationTest/AvalonDockTest/AvalonDockTest.csproj
+++ b/source/AutomationTest/AvalonDockTest/AvalonDockTest.csproj
@@ -1,113 +1,28 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" />
-  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <TargetFrameworks>netcoreapp3.0;net452</TargetFrameworks>
     <ProjectGuid>{FE4E16A2-876A-4356-9974-8A89C50B2A5A}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AvalonDockTest</RootNamespace>
     <AssemblyName>AvalonDockTest</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
-    <IsCodedUITest>False</IsCodedUITest>
-    <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-    <TargetFrameworkProfile />
+    <FileVersion>1.0.0.0</FileVersion>
+    <UseWPF>true</UseWPF>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MSTest.TestFramework.2.1.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MSTest.TestFramework.2.1.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="System.XML" />
-    <Reference Include="WindowsBase" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="MSTest.STAExtensions" Version="1.0.3-beta" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="LayoutAnchorableFloatingWindowControlTest.cs" />
-    <Compile Include="AnchorablePaneTest.cs" />
-    <Compile Include="DockingUtilitiesTest.cs" />
-    <Compile Include="LayoutAnchorableTest.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TestApp.xaml.cs">
-      <DependentUpon>TestApp.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="TestHelpers\AutomationTestBase.cs" />
-    <Compile Include="TestHelpers\Extensions.cs" />
-    <Compile Include="TestHelpers\SwitchContextToUiThreadAwaiter.cs" />
-    <Compile Include="TestHelpers\TestHost.cs" />
-    <Compile Include="TestHelpers\WindowHelpers.cs" />
-    <Compile Include="Views\AnchorablePaneTestWindow.xaml.cs">
-      <DependentUpon>AnchorablePaneTestWindow.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Views\LayoutAnchorableFloatingWindowControlTestWindow.xaml.cs">
-      <DependentUpon>LayoutAnchorableFloatingWindowControlTestWindow.xaml</DependentUpon>
-    </Compile>
+    <ProjectReference Include="..\..\Components\AvalonDock\AvalonDock.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-    <None Include="Testsettings.runsettings" />
-  </ItemGroup>
-  <ItemGroup>
-    <Page Include="TestApp.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Include="Views\AnchorablePaneTestWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Include="Views\LayoutAnchorableFloatingWindowControlTestWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\Components\AvalonDock\AvalonDock.csproj">
-      <Project>{db81988f-e0f2-45a0-a1fd-8c37f3d35244}</Project>
-      <Name>AvalonDock</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets'))" />
-  </Target>
-  <Import Project="..\..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets')" />
+
 </Project>

--- a/source/AutomationTest/AvalonDockTest/CollectionResetTest.cs
+++ b/source/AutomationTest/AvalonDockTest/CollectionResetTest.cs
@@ -1,0 +1,234 @@
+﻿using AvalonDockTest.TestHelpers;
+using AvalonDockTest.Views;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.STAExtensions;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Windows.Controls;
+
+namespace AvalonDockTest
+{
+	/// <summary>
+	/// This class tests the NotifyCollectionChangedAction.Reset handling. Previous implementations
+	/// of AvalonDock clear the associated collection if the notification was received, instead
+	/// of iterating for any remaining items in the collection.
+	/// </summary>
+	[STATestClass]
+	public class CollectionResetTest : AutomationTestBase
+	{
+		#region Notification Counting for CollectionChanged
+		public class NotifyActionCount
+		{
+			public int AddCount;
+			public int RemoveCount;
+			public int ReplaceCount;
+			public int MoveCount;
+			public int ResetCount;
+
+			// Use simple string comparison instead of IEquatable<T>
+			public override string ToString()
+			{
+				return $"{{ AddCount: {AddCount}, RemoveCount: {RemoveCount}, ReplaceCount: {ReplaceCount}, MoveCount: {MoveCount}, ResetCount: {ResetCount} }}";
+			}
+		}
+
+		private static void UpdateNotificationCount(NotifyCollectionChangedEventArgs e, NotifyActionCount notifyCount)
+		{
+			switch (e.Action)
+			{
+				case NotifyCollectionChangedAction.Add:
+					++notifyCount.AddCount;
+					break;
+				case NotifyCollectionChangedAction.Remove:
+					++notifyCount.RemoveCount;
+					break;
+				case NotifyCollectionChangedAction.Replace:
+					++notifyCount.ReplaceCount;
+					break;
+				case NotifyCollectionChangedAction.Move:
+					++notifyCount.MoveCount;
+					break;
+				case NotifyCollectionChangedAction.Reset:
+					++notifyCount.ResetCount;
+					break;
+				default:
+					break;
+			}
+		}
+		#endregion
+
+		#region Shared Main Test Window for both Anchorables and Documents
+		static Lazy<CollectionResetTestWindow> TestWindow =
+			new Lazy<CollectionResetTestWindow>(() => CreateTestWindow());
+
+		private static CollectionResetTestWindow CreateTestWindow()
+		{
+			TestHost.SwitchToAppThread();
+
+			var task = WindowHelpers.CreateInvisibleWindowAsync<CollectionResetTestWindow>();
+			task.Wait();
+
+			CollectionResetTestWindow window = task.Result;
+			Assert.IsTrue(window.IsLoaded);
+
+			// Hook up to ObservableCollection notifications
+			window.Anchorables.CollectionChanged += (s, e) => { UpdateNotificationCount(e, AnchorNotifications); };
+			window.Documents.CollectionChanged += (s, e) => { UpdateNotificationCount(e, DocumentNotifications); };
+
+			// Create some anchorable test items
+			for (int index = 0; index < ExpectedAnchorableCount; index++)
+			{
+				var child = new UserControl() { Tag = $"Anchorable {index}" };
+				window.Anchorables.Add(child);
+			}
+
+			// Create some document test items
+			for (int index = 0; index < ExpectedDocumentCount; index++)
+			{
+				var child = new UserControl() { Tag = $"Document {index}" };
+				window.Documents.Add(child);
+			}
+
+			return window;
+		}
+		#endregion
+
+		#region Adapter for testing Anchorables and Documents
+		const int ExpectedAnchorableCount = 5;
+		const int ExpectedDocumentCount = 7;
+
+		static NotifyActionCount AnchorNotifications = new NotifyActionCount();
+		static NotifyActionCount DocumentNotifications = new NotifyActionCount();
+
+		public interface ITestAdapter
+		{
+			CustomObservableCollection<object> GetCollection();
+			IEnumerable<object> GetSource();
+			int ExpectedCount { get; }
+			int CollectionCount { get; }
+			int SourceCount { get; }
+			NotifyActionCount Notifications { get; }
+		}
+
+		public class AnchorablesTestAdapter : ITestAdapter
+		{
+			private readonly CollectionResetTestWindow _window;
+
+			public AnchorablesTestAdapter(CollectionResetTestWindow window)
+			{
+				_window = window;
+			}
+
+			public int ExpectedCount => ExpectedAnchorableCount;
+
+			public int CollectionCount => _window.Anchorables.Count;
+
+			public int SourceCount => _window.DockManager.AnchorablesSource.Cast<object>().Count();
+
+			public NotifyActionCount Notifications => AnchorNotifications;
+
+			public CustomObservableCollection<object> GetCollection()
+			{
+				return _window.Anchorables;
+			}
+
+			public IEnumerable<object> GetSource()
+			{
+				return _window.DockManager.AnchorablesSource.Cast<object>();
+			}
+		}
+
+		public class DocumentsTestAdapter : ITestAdapter
+		{
+			private readonly CollectionResetTestWindow _window;
+
+			public DocumentsTestAdapter(CollectionResetTestWindow window)
+			{
+				_window = window;
+			}
+
+			public int ExpectedCount => ExpectedDocumentCount;
+
+			public int CollectionCount => _window.Documents.Count;
+
+			public int SourceCount => _window.DockManager.DocumentsSource.Cast<object>().Count();
+
+			public NotifyActionCount Notifications => DocumentNotifications;
+
+			public CustomObservableCollection<object> GetCollection()
+			{
+				return _window.Documents;
+			}
+
+			public IEnumerable<object> GetSource()
+			{
+				return _window.DockManager.DocumentsSource.Cast<object>();
+			}
+		}
+		#endregion
+
+		[STATestMethod]
+		public void CollectionResetAnchorablesTest()
+		{
+			CollectionResetTestWindow window = TestWindow.Value;
+			Assert.IsTrue(window.IsLoaded);
+
+			var adapter = new AnchorablesTestAdapter(window);
+			TestResetNotification(adapter);
+		}
+
+		[STATestMethod]
+		public void CollectionResetDocumentsTest()
+		{
+			CollectionResetTestWindow window = TestWindow.Value;
+			Assert.IsTrue(window.IsLoaded);
+
+			var adapter = new DocumentsTestAdapter(window);
+			TestResetNotification(adapter);
+		}
+
+		/// <summary>
+		/// Common logic for test both Anchorables and Documents
+		/// </summary>
+		/// <param name="adapter"></param>
+		private void TestResetNotification(ITestAdapter adapter)
+		{
+			// Make sure we have the correct initial counts
+			Assert.AreEqual(adapter.ExpectedCount, adapter.CollectionCount);
+			Assert.AreEqual(adapter.ExpectedCount, adapter.SourceCount);
+
+			// We are only expecting the newly added items
+			AreEqual(adapter.Notifications, new NotifyActionCount { AddCount = adapter.ExpectedCount });
+
+			// Raise the Reset notification. Previous versions of AvalonDock assumed the collection was cleared.
+			adapter.GetCollection().Refresh();
+
+			// Nothing should have changed
+			Assert.AreEqual(adapter.ExpectedCount, adapter.CollectionCount);
+			Assert.AreEqual(adapter.ExpectedCount, adapter.SourceCount);
+
+			// Verify nothing has been closed and the Reset notification was received
+			AreEqual(adapter.Notifications, new NotifyActionCount { AddCount = adapter.ExpectedCount, ResetCount = 1 });
+
+			// Close the odd items. This will also raise the Reset notification.
+			var removeChildren = adapter.GetSource().Where((x, i) => i % 2 != 0).ToList();
+			adapter.GetCollection().RemoveRange(removeChildren);
+
+			// Verify the remaining items
+			int remainingCount = adapter.ExpectedCount - removeChildren.Count;
+			Assert.AreEqual(remainingCount, adapter.CollectionCount);
+			Assert.AreEqual(remainingCount, adapter.SourceCount);
+
+			// NOTE: The RemoveCount is still zero because RemoveRange silently removed the items then issues a Reset.
+			AreEqual(adapter.Notifications, new NotifyActionCount { AddCount = adapter.ExpectedCount, ResetCount = 2 });
+		}
+
+		// Use simple string comparison instead of IEquatable<T>
+		private void AreEqual(NotifyActionCount expected, NotifyActionCount actual)
+		{
+			Assert.AreEqual(expected.ToString(), actual.ToString());
+		}
+	}
+}

--- a/source/AutomationTest/AvalonDockTest/CustomObservableCollection.cs
+++ b/source/AutomationTest/AvalonDockTest/CustomObservableCollection.cs
@@ -1,0 +1,92 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+namespace AvalonDockTest
+{
+	/// <summary>
+	/// Custom ObservableCollection to raise the Reset notification for unit testing
+	/// </summary>
+	public class CustomObservableCollection<T> : ObservableCollection<T>
+	{
+		/// <summary>
+		/// Enables/Disables property change notification.
+		/// </summary>
+		public bool IsNotifying { get; set; } = true;
+
+		/// <summary>
+		/// Raises a change notification indicating that all bindings should be refreshed.
+		/// </summary>
+		public void Refresh()
+		{
+			OnPropertyChanged(new PropertyChangedEventArgs("Count"));
+			OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
+			OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+		}
+
+		/// <summary>
+		/// Adds a range of items. Suspends notifications during add, then raises a Reset notification.
+		/// </summary>
+		/// <param name="items"></param>
+		public void AddRange(IEnumerable<T> items)
+		{
+			var previousNotifying = IsNotifying;
+			IsNotifying = false;
+			var index = Count;
+			foreach (var item in items)
+			{
+				InsertItem(index, item);
+				++index;
+			}
+			IsNotifying = previousNotifying;
+
+			Refresh();
+		}
+
+		/// <summary>
+		/// Removes a range of items. Suspends notifications during add, then raises a Reset notification.
+		/// </summary>
+		/// <param name="items"></param>
+		public void RemoveRange(IEnumerable<T> items)
+		{
+			var previousNotifying = IsNotifying;
+			IsNotifying = false;
+			foreach (var item in items)
+			{
+				var index = IndexOf(item);
+				if (index >= 0)
+				{
+					RemoveItem(index);
+				}
+			}
+			IsNotifying = previousNotifying;
+
+			Refresh();
+		}
+
+		/// <summary>
+		/// Raises the <see cref = "E:System.Collections.ObjectModel.ObservableCollection`1.CollectionChanged" /> event with the provided arguments.
+		/// </summary>
+		/// <param name = "e">Arguments of the event being raised.</param>
+		protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+		{
+			if (IsNotifying)
+			{
+				base.OnCollectionChanged(e);
+			}
+		}
+
+		/// <summary>
+		/// Raises the PropertyChanged event with the provided arguments.
+		/// </summary>
+		/// <param name = "e">The event data to report in the event.</param>
+		protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+		{
+			if (IsNotifying)
+			{
+				base.OnPropertyChanged(e);
+			}
+		}
+	}
+}

--- a/source/AutomationTest/AvalonDockTest/LayoutAnchorableFloatingWindowControlTest.cs
+++ b/source/AutomationTest/AvalonDockTest/LayoutAnchorableFloatingWindowControlTest.cs
@@ -3,15 +3,16 @@
 	using System.Threading.Tasks;
 
 	using Microsoft.VisualStudio.TestTools.UnitTesting;
+	using Microsoft.VisualStudio.TestTools.UnitTesting.STAExtensions;
 
 	using AvalonDock.Layout.Serialization;
 	using AvalonDockTest.TestHelpers;
 	using AvalonDockTest.Views;
 
-	[TestClass]
+	[STATestClass]
 	public class LayoutAnchorableFloatingWindowControlTest : AutomationTestBase
 	{
-		[TestMethod]
+		[STATestMethod]
 		public async Task CloseWithHiddenFloatingWindowsTest()
 		{
 			LayoutAnchorableFloatingWindowControlTestWindow window = await WindowHelpers.CreateInvisibleWindowAsync<LayoutAnchorableFloatingWindowControlTestWindow>();

--- a/source/AutomationTest/AvalonDockTest/LayoutAnchorableTest.cs
+++ b/source/AutomationTest/AvalonDockTest/LayoutAnchorableTest.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Data;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.STAExtensions;
 
 using AvalonDock.Controls;
 using AvalonDock.Converters;
@@ -11,10 +12,10 @@ using AvalonDock.Layout;
 
 namespace AvalonDockTest
 {
-	[TestClass]
+	[STATestClass]
 	public sealed class LayoutAnchorableTest
 	{
-		[TestMethod]
+		[STATestMethod]
 		public void ClearBindingOfHiddenWindowTest()
 		{
 			LayoutAnchorable layoutAnchorable = new LayoutAnchorable

--- a/source/AutomationTest/AvalonDockTest/Properties/AssemblyInfo.cs
+++ b/source/AutomationTest/AvalonDockTest/Properties/AssemblyInfo.cs
@@ -1,19 +1,5 @@
-using System.Reflection;
 using System.Runtime.InteropServices;
-
-[assembly: AssemblyTitle("AvalonDockTest")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("AvalonDockTest")]
-[assembly: AssemblyCopyright("Copyright ©  2019")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 [assembly: ComVisible(false)]
 
 [assembly: Guid("fe4e16a2-876a-4356-9974-8a89c50b2a5a")]
-
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/source/AutomationTest/AvalonDockTest/Views/CollectionResetTestWindow.xaml
+++ b/source/AutomationTest/AvalonDockTest/Views/CollectionResetTestWindow.xaml
@@ -1,0 +1,25 @@
+﻿<Window x:Class="AvalonDockTest.Views.CollectionResetTestWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:AvalonDockTest.Views"
+        mc:Ignorable="d"
+        Title="ObservableCollection Reset Test"
+        Height="450" Width="800">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary>
+                    <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+                </ResourceDictionary>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+    <Grid>
+        <DockingManager x:Name="DockManager"
+                        AnchorablesSource="{Binding Anchorables, Mode=OneWay}"
+                        DocumentsSource="{Binding Documents, Mode=OneWay}">
+        </DockingManager>
+    </Grid>
+</Window>

--- a/source/AutomationTest/AvalonDockTest/Views/CollectionResetTestWindow.xaml.cs
+++ b/source/AutomationTest/AvalonDockTest/Views/CollectionResetTestWindow.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace AvalonDockTest.Views
+{
+	/// <summary>
+	/// Interaction logic for CollectionResetTestWindow.xaml
+	/// </summary>
+	public partial class CollectionResetTestWindow : Window
+	{
+		public CollectionResetTestWindow()
+		{
+			InitializeComponent();
+			DataContext = this;
+			Anchorables = new CustomObservableCollection<object>();
+			Documents = new CustomObservableCollection<object>();
+		}
+
+		public CustomObservableCollection<object> Anchorables { get; private set; }
+		public CustomObservableCollection<object> Documents { get; private set; }
+	}
+}

--- a/source/AutomationTest/AvalonDockTest/packages.config
+++ b/source/AutomationTest/AvalonDockTest/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="MSTest.TestAdapter" version="2.1.2" targetFramework="net452" />
-  <package id="MSTest.TestFramework" version="2.1.2" targetFramework="net452" />
-</packages>

--- a/source/AvalonDock.sln
+++ b/source/AvalonDock.sln
@@ -40,6 +40,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WinFormsTestApp", "WinForms
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AvalonDocPanelMemoryLeaks", "AvalonDocPanelMemoryLeaks\AvalonDocPanelMemoryLeaks.csproj", "{5543BFED-827A-4404-8066-3FFDB201DDF0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CaliburnDockTestApp", "CaliburnDockTestApp\CaliburnDockTestApp.csproj", "{F8AEE594-DB5E-4DB8-9F45-4969CA5F8EF1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -230,6 +232,18 @@ Global
 		{5543BFED-827A-4404-8066-3FFDB201DDF0}.Release|x64.Build.0 = Release|Any CPU
 		{5543BFED-827A-4404-8066-3FFDB201DDF0}.Release|x86.ActiveCfg = Release|Any CPU
 		{5543BFED-827A-4404-8066-3FFDB201DDF0}.Release|x86.Build.0 = Release|Any CPU
+		{F8AEE594-DB5E-4DB8-9F45-4969CA5F8EF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8AEE594-DB5E-4DB8-9F45-4969CA5F8EF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F8AEE594-DB5E-4DB8-9F45-4969CA5F8EF1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F8AEE594-DB5E-4DB8-9F45-4969CA5F8EF1}.Debug|x64.Build.0 = Debug|Any CPU
+		{F8AEE594-DB5E-4DB8-9F45-4969CA5F8EF1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F8AEE594-DB5E-4DB8-9F45-4969CA5F8EF1}.Debug|x86.Build.0 = Debug|Any CPU
+		{F8AEE594-DB5E-4DB8-9F45-4969CA5F8EF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F8AEE594-DB5E-4DB8-9F45-4969CA5F8EF1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F8AEE594-DB5E-4DB8-9F45-4969CA5F8EF1}.Release|x64.ActiveCfg = Release|Any CPU
+		{F8AEE594-DB5E-4DB8-9F45-4969CA5F8EF1}.Release|x64.Build.0 = Release|Any CPU
+		{F8AEE594-DB5E-4DB8-9F45-4969CA5F8EF1}.Release|x86.ActiveCfg = Release|Any CPU
+		{F8AEE594-DB5E-4DB8-9F45-4969CA5F8EF1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -252,6 +266,7 @@ Global
 		{3B75DEA1-F1B2-403C-AB74-C108EDB45EF2} = {1D267DDB-F2DE-4B70-87C1-E93A0C2D73F4}
 		{2433B8AF-0788-4C86-8FDD-E3BCB62E2157} = {1D267DDB-F2DE-4B70-87C1-E93A0C2D73F4}
 		{5543BFED-827A-4404-8066-3FFDB201DDF0} = {1D267DDB-F2DE-4B70-87C1-E93A0C2D73F4}
+		{F8AEE594-DB5E-4DB8-9F45-4969CA5F8EF1} = {1D267DDB-F2DE-4B70-87C1-E93A0C2D73F4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {459B8289-CF04-4E70-AEC9-23DC3A6E66F6}

--- a/source/CaliburnDockTestApp/App.xaml
+++ b/source/CaliburnDockTestApp/App.xaml
@@ -1,0 +1,14 @@
+﻿<Application x:Class="CaliburnDockTestApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:CaliburnDockTestApp">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary>
+                    <local:Bootstrapper x:Key="Bootstrapper"/>
+                </ResourceDictionary>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/source/CaliburnDockTestApp/App.xaml.cs
+++ b/source/CaliburnDockTestApp/App.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace CaliburnDockTestApp
+{
+	/// <summary>
+	/// Interaction logic for App.xaml
+	/// </summary>
+	public partial class App : Application
+	{
+	}
+}

--- a/source/CaliburnDockTestApp/AssemblyInfo.cs
+++ b/source/CaliburnDockTestApp/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+                                     //(used if a resource is not found in the page,
+                                     // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+                                              //(used if a resource is not found in the page,
+                                              // app, or any theme specific resource dictionaries)
+)]

--- a/source/CaliburnDockTestApp/Bootstrapper.cs
+++ b/source/CaliburnDockTestApp/Bootstrapper.cs
@@ -1,0 +1,21 @@
+﻿using Caliburn.Micro;
+using CaliburnDockTestApp.ViewModels;
+using System.Windows;
+
+namespace CaliburnDockTestApp
+{
+	public class Bootstrapper : Caliburn.Micro.BootstrapperBase
+	{
+		public Bootstrapper()
+		{
+			LogManager.GetLog = type => new CaliburnLogger(type);
+			Initialize();
+		}
+
+		protected override void OnStartup(object sender, StartupEventArgs e)
+		{
+			base.OnStartup(sender, e);
+			DisplayRootViewFor<MainWindowViewModel>();
+		}
+	}
+}

--- a/source/CaliburnDockTestApp/CaliburnDockTestApp.csproj
+++ b/source/CaliburnDockTestApp/CaliburnDockTestApp.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFrameworks>netcoreapp3.0;net4.5.2</TargetFrameworks>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <DefineConstants>DEBUG;TRACE;CALIBURN_ASYNC</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DefineConstants>TRACE;CALIBURN_ASYNC</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Caliburn.Micro" Version="4.0.136-rc" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Components\AvalonDock\AvalonDock.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/source/CaliburnDockTestApp/CaliburnLogger.cs
+++ b/source/CaliburnDockTestApp/CaliburnLogger.cs
@@ -1,0 +1,31 @@
+﻿using Caliburn.Micro;
+using System;
+using System.Diagnostics;
+
+namespace CaliburnDockTestApp
+{
+	class CaliburnLogger : ILog
+	{
+		private readonly Type _type;
+
+		public CaliburnLogger(Type type)
+		{
+			_type = type;
+		}
+
+		public void Error(Exception exception)
+		{
+			Trace.TraceError($"{_type.Name}: {exception}");
+		}
+
+		public void Info(string format, params object[] args)
+		{
+			Trace.TraceInformation($"{_type.Name}: " + format, args);
+		}
+
+		public void Warn(string format, params object[] args)
+		{
+			Trace.TraceWarning($"{_type.Name}: " + format, args);
+		}
+	}
+}

--- a/source/CaliburnDockTestApp/RelayCommand.cs
+++ b/source/CaliburnDockTestApp/RelayCommand.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Diagnostics;
+using System.Windows.Input;
+
+/// <summary>
+/// Used where Caliburn.Micro needs to be interfaced to ICommand.
+/// </summary>
+public class RelayCommand<T> : ICommand
+{
+	#region Fields
+
+	private readonly Action<T> _execute;
+	private readonly Predicate<T> _canExecute;
+
+	#endregion // Fields
+
+	#region Constructors
+
+	public RelayCommand(Action<T> execute)
+		: this(execute, null)
+	{
+	}
+
+	public RelayCommand(Action<T> execute, Predicate<T> canExecute)
+	{
+		if (execute == null)
+			throw new ArgumentNullException(nameof(execute));
+
+		_execute = execute;
+		_canExecute = canExecute;
+	}
+	#endregion // Constructors
+
+	#region ICommand Members
+
+	[DebuggerStepThrough]
+	public virtual bool CanExecute(T parameter)
+	{
+		return _canExecute == null || _canExecute(parameter);
+	}
+
+	public event EventHandler CanExecuteChanged;
+
+	public virtual void Execute(T parameter)
+	{
+		_execute(parameter);
+	}
+
+	bool ICommand.CanExecute(object parameter)
+	{
+		if (parameter != null && typeof(T).IsAssignableFrom(parameter.GetType()) == false)
+			throw new ArgumentException($"RelayCommand.CanExecute: Invalid type {parameter.GetType().FullName} - Expecting {typeof(T).FullName}");
+		return CanExecute((T)parameter);
+	}
+
+	void ICommand.Execute(object parameter)
+	{
+		Execute((T)parameter);
+	}
+
+	/// <summary>
+	/// Method used to raise the <see cref="CanExecuteChanged"/> event
+	/// to indicate that the return value of the <see cref="CanExecute"/>
+	/// method has changed.
+	/// </summary>
+	public void RaiseCanExecuteChanged()
+	{
+		CommandManager.InvalidateRequerySuggested();
+		CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+	}
+	#endregion // ICommand Members
+}
+
+public class RelayCommand : RelayCommand<object>
+{
+	public RelayCommand(Action<object> execute)
+	: this(execute, null)
+	{ }
+
+	public RelayCommand(Action<object> execute, Predicate<object> canExecute)
+		: base(execute, canExecute)
+	{ }
+}

--- a/source/CaliburnDockTestApp/ViewModels/MainWindowViewModel.cs
+++ b/source/CaliburnDockTestApp/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,127 @@
+﻿using Caliburn.Micro;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CaliburnDockTestApp.ViewModels
+{
+	public class MainWindowViewModel : Conductor<Screen>.Collection.OneActive
+	{
+		private RelayCommand _showACommand;
+		private RelayCommand _showBCommand;
+		private RelayCommand _showCCommand;
+		private RelayCommand _showDCommand;
+
+		public MainWindowViewModel()
+		{
+			SetShowCommand<TestViewModel>(ref _showACommand, "Test A");
+			SetShowCommand<TestViewModel>(ref _showBCommand, "Test B");
+			SetShowCommand<TestViewModel>(ref _showCCommand, "Test C");
+			SetShowCommand<TestViewModel>(ref _showDCommand, "Test D");
+		}
+
+		public RelayCommand ShowACommand { get { return _showACommand; } }
+		public RelayCommand ShowBCommand { get { return _showBCommand; } }
+		public RelayCommand ShowCCommand { get { return _showCCommand; } }
+
+		private void SetShowCommand<T>(ref RelayCommand command, string displayName)
+			where T : ViewModelBase
+		{
+			command = new RelayCommand(_ => ActivateOrCreate<T>(displayName));
+		}
+
+		private int _createCount;
+
+		public Task ActivateOrCreate<T>(string displayName)
+			where T : ViewModelBase
+		{
+			var item = Items.OfType<T>().FirstOrDefault(x => x.DisplayName == displayName);
+			if (item == null)
+			{
+				item = (T)Activator.CreateInstance(typeof(T));
+				item.Parent = this;
+				item.ConductWith(this);
+				item.DisplayName = displayName;
+				item.IsDirty = ++_createCount % 2 > 0;
+			}
+			return ActivateItemAsync(item, CancellationToken.None);
+		}
+
+		private string GetListItemName(object obj)
+		{
+			if (obj == null)
+				return "null";
+			else if (obj is IHaveDisplayName)
+				return ((IHaveDisplayName)obj).DisplayName;
+			else
+				return obj.GetType().Name;
+		}
+		private string GetListTypes(System.Collections.IList list)
+		{
+			if (list == null)
+				return "null";
+			else
+				return "[" + string.Join(",", list.Cast<object>().Select(x => GetListItemName(x))) + "]";
+		}
+
+		private void Items_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		{
+			Trace.TraceInformation($"{GetType().Name}.Items_CollectionChanged: Action={e.Action}, OldItems={GetListTypes(e.OldItems)}, OldStartingIndex={e.OldStartingIndex}, NewItems={GetListTypes(e.NewItems)}, NewStartingIndex={e.NewStartingIndex}");
+		}
+
+#if CALIBURN_ASYNC
+		// For Caliburn 4.0 or higher (asynchronous)
+		protected override Task OnDeactivateAsync(bool close, CancellationToken cancellationToken)
+		{
+			Trace.TraceInformation($"{GetType().Name}.OnDeactivateAsync: close={close}");
+			return base.OnDeactivateAsync(close, cancellationToken);
+		}
+
+		protected override Task OnInitializeAsync(CancellationToken cancellationToken)
+		{
+			Trace.TraceInformation($"{GetType().Name}.OnInitializeAsync");
+
+			Items.CollectionChanged += Items_CollectionChanged;
+			Task.Run(() => StartInitialDocuments());
+
+			return base.OnInitializeAsync(cancellationToken);
+		}
+#else
+		// For Caliburn 3.2 and lower (synchronous)
+		public Task ActivateItemAsync(Screen item, CancellationToken cancellationToken)
+		{
+			ActivateItem(item);
+			return Task.FromResult(0);
+		}
+
+		protected override void OnDeactivate(bool close)
+		{
+			Trace.TraceInformation($"{GetType().Name}.OnDeactivate: close={close}");
+			base.OnDeactivate(close);
+		}
+
+		protected override void OnInitialize()
+		{
+			Trace.TraceInformation($"{GetType().Name}.OnInitialize");
+
+			Task.Run(() => StartInitialDocuments());
+
+			base.OnInitialize();
+		}
+#endif
+
+		protected async Task StartInitialDocuments()
+		{
+			await Task.Delay(100);
+			await ActivateOrCreate<TestViewModel>("Test A");
+			await Task.Delay(100);
+			await ActivateOrCreate<TestViewModel>("Test B");
+			await Task.Delay(100);
+			await ActivateOrCreate<TestViewModel>("Test C");
+			await Task.Delay(100);
+			await ActivateOrCreate<TestViewModel>("Test D");
+		}
+	}
+}

--- a/source/CaliburnDockTestApp/ViewModels/TestViewModel.cs
+++ b/source/CaliburnDockTestApp/ViewModels/TestViewModel.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CaliburnDockTestApp.ViewModels
+{
+	public class TestViewModel : ViewModelBase
+	{
+	}
+}

--- a/source/CaliburnDockTestApp/ViewModels/ViewModelBase.cs
+++ b/source/CaliburnDockTestApp/ViewModels/ViewModelBase.cs
@@ -1,0 +1,95 @@
+﻿using Caliburn.Micro;
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace CaliburnDockTestApp.ViewModels
+{
+	public abstract class ViewModelBase : Screen
+	{
+		public ViewModelBase()
+		{
+			DisplayName = GetType().Name;
+		}
+
+		private bool _isDirty;
+
+		public bool IsDirty
+		{
+			get { return _isDirty; }
+			set { Set(ref _isDirty, value); }
+		}
+
+		private string _customText;
+
+		public string CustomText
+		{
+			get { return _customText; }
+			set
+			{
+				if (Set(ref _customText, value))
+					IsDirty = true;
+			}
+		}
+
+		private RelayCommand _closeCommand;
+
+		public RelayCommand CloseCommand
+		{
+			get
+			{
+				return _closeCommand
+					?? (_closeCommand = new RelayCommand(_ => TryCloseAsync(null)));
+			}
+		}
+
+		protected bool CanClosePrompt()
+		{
+			bool close = true;
+			if (IsDirty)
+			{
+				var result = MessageBox.Show($"Are you sure you want to close '{DisplayName}'?", DisplayName, MessageBoxButton.YesNo, MessageBoxImage.Question);
+				close = result == MessageBoxResult.Yes;
+			}
+			return close;
+		}
+
+#if CALIBURN_ASYNC
+		// For Caliburn 4.0 or higher (asynchronous)
+		public override Task<bool> CanCloseAsync(CancellationToken cancellationToken = default)
+		{
+			bool close = CanClosePrompt();
+			Trace.TraceInformation($"{GetType().Name}.CanCloseAsync: close={close}");
+			return Task.FromResult(close);
+		}
+
+		protected override Task OnDeactivateAsync(bool close, CancellationToken cancellationToken)
+		{
+			Trace.TraceInformation($"{GetType().Name}.OnDeactivateAsync: close={close}");
+			return base.OnDeactivateAsync(close, cancellationToken);
+		}
+#else
+		// For Caliburn 3.2 and lower (synchronous)
+		public Task TryCloseAsync(bool? dialogResult)
+		{
+			TryClose(dialogResult);
+			return Task.FromResult(dialogResult);
+		}
+
+		public override void CanClose(Action<bool> callback)
+		{
+			bool close = CanClosePrompt();
+			Trace.TraceInformation($"{GetType().Name}.CanClose: close={close}");
+			callback(close);
+		}
+
+		protected override void OnDeactivate(bool close)
+		{
+			Trace.TraceInformation($"{GetType().Name}.OnDeactivate: close={close}");
+			base.OnDeactivate(close);
+		}
+#endif
+	}
+}

--- a/source/CaliburnDockTestApp/Views/MainWindowView.xaml
+++ b/source/CaliburnDockTestApp/Views/MainWindowView.xaml
@@ -1,0 +1,148 @@
+﻿<Window x:Class="CaliburnDockTestApp.Views.MainWindowView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:cal="http://www.caliburnproject.org"
+        mc:Ignorable="d"
+        Title="Caliburn AvalonDock Test"
+        Height="450" Width="800">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary>
+                    <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+                    <Style x:Key="Flat">
+                        <Setter Property="Control.Background" Value="{x:Null}" />
+                        <Setter Property="Control.BorderBrush" Value="{x:Null}" />
+                        <Style.Triggers>
+                            <Trigger Property="Control.IsMouseOver" Value="True">
+                                <Setter Property="Control.Background" Value="{x:Null}" />
+                                <Setter Property="Control.BorderBrush" Value="{x:Null}" />
+                            </Trigger>
+                            <Trigger Property="Control.IsFocused" Value="True">
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </ResourceDictionary>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="1*"/>
+            <ColumnDefinition Width="1*"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <Menu Grid.Row="0" Grid.ColumnSpan="2">
+            <MenuItem Header="_Window">
+                <MenuItem Header="Window A" Command="{Binding ShowACommand}"/>
+                <MenuItem Header="Window B" Command="{Binding ShowBCommand}"/>
+                <MenuItem Header="Window C" Command="{Binding ShowCCommand}"/>
+            </MenuItem>
+        </Menu>
+
+        <Border Grid.Row="1" Grid.Column="0" Background="LightGray">
+            <TextBlock Text="AvalonDock" HorizontalAlignment="Center"/>
+        </Border>
+        <DockingManager x:Name="DockManager"
+                                   Grid.Row="2" Grid.Column="0"
+                                   ActiveContent="{Binding ActiveItem, Mode=TwoWay}"
+                                   DocumentsSource="{Binding Items}">
+            <DockingManager.DocumentHeaderTemplate>
+                <DataTemplate>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Ellipse x:Name="DirtyIndicator" Grid.Column="0" Height="6" Width="6" StrokeThickness="1" Stroke="Black" Fill="Red" SnapsToDevicePixels="True"
+                                 Visibility="{Binding Content.IsDirty, Converter={StaticResource BooleanToVisibilityConverter}, FallbackValue=Collapsed}" Margin="1,0,1,0"/>
+                        <TextBlock x:Name="TitleText" Grid.Column="1" Margin="1,0,1,0" MaxWidth="200"
+                                   Text="{Binding Content.DisplayName, FallbackValue=#ERROR#}"
+                                   ToolTip="{Binding Content.DisplayName}" TextTrimming="CharacterEllipsis"/>
+                    </Grid>
+                </DataTemplate>
+            </DockingManager.DocumentHeaderTemplate>
+            <DockingManager.LayoutItemTemplate>
+                <DataTemplate>
+                    <ContentControl cal:View.Model="{Binding Content}" IsTabStop="False"/>
+                </DataTemplate>
+            </DockingManager.LayoutItemTemplate>
+            <DockingManager.LayoutItemContainerStyle>
+                <Style TargetType="{x:Type LayoutItem}">
+                    <Setter Property="Title" Value="{Binding Model.DisplayName, Mode=OneWay}"/>
+                    <Setter Property="CloseCommand" Value="{Binding Model.CloseCommand}"/>
+                </Style>
+            </DockingManager.LayoutItemContainerStyle>
+        </DockingManager>
+
+        <Border Grid.Row="1" Grid.Column="1" Background="LightGray">
+            <TextBlock Text="TabControl" HorizontalAlignment="Center"/>
+        </Border>
+        <TabControl x:Name="TabManager"
+                    Grid.Row="2" Grid.Column="1"
+                    ItemsSource="{Binding Items}"
+                    SelectedItem="{Binding ActiveItem, Mode=TwoWay}">
+            <TabControl.ItemTemplate>
+                <DataTemplate>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <Ellipse x:Name="DirtyIndicator"
+                                 Grid.Column="0"
+                                 Height="6"
+                                 Width="6"
+                                 Fill="Red"
+                                 StrokeThickness="1"
+                                 Stroke="Black"
+                                 SnapsToDevicePixels="True"
+                                 Visibility="{Binding IsDirty, Converter={StaticResource BooleanToVisibilityConverter}, FallbackValue=Collapsed}"
+                                 Margin="1,0,1,0"/>
+                        <TextBlock x:Name="TitleText"
+                                   Grid.Column="1"
+                                   Margin="1,0,1,0"
+                                   MaxWidth="200"
+                                   Text="{Binding DisplayName, FallbackValue=#ERROR#}"
+                                   TextTrimming="CharacterEllipsis"
+                                   ToolTip="{Binding DisplayName}"/>
+                        <Button x:Name="CloseTabButton"
+                                Grid.Column="2"
+                                Margin="4,0,0,0"
+                                FontFamily="Marlett"
+                                Content="r"
+                                Command="{Binding CloseCommand}">
+                            <Button.Style>
+                                <Style TargetType="{x:Type Button}" BasedOn="{StaticResource Flat}">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType={x:Type TabItem}}}" Value="False">
+                                            <Setter Property="Visibility" Value="Hidden"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType={x:Type TabItem}}}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                        </Button>
+                    </Grid>
+                </DataTemplate>
+            </TabControl.ItemTemplate>
+            <TabControl.ContentTemplate>
+                <DataTemplate>
+                    <ContentControl cal:View.Model="{Binding}" IsTabStop="False"/>
+                </DataTemplate>
+            </TabControl.ContentTemplate>
+        </TabControl>
+
+    </Grid>
+</Window>

--- a/source/CaliburnDockTestApp/Views/MainWindowView.xaml.cs
+++ b/source/CaliburnDockTestApp/Views/MainWindowView.xaml.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace CaliburnDockTestApp.Views
+{
+	/// <summary>
+	/// Interaction logic for MainWindowView.xaml
+	/// </summary>
+	public partial class MainWindowView : Window
+	{
+		public MainWindowView()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/source/CaliburnDockTestApp/Views/TestView.xaml
+++ b/source/CaliburnDockTestApp/Views/TestView.xaml
@@ -1,0 +1,24 @@
+﻿<UserControl x:Class="CaliburnDockTestApp.Views.TestView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:CaliburnDockTestApp.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Label Grid.Row="0" Grid.Column="0">IsDirty</Label>
+        <CheckBox Grid.Row="0" Grid.Column="1" IsChecked="{Binding IsDirty}">Is Dirty</CheckBox>
+
+        <Label Grid.Row="1" Grid.Column="0">Custom Text</Label>
+        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding CustomText,UpdateSourceTrigger=PropertyChanged}"/>
+    </Grid>
+</UserControl>

--- a/source/CaliburnDockTestApp/Views/TestView.xaml.cs
+++ b/source/CaliburnDockTestApp/Views/TestView.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace CaliburnDockTestApp.Views
+{
+	/// <summary>
+	/// Interaction logic for TestView.xaml
+	/// </summary>
+	public partial class TestView : UserControl
+	{
+		public TestView()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/source/Components/AvalonDock/ReferenceEqualityComparer.cs
+++ b/source/Components/AvalonDock/ReferenceEqualityComparer.cs
@@ -1,0 +1,22 @@
+﻿/************************************************************************
+   AvalonDock
+
+   Copyright (C) 2007-2013 Xceed Software Inc.
+
+   This program is provided to you under the terms of the Microsoft Public
+   License (Ms-PL) as published at https://opensource.org/licenses/MS-PL
+ ************************************************************************/
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace AvalonDock
+{
+	public sealed class ReferenceEqualityComparer : IEqualityComparer, IEqualityComparer<object>
+	{
+		public static ReferenceEqualityComparer Default { get; } = new ReferenceEqualityComparer();
+
+		public new bool Equals(object x, object y) => ReferenceEquals(x, y);
+		public int GetHashCode(object obj) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
+	}
+}


### PR DESCRIPTION
This is the fix for #184 where the previous handler assumed the collection was cleared when the [`NotifyCollectionChangedAction.Reset`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.specialized.notifycollectionchangedaction) action was received. The new handler iterates through the collection to find which items were removed and then only removes those items.

I added a test for the `Reset` handling in the AutomationTest `AvalonDockTest` project. It creates several `Anchorables` and `Documents` and uses a `CustomObservableCollection` that raises the `Reset` notification. I also modified that project (`AvalonDockTest`) to the new `csproj` format because the reference to `AvalonDock` since it had the new file format. There was an issue with the Apartment STA, so I referenced a nuget project to help with that.

Finally, I added a new test project `CaliburnDockTestApp` that is a simplified version of my original test project [AvalonDockTestIssue](https://github.com/ryanvs/AvalonDockIssue).