### PR TITLE
Raise PropertyChanged notification when LayoutContent.IsFloating changes

### DIFF
--- a/source/Components/AvalonDock/Layout/LayoutContent.cs
+++ b/source/Components/AvalonDock/Layout/LayoutContent.cs
@@ -604,10 +604,13 @@ namespace AvalonDock.Layout
 				IsSelected = true;
 				IsActive = true;
 			}
-		}
 
-		/// <summary>Dock the content as document.</summary>
-		public void DockAsDocument()
+            // BD: 14.08.2020 raise IsFloating property changed
+            RaisePropertyChanged(nameof(IsFloating));
+        }
+
+        /// <summary>Dock the content as document.</summary>
+        public void DockAsDocument()
 		{
 			if (!(Root is LayoutRoot root)) throw new InvalidOperationException();
 			if (Parent is LayoutDocumentPane) return;
@@ -631,12 +634,15 @@ namespace AvalonDock.Layout
 			}
 			IsSelected = true;
 			IsActive = true;
-		}
 
-		/// <summary>
-		/// Re-dock the content to its previous container
-		/// </summary>
-		public void Dock()
+			// BD: 14.08.2020 raise IsFloating property changed
+			RaisePropertyChanged(nameof(IsFloating));
+        }
+
+        /// <summary>
+        /// Re-dock the content to its previous container
+        /// </summary>
+        public void Dock()
 		{
 			if (PreviousContainer != null)
 			{
@@ -667,13 +673,16 @@ namespace AvalonDock.Layout
 				InternalDock();
 
 			Root.CollectGarbage();
-		}
 
-		#endregion Public Methods
+			// BD: 14.08.2020 raise IsFloating property changed
+			RaisePropertyChanged(nameof(IsFloating));
+        }
 
-		#region Overrides
+        #endregion Public Methods
 
-		protected override void OnParentChanging(ILayoutContainer oldValue, ILayoutContainer newValue)
+        #region Overrides
+
+        protected override void OnParentChanging(ILayoutContainer oldValue, ILayoutContainer newValue)
 		{
 			if (oldValue != null) IsSelected = false;
 			//var root = Root;


### PR DESCRIPTION
Hi Dirk, that's first of series of small and hopefully safe PRs that I plan to do for changes in our fork to synchronize with main.

In this one we raise PropertyChanged for IsFloating property of LayoutContent which is read-only and indirectly changed when layout element is made floating or docked back to main window.
In our project there are places where we have bindings to IsFloating and they don't work as expected due to notifications not being sent.