### PR TITLE
Added additional check in UpdateRowColDefinitions to avoid exception.

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutGridControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutGridControl.cs
@@ -1,4 +1,4 @@
-﻿/************************************************************************
+/************************************************************************
    AvalonDock
 
    Copyright (C) 2007-2013 Xceed Software Inc.
@@ -209,7 +209,8 @@ namespace AvalonDock.Controls
 			{
 				var iColumn = 0;
 				var iChild = 0;
-				for (var iChildModel = 0; iChildModel < _model.Children.Count; iChildModel++, iColumn++, iChild++)
+				// BD: 24.08.2020 added check for iChild against InternalChildren.Count
+				for (var iChildModel = 0; iChildModel < _model.Children.Count && iChild < InternalChildren.Count; iChildModel++, iColumn++, iChild++)
 				{
 					var childModel = _model.Children[iChildModel] as ILayoutPositionableElement;
 					ColumnDefinitions.Add(new ColumnDefinition
@@ -244,7 +245,8 @@ namespace AvalonDock.Controls
 			{
 				var iRow = 0;
 				var iChild = 0;
-				for (var iChildModel = 0; iChildModel < _model.Children.Count; iChildModel++, iRow++, iChild++)
+				// BD: 24.08.2020 added check for iChild against InternalChildren.Count
+				for (var iChildModel = 0; iChildModel < _model.Children.Count && iChild < InternalChildren.Count; iChildModel++, iRow++, iChild++)
 				{
 					var childModel = _model.Children[iChildModel] as ILayoutPositionableElement;
 					RowDefinitions.Add(new RowDefinition


### PR DESCRIPTION
With certain layouts (produced by our software) undocking an anchorable leads to following:

> System.ArgumentOutOfRangeException
>   HResult=0x80131502
>   Message=Specified argument was out of the range of valid values.
> Parameter name: index
>   Source=PresentationCore
>   StackTrace:
>    at System.Windows.Media.VisualCollection.get_Item(Int32 index)
>    at System.Windows.Controls.UIElementCollection.get_Item(Int32 index)
>    at AvalonDock.Controls.LayoutGridControl`1.UpdateRowColDefinitions() in C:\SOURCE\Tests\AvalonDock\Dirkster99\source\Components\AvalonDock\Controls\LayoutGridControl.cs:line 255
> 
>   This exception was originally thrown at this call stack:
>     [External Code]
>     AvalonDock.Controls.LayoutGridControl<T>.UpdateRowColDefinitions() in LayoutGridControl.cs
> 