### PR TITLE
Handle CanClose and CanHide in XAML

### DIFF
--- a/source/Components/AvalonDock.Themes.Aero/Theme.xaml
+++ b/source/Components/AvalonDock.Themes.Aero/Theme.xaml
@@ -1059,9 +1059,22 @@
 							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
 						</MultiDataTrigger>
-						<DataTrigger Binding="{Binding Path=CanClose}" Value="false">
+						<!--BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true-->
+						<MultiDataTrigger>
+							<MultiDataTrigger.Conditions>
+								<Condition Binding="{Binding Path=CanClose}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide}" Value="true" />
+							</MultiDataTrigger.Conditions>
+							<Setter TargetName="DocumentCloseButton" Property="Command" Value="{Binding Path=LayoutItem.HideCommand, RelativeSource={RelativeSource TemplatedParent}}" />
+						</MultiDataTrigger>
+						<!--BD: 17.08.2020 hide button if both CanClose=false and CanHide=false-->
+						<MultiDataTrigger>
+							<MultiDataTrigger.Conditions>
+								<Condition Binding="{Binding Path=CanClose}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide}" Value="false" />
+							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Collapsed" />
-						</DataTrigger>
+						</MultiDataTrigger>
 
 
 					</ControlTemplate.Triggers>

--- a/source/Components/AvalonDock.Themes.Expression/Theme.xaml
+++ b/source/Components/AvalonDock.Themes.Expression/Theme.xaml
@@ -926,9 +926,22 @@
 						<Trigger Property="IsMouseOver" Value="True">
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
 						</Trigger>
-						<DataTrigger Binding="{Binding Path=CanClose}" Value="false">
+						<!--BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true-->
+						<MultiDataTrigger>
+							<MultiDataTrigger.Conditions>
+								<Condition Binding="{Binding Path=CanClose}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide}" Value="true" />
+							</MultiDataTrigger.Conditions>
+							<Setter TargetName="DocumentCloseButton" Property="Command" Value="{Binding Path=LayoutItem.HideCommand, RelativeSource={RelativeSource TemplatedParent}}" />
+						</MultiDataTrigger>
+						<!--BD: 17.08.2020 hide button if both CanClose=false and CanHide=false-->
+						<MultiDataTrigger>
+							<MultiDataTrigger.Conditions>
+								<Condition Binding="{Binding Path=CanClose}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide}" Value="false" />
+							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Collapsed" />
-						</DataTrigger>
+						</MultiDataTrigger>
 						<Trigger SourceName="DocumentCloseButton" Property="IsMouseOver" Value="True">
 							<Setter TargetName="PART_ImgPinClose" Property="Source" Value="/AvalonDock.Themes.Expression;component/Images/PinClose_Light.png" />
 						</Trigger>

--- a/source/Components/AvalonDock.Themes.Metro/Theme.xaml
+++ b/source/Components/AvalonDock.Themes.Metro/Theme.xaml
@@ -1088,9 +1088,22 @@
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
 							<Setter TargetName="PART_ImgPinClose" Property="Source" Value="Images/PinClose_Dark.png" />
 						</MultiDataTrigger>
-						<DataTrigger Binding="{Binding Path=CanClose}" Value="false">
+						<!--BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true-->
+						<MultiDataTrigger>
+							<MultiDataTrigger.Conditions>
+								<Condition Binding="{Binding Path=CanClose}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide}" Value="true" />
+							</MultiDataTrigger.Conditions>
+							<Setter TargetName="DocumentCloseButton" Property="Command" Value="{Binding Path=LayoutItem.HideCommand, RelativeSource={RelativeSource TemplatedParent}}" />
+						</MultiDataTrigger>
+						<!--BD: 17.08.2020 hide button if both CanClose=false and CanHide=false-->
+						<MultiDataTrigger>
+							<MultiDataTrigger.Conditions>
+								<Condition Binding="{Binding Path=CanClose}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide}" Value="false" />
+							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Collapsed" />
-						</DataTrigger>
+						</MultiDataTrigger>
 						<Trigger SourceName="DocumentCloseButton" Property="IsMouseOver" Value="True">
 							<Setter TargetName="PART_ImgPinClose" Property="Source" Value="Images/PinClose_Black.png" />
 						</Trigger>

--- a/source/Components/AvalonDock.Themes.VS2010/Theme.xaml
+++ b/source/Components/AvalonDock.Themes.VS2010/Theme.xaml
@@ -1134,9 +1134,22 @@
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
 							<Setter TargetName="PART_ImgPinClose" Property="Source" Value="Images/PinClose_Dark.png" />
 						</MultiDataTrigger>
-						<DataTrigger Binding="{Binding Path=CanClose}" Value="false">
+						<!--BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true-->
+						<MultiDataTrigger>
+							<MultiDataTrigger.Conditions>
+								<Condition Binding="{Binding Path=CanClose}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide}" Value="true" />
+							</MultiDataTrigger.Conditions>
+							<Setter TargetName="DocumentCloseButton" Property="Command" Value="{Binding Path=LayoutItem.HideCommand, RelativeSource={RelativeSource TemplatedParent}}" />
+						</MultiDataTrigger>
+						<!--BD: 17.08.2020 hide button if both CanClose=false and CanHide=false-->
+						<MultiDataTrigger>
+							<MultiDataTrigger.Conditions>
+								<Condition Binding="{Binding Path=CanClose}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide}" Value="false" />
+							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Collapsed" />
-						</DataTrigger>
+						</MultiDataTrigger>
 						<Trigger SourceName="DocumentCloseButton" Property="IsMouseOver" Value="True">
 							<Setter TargetName="PART_ImgPinClose" Property="Source" Value="Images/PinClose_Black.png" />
 						</Trigger>

--- a/source/Components/AvalonDock.Themes.VS2013/Themes/Generic.xaml
+++ b/source/Components/AvalonDock.Themes.VS2013/Themes/Generic.xaml
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 	************************************************************************
 	AvalonDock
 	
@@ -1425,9 +1425,22 @@
 						<DataTrigger Binding="{Binding Path=IsActive}" Value="true">
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
 						</DataTrigger>
-						<DataTrigger Binding="{Binding Path=CanClose}" Value="false">
+						<!--BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true-->
+						<MultiDataTrigger>
+							<MultiDataTrigger.Conditions>
+							<Condition Binding="{Binding Path=CanClose}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide}" Value="true" />
+							</MultiDataTrigger.Conditions>
+							<Setter TargetName="DocumentCloseButton" Property="Command" Value="{Binding Path=LayoutItem.HideCommand, RelativeSource={RelativeSource TemplatedParent}}" />
+						</MultiDataTrigger>
+						<!--BD: 17.08.2020 hide button if both CanClose=false and CanHide=false-->
+						<MultiDataTrigger>
+							<MultiDataTrigger.Conditions>
+								<Condition Binding="{Binding Path=CanClose}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide}" Value="false" />
+							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Collapsed" />
-						</DataTrigger>
+						</MultiDataTrigger>
 
 						<!--  Document Well : Tab : Button / Selected, inactive  -->
 						<MultiDataTrigger>

--- a/source/Components/AvalonDock/Controls/DocumentPaneDropTarget.cs
+++ b/source/Components/AvalonDock/Controls/DocumentPaneDropTarget.cs
@@ -506,7 +506,8 @@ namespace AvalonDock.Controls
 								checkPreviousContainer = false;
 							}
 
-							anchorableToImport.SetCanCloseInternal(true);
+							// BD: 17.08.2020 Remove that bodge and handle CanClose=false && CanHide=true in XAML
+							//anchorableToImport.SetCanCloseInternal(true);
 
 							paneModel.Children.Insert(i, anchorableToImport);
 							i++;

--- a/source/Components/AvalonDock/Controls/DocumentPaneGroupDropTarget.cs
+++ b/source/Components/AvalonDock/Controls/DocumentPaneGroupDropTarget.cs
@@ -99,7 +99,8 @@ namespace AvalonDock.Controls
 						int i = 0;
 						foreach (var anchorableToImport in layoutAnchorablePaneGroup.Descendents().OfType<LayoutAnchorable>().ToArray())
 						{
-							anchorableToImport.SetCanCloseInternal(true);
+							// BD: 18.07.2020 Remove that bodge and handle CanClose=false && CanHide=true in XAML
+							//anchorableToImport.SetCanCloseInternal(true);
 
 							paneModel.Children.Insert(i, anchorableToImport);
 							i++;

--- a/source/Components/AvalonDock/Controls/LayoutDocumentTabItem.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentTabItem.cs
@@ -210,7 +210,8 @@ namespace AvalonDock.Controls
 		private void StartDraggingFloatingWindowForContent()
 		{
 			ReleaseMouseCapture();
-			if (Model is LayoutAnchorable layoutAnchorable) layoutAnchorable.ResetCanCloseInternal();
+			// BD: 17.08.2020 Remove that bodge and handle CanClose=false && CanHide=true in XAML
+			//if (Model is LayoutAnchorable layoutAnchorable) layoutAnchorable.ResetCanCloseInternal();
 			var manager = Model.Root.Manager;
 			manager.StartDraggingFloatingWindowForContent(Model);
 		}

--- a/source/Components/AvalonDock/Layout/LayoutAnchorable.cs
+++ b/source/Components/AvalonDock/Layout/LayoutAnchorable.cs
@@ -1,4 +1,4 @@
-﻿/************************************************************************
+/************************************************************************
    AvalonDock
 
    Copyright (C) 2007-2013 Xceed Software Inc.
@@ -34,7 +34,8 @@ namespace AvalonDock.Layout
 		private bool _canHide = true;
 		private bool _canAutoHide = true;
 		private bool _canDockAsTabbedDocument = true;
-		private bool _canCloseValueBeforeInternalSet;
+		// BD: 17.08.2020 Remove that bodge and handle CanClose=false && CanHide=true in XAML
+		//private bool _canCloseValueBeforeInternalSet;
 		private bool _canMove = true;
 
 		#endregion fields
@@ -575,16 +576,17 @@ namespace AvalonDock.Layout
 			CloseInternal();
 		}
 
-		internal void SetCanCloseInternal(bool canClose)
-		{
-			_canCloseValueBeforeInternalSet = _canClose;
-			_canClose = canClose;
-		}
+		// BD: 17.08.2020 Remove that bodge and handle CanClose=false && CanHide=true in XAML
+		//internal void SetCanCloseInternal(bool canClose)
+		//{
+		//	_canCloseValueBeforeInternalSet = _canClose;
+		//	_canClose = canClose;
+		//}
 
-		internal void ResetCanCloseInternal()
-		{
-			_canClose = _canCloseValueBeforeInternalSet;
-		}
+		//internal void ResetCanCloseInternal()
+		//{
+		//	_canClose = _canCloseValueBeforeInternalSet;
+		//}
 
 		#endregion Internal Methods
 

--- a/source/Components/AvalonDock/Themes/generic.xaml
+++ b/source/Components/AvalonDock/Themes/generic.xaml
@@ -799,9 +799,22 @@
 							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
 						</MultiDataTrigger>
-						<DataTrigger Binding="{Binding Path=CanClose}" Value="false">
+						<!--BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true-->
+						<MultiDataTrigger>
+							<MultiDataTrigger.Conditions>
+								<Condition Binding="{Binding Path=CanClose}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide}" Value="true" />
+							</MultiDataTrigger.Conditions>
+							<Setter TargetName="DocumentCloseButton" Property="Command" Value="{Binding Path=LayoutItem.HideCommand, RelativeSource={RelativeSource TemplatedParent}}" />
+						</MultiDataTrigger>
+						<!--BD: 17.08.2020 hide button if both CanClose=false and CanHide=false-->
+						<MultiDataTrigger>
+							<MultiDataTrigger.Conditions>
+								<Condition Binding="{Binding Path=CanClose}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide}" Value="false" />
+							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Collapsed" />
-						</DataTrigger>
+						</MultiDataTrigger>
 					</ControlTemplate.Triggers>
 				</ControlTemplate>
 			</Setter.Value>


### PR DESCRIPTION
Here's another set of changes improving behavior when anchorable is docked in document area.
In original code there was a bodge using SetCanCloseInternal/ResetCanCloseInternal methods to store and restore CanClose state during window drag-drop operation. With my changes that bodge is removed and instead style for LayoutDocumentTabItem is improved in per theme XAMLs to react properly on CanClose = false and CanHide = true and use HideCommand instead of Close Command.