### PR TITLE
Allow to serialize CanClose if set to true for LayoutAnchorable instance

### DIFF
--- a/source/Components/AvalonDock/Layout/LayoutAnchorable.cs
+++ b/source/Components/AvalonDock/Layout/LayoutAnchorable.cs
@@ -45,7 +45,9 @@ namespace AvalonDock.Layout
 		public LayoutAnchorable()
 		{
 			// LayoutAnchorable will hide by default, not close.
-			_canClose = false;
+			// BD: 14.08.2020 Inverting both _canClose and _canCloseDefault to false as anchorables are only hidden but not closed
+			//     That would allow CanClose to be properly serialized if set to true for an instance of LayoutAnchorable
+			_canClose = _canCloseDefault = false;
 		}
 
 		#endregion Constructors

--- a/source/Components/AvalonDock/Layout/LayoutContent.cs
+++ b/source/Components/AvalonDock/Layout/LayoutContent.cs
@@ -425,7 +425,10 @@ namespace AvalonDock.Layout
 
 		#region CanClose
 
-		internal bool _canClose = true;
+		// BD: 14.08.2020 added _canCloseDefault to properly implement inverting _canClose default value in inheritors (e.g. LayoutAnchorable)
+		//     Thus CanClose property will be serialized only when not equal to its default for given class
+		//     With previous code it was not possible to serialize CanClose if set to true for LayoutAnchorable instance
+		internal bool _canClose = true, _canCloseDefault = true;
 
 		public bool CanClose
 		{
@@ -557,7 +560,10 @@ namespace AvalonDock.Layout
 			if (FloatingHeight != 0.0) writer.WriteAttributeString(nameof(FloatingHeight), FloatingHeight.ToString(CultureInfo.InvariantCulture));
 
 			if (IsMaximized) writer.WriteAttributeString(nameof(IsMaximized), IsMaximized.ToString());
-			if (!CanClose) writer.WriteAttributeString(nameof(CanClose), CanClose.ToString());
+			// BD: 14.08.2020 changed to check CanClose value against the default in _canCloseDefault
+			//     thus CanClose property will be serialized only when not equal to its default for given class
+			//     With previous code it was not possible to serialize CanClose if set to true for LayoutAnchorable instance
+			if (CanClose != _canCloseDefault) writer.WriteAttributeString(nameof(CanClose), CanClose.ToString());
 			if (!CanFloat) writer.WriteAttributeString(nameof(CanFloat), CanFloat.ToString());
 
 			if (LastActivationTimeStamp != null) writer.WriteAttributeString(nameof(LastActivationTimeStamp), LastActivationTimeStamp.Value.ToString(CultureInfo.InvariantCulture));


### PR DESCRIPTION
Hi Dirk, this one is a bit more risky so leaving up to you to decide whether to accept.

The problem here is that with the original code in LayoutContent CanClose could be serialized only if its value is false. Now in LayoutAnchorable the default of CanClose is altered to false but if for some reason you would like to change CanClose to true for LayoutAnchorable (i.e. to make some tools closable by behaviour) it won't be possible to serialize that change because serialization code in LayoutContent class would serialize only if value is false.
I added another field _canCloseDefault in LayoutContent and in serialization code CanClose is checked against that value to decide whether to save it. In LayoutAnchorable _canClose value is set to false by default but so is _canCloseDefault and the serializer will now save if the value is true.
It should be all good but there is a side effect of that change. Now for LayoutAnchorables CanClose will no longer be saved in XML by default because it is false and value equals to its default. That's in contrast with previous implementation which always saved CanClose for LayoutAnchorables because it was false.