### PR TITLE
Adding FallbAckValue to CanHide Binding to handle binding to a LayoutDocumentControl -> LayoutDocument (which does not implement a CanHide property).

### DIFF
--- a/source/Components/AvalonDock.Themes.Aero/Theme.xaml
+++ b/source/Components/AvalonDock.Themes.Aero/Theme.xaml
@@ -1059,20 +1059,20 @@
 							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
 						</MultiDataTrigger>
-						<!--BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true-->
+						<!--  BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true  -->
 						<MultiDataTrigger>
 							<MultiDataTrigger.Conditions>
 								<Condition Binding="{Binding Path=CanClose}" Value="false" />
-								<Condition Binding="{Binding Path=CanHide}" Value="true" />
+								<Condition Binding="{Binding Path=CanHide, FallbackValue=false}" Value="true" />
 							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Command" Value="{Binding Path=LayoutItem.HideCommand, RelativeSource={RelativeSource TemplatedParent}}" />
 							<Setter TargetName="DocumentCloseButton" Property="ToolTip" Value="{x:Static avalonDockProperties:Resources.Anchorable_Hide}" />
 						</MultiDataTrigger>
-						<!--BD: 17.08.2020 hide button if both CanClose=false and CanHide=false-->
+						<!--  BD: 17.08.2020 hide button if both CanClose=false and CanHide=false  -->
 						<MultiDataTrigger>
 							<MultiDataTrigger.Conditions>
 								<Condition Binding="{Binding Path=CanClose}" Value="false" />
-								<Condition Binding="{Binding Path=CanHide}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide, FallbackValue=false}" Value="false" />
 							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Collapsed" />
 						</MultiDataTrigger>

--- a/source/Components/AvalonDock.Themes.Expression/Theme.xaml
+++ b/source/Components/AvalonDock.Themes.Expression/Theme.xaml
@@ -926,20 +926,20 @@
 						<Trigger Property="IsMouseOver" Value="True">
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
 						</Trigger>
-						<!--BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true-->
+						<!--  BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true  -->
 						<MultiDataTrigger>
 							<MultiDataTrigger.Conditions>
 								<Condition Binding="{Binding Path=CanClose}" Value="false" />
-								<Condition Binding="{Binding Path=CanHide}" Value="true" />
+								<Condition Binding="{Binding Path=CanHide, FallbackValue=false}" Value="true" />
 							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Command" Value="{Binding Path=LayoutItem.HideCommand, RelativeSource={RelativeSource TemplatedParent}}" />
 							<Setter TargetName="DocumentCloseButton" Property="ToolTip" Value="{x:Static avalonDockProperties:Resources.Anchorable_Hide}" />
 						</MultiDataTrigger>
-						<!--BD: 17.08.2020 hide button if both CanClose=false and CanHide=false-->
+						<!--  BD: 17.08.2020 hide button if both CanClose=false and CanHide=false  -->
 						<MultiDataTrigger>
 							<MultiDataTrigger.Conditions>
 								<Condition Binding="{Binding Path=CanClose}" Value="false" />
-								<Condition Binding="{Binding Path=CanHide}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide, FallbackValue=false}" Value="false" />
 							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Collapsed" />
 						</MultiDataTrigger>

--- a/source/Components/AvalonDock.Themes.Metro/Brushes.xaml
+++ b/source/Components/AvalonDock.Themes.Metro/Brushes.xaml
@@ -1,11 +1,13 @@
-﻿<!--************************************************************************
+﻿<!--
+	************************************************************************
 	AvalonDock
 	
 	Copyright (C) 2007-2013 Xceed Software Inc.
 	
 	This program is provided to you under the terms of the Microsoft Public
 	License (Ms-PL) as published at https://opensource.org/licenses/MS-PL
-	************************************************************************-->
+	************************************************************************
+-->
 
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 

--- a/source/Components/AvalonDock.Themes.Metro/Theme.xaml
+++ b/source/Components/AvalonDock.Themes.Metro/Theme.xaml
@@ -1088,20 +1088,20 @@
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
 							<Setter TargetName="PART_ImgPinClose" Property="Source" Value="Images/PinClose_Dark.png" />
 						</MultiDataTrigger>
-						<!--BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true-->
+						<!--  BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true  -->
 						<MultiDataTrigger>
 							<MultiDataTrigger.Conditions>
 								<Condition Binding="{Binding Path=CanClose}" Value="false" />
-								<Condition Binding="{Binding Path=CanHide}" Value="true" />
+								<Condition Binding="{Binding Path=CanHide, FallbackValue=false}" Value="true" />
 							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Command" Value="{Binding Path=LayoutItem.HideCommand, RelativeSource={RelativeSource TemplatedParent}}" />
 							<Setter TargetName="DocumentCloseButton" Property="ToolTip" Value="{x:Static avalonDockProperties:Resources.Anchorable_Hide}" />
 						</MultiDataTrigger>
-						<!--BD: 17.08.2020 hide button if both CanClose=false and CanHide=false-->
+						<!--  BD: 17.08.2020 hide button if both CanClose=false and CanHide=false  -->
 						<MultiDataTrigger>
 							<MultiDataTrigger.Conditions>
 								<Condition Binding="{Binding Path=CanClose}" Value="false" />
-								<Condition Binding="{Binding Path=CanHide}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide, FallbackValue=false}" Value="false" />
 							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Collapsed" />
 						</MultiDataTrigger>

--- a/source/Components/AvalonDock.Themes.VS2010/Brushes.xaml
+++ b/source/Components/AvalonDock.Themes.VS2010/Brushes.xaml
@@ -1,158 +1,142 @@
-﻿<!--************************************************************************
-   AvalonDock
+﻿<!--
+	************************************************************************
+	AvalonDock
+	
+	Copyright (C) 2007-2013 Xceed Software Inc.
+	
+	This program is provided to you under the terms of the Microsoft Public
+	License (Ms-PL) as published at https://opensource.org/licenses/MS-PL
+	************************************************************************
+-->
 
-   Copyright (C) 2007-2013 Xceed Software Inc.
-
-   This program is provided to you under the terms of the Microsoft Public
-   License (Ms-PL) as published at https://opensource.org/licenses/MS-PL
- ************************************************************************-->
-
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
 
-    <DrawingBrush x:Key="AvalonDock_ThemeVS2010_BaseColor1" 
-                  TileMode="Tile"  
-                Viewport="0 0 5 5" 
-				ViewportUnits="Absolute" 
-				Stretch="None">
-        <DrawingBrush.Drawing>
-            <DrawingGroup>
-                <GeometryDrawing Brush="#2C3D5A">
-                    <GeometryDrawing.Geometry>
-                        <RectangleGeometry Rect="0,0,10,10"/>
-                    </GeometryDrawing.Geometry>
-                </GeometryDrawing>
-                <GeometryDrawing>
-                    <GeometryDrawing.Pen>
-                        <Pen Thickness="1" Brush="#35496A" />
-                    </GeometryDrawing.Pen>
-                    <GeometryDrawing.Geometry>
-                        <GeometryGroup>
-                            <LineGeometry StartPoint="0,0" EndPoint="10,10" />
-                        </GeometryGroup>
-                    </GeometryDrawing.Geometry>
-                </GeometryDrawing>
-                <GeometryDrawing>
-                    <GeometryDrawing.Pen>
-                        <Pen Thickness="1" Brush="#293955" />
-                    </GeometryDrawing.Pen>
-                    <GeometryDrawing.Geometry>
-                        <GeometryGroup>
-                            <LineGeometry StartPoint="1,0" EndPoint="10,9" />
-                        </GeometryGroup>
-                    </GeometryDrawing.Geometry>
-                </GeometryDrawing>
-            </DrawingGroup>
-        </DrawingBrush.Drawing>
-    </DrawingBrush>
+	<DrawingBrush
+		x:Key="AvalonDock_ThemeVS2010_BaseColor1"
+		Stretch="None"
+		TileMode="Tile"
+		Viewport="0 0 5 5"
+		ViewportUnits="Absolute">
+		<DrawingBrush.Drawing>
+			<DrawingGroup>
+				<GeometryDrawing Brush="#2C3D5A">
+					<GeometryDrawing.Geometry>
+						<RectangleGeometry Rect="0,0,10,10" />
+					</GeometryDrawing.Geometry>
+				</GeometryDrawing>
+				<GeometryDrawing>
+					<GeometryDrawing.Pen>
+						<Pen Brush="#35496A" Thickness="1" />
+					</GeometryDrawing.Pen>
+					<GeometryDrawing.Geometry>
+						<GeometryGroup>
+							<LineGeometry StartPoint="0,0" EndPoint="10,10" />
+						</GeometryGroup>
+					</GeometryDrawing.Geometry>
+				</GeometryDrawing>
+				<GeometryDrawing>
+					<GeometryDrawing.Pen>
+						<Pen Brush="#293955" Thickness="1" />
+					</GeometryDrawing.Pen>
+					<GeometryDrawing.Geometry>
+						<GeometryGroup>
+							<LineGeometry StartPoint="1,0" EndPoint="10,9" />
+						</GeometryGroup>
+					</GeometryDrawing.Geometry>
+				</GeometryDrawing>
+			</DrawingGroup>
+		</DrawingBrush.Drawing>
+	</DrawingBrush>
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor2" 
-                     Color="White"/>
+	<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor2" Color="White" />
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor3" 
-                     Color="Black"/>
+	<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor3" Color="Black" />
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor4" 
-                     Color="Transparent"/>
+	<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor4" Color="Transparent" />
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor5" 
-                     Color="#293955"/>
+	<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor5" Color="#293955" />
 
-    <LinearGradientBrush x:Key="AvalonDock_ThemeVS2010_BaseColor6"
-                         StartPoint="0,0"
-                         EndPoint="0,1">
-        <LinearGradientBrush.GradientStops>
-            <GradientStop Color="#50FFE8A6" Offset="0" />
-            <GradientStop Color="#50FFE8A6" Offset="0.5" />
-            <GradientStop Color="#50FFEDBA" Offset="0.5" />
-            <GradientStop Color="#50FFFCF2" Offset="1" />
-        </LinearGradientBrush.GradientStops>
-    </LinearGradientBrush>
+	<LinearGradientBrush x:Key="AvalonDock_ThemeVS2010_BaseColor6" StartPoint="0,0" EndPoint="0,1">
+		<LinearGradientBrush.GradientStops>
+			<GradientStop Offset="0" Color="#50FFE8A6" />
+			<GradientStop Offset="0.5" Color="#50FFE8A6" />
+			<GradientStop Offset="0.5" Color="#50FFEDBA" />
+			<GradientStop Offset="1" Color="#50FFFCF2" />
+		</LinearGradientBrush.GradientStops>
+	</LinearGradientBrush>
 
-    <LinearGradientBrush x:Key="AvalonDock_ThemeVS2010_BaseColor7"
-                         StartPoint="0,1"
-                         EndPoint="0,0">
-        <LinearGradientBrush.GradientStops>
-            <GradientStop Color="#FFCED4DB" Offset="0" />
-            <GradientStop Color="#FFD4DBE4" Offset="0.1" />
-            <GradientStop Color="#FFD4DDEA" Offset="0.5" />
-            <GradientStop Color="#FFC8D5E8" Offset="1" />
-        </LinearGradientBrush.GradientStops>
-    </LinearGradientBrush>
+	<LinearGradientBrush x:Key="AvalonDock_ThemeVS2010_BaseColor7" StartPoint="0,1" EndPoint="0,0">
+		<LinearGradientBrush.GradientStops>
+			<GradientStop Offset="0" Color="#FFCED4DB" />
+			<GradientStop Offset="0.1" Color="#FFD4DBE4" />
+			<GradientStop Offset="0.5" Color="#FFD4DDEA" />
+			<GradientStop Offset="1" Color="#FFC8D5E8" />
+		</LinearGradientBrush.GradientStops>
+	</LinearGradientBrush>
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor8"
-                     Color="White"/>
+	<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor8" Color="White" />
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor9"
-                     Color="#FFF5F4EA"/>
+	<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor9" Color="#FFF5F4EA" />
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor10" 
-                     Color="White"/>
+	<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor10" Color="White" />
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor11" 
-                     Color="#FFBBC0C7" />
+	<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor11" Color="#FFBBC0C7" />
 
-    <!--<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor12"
+	<!--<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor12"
                      Color="White"/>-->
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor13"
-                     Color="White"/>
+	<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor13" Color="White" />
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor14"
-                     Color="White"/>
+	<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor14" Color="White" />
 
-    <LinearGradientBrush x:Key="AvalonDock_ThemeVS2010_BaseColor15"
-                         StartPoint="0,0"
-                         EndPoint="0,1">
-        <GradientStop Color="#FFFCF2" Offset="0" />
-        <GradientStop Color="#FFEDBA" Offset="0.5" />
-        <GradientStop Color="#FFE8A6" Offset="0.5" />
-        <GradientStop Color="#FFE8A6" Offset="1" />
-    </LinearGradientBrush>
+	<LinearGradientBrush x:Key="AvalonDock_ThemeVS2010_BaseColor15" StartPoint="0,0" EndPoint="0,1">
+		<GradientStop Offset="0" Color="#FFFCF2" />
+		<GradientStop Offset="0.5" Color="#FFEDBA" />
+		<GradientStop Offset="0.5" Color="#FFE8A6" />
+		<GradientStop Offset="1" Color="#FFE8A6" />
+	</LinearGradientBrush>
 
 
-    <LinearGradientBrush x:Key="AvalonDock_ThemeVS2010_BaseColor16"
-                         StartPoint="0,0"
-                         EndPoint="0,1">
-        <GradientStop Color="#4D6082" Offset="0" />
-        <GradientStop Color="#3D5277" Offset="1" />
-    </LinearGradientBrush>
+	<LinearGradientBrush x:Key="AvalonDock_ThemeVS2010_BaseColor16" StartPoint="0,0" EndPoint="0,1">
+		<GradientStop Offset="0" Color="#4D6082" />
+		<GradientStop Offset="1" Color="#3D5277" />
+	</LinearGradientBrush>
 
-    <!--<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor17" 
+	<!--<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor17"
         Color="White"/>
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor18" 
+    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor18"
         Color="Black"/>
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor20" 
+    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor20"
                      Color="White"/>
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor21" 
+    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor21"
         Color="White"/>
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor22" 
+    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor22"
         Color="Black"/>
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor23" 
+    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor23"
         Color="Black"/>-->
 
 
-    <LinearGradientBrush x:Key="AvalonDock_ThemeVS2010_BaseColor24" StartPoint="0,0" EndPoint="0,1">
-        <GradientStop Color="#FBFCFC" Offset="0" />
-        <GradientStop Color="#D7DCE4" Offset="0.5" />
-        <GradientStop Color="#CED4DF" Offset="0.5" />
-        <GradientStop Color="#CED4DF" Offset="1" />
-    </LinearGradientBrush>
+	<LinearGradientBrush x:Key="AvalonDock_ThemeVS2010_BaseColor24" StartPoint="0,0" EndPoint="0,1">
+		<GradientStop Offset="0" Color="#FBFCFC" />
+		<GradientStop Offset="0.5" Color="#D7DCE4" />
+		<GradientStop Offset="0.5" Color="#CED4DF" />
+		<GradientStop Offset="1" Color="#CED4DF" />
+	</LinearGradientBrush>
 
-    <LinearGradientBrush x:Key="AvalonDock_ThemeVS2010_BaseColor25" StartPoint="0,0" EndPoint="0,1">
-        <GradientStop Color="#FFFCF2" Offset="0" />
-        <GradientStop Color="#FFEDBA" Offset="0.5" />
-        <GradientStop Color="#FFE8A6" Offset="0.5" />
-        <GradientStop Color="#FFE8A6" Offset="1" />
-    </LinearGradientBrush>
+	<LinearGradientBrush x:Key="AvalonDock_ThemeVS2010_BaseColor25" StartPoint="0,0" EndPoint="0,1">
+		<GradientStop Offset="0" Color="#FFFCF2" />
+		<GradientStop Offset="0.5" Color="#FFEDBA" />
+		<GradientStop Offset="0.5" Color="#FFE8A6" />
+		<GradientStop Offset="1" Color="#FFE8A6" />
+	</LinearGradientBrush>
 
-    <!--<LinearGradientBrush x:Key="AvalonDock_ThemeVS2010_BaseColor26" StartPoint="0,0" EndPoint="0,1">
+	<!--<LinearGradientBrush x:Key="AvalonDock_ThemeVS2010_BaseColor26" StartPoint="0,0" EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStop Color="#50FFE8A6" Offset="0" />
             <GradientStop Color="#50FFE8A6" Offset="0.5" />
@@ -171,18 +155,14 @@
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>-->
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor28"
-                         Color="White"/>
+	<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor28" Color="White" />
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor30" 
-        Color="#CED4DF"/>
+	<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor30" Color="#CED4DF" />
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor31" 
-        Color="#FFE8A6"/>
+	<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor31" Color="#FFE8A6" />
 
-    <!--<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor32"
+	<!--<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor32"
                      Color="Transparent"/>-->
 
-    <SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor33"
-        Color="#3D5277"/>    
+	<SolidColorBrush x:Key="AvalonDock_ThemeVS2010_BaseColor33" Color="#3D5277" />
 </ResourceDictionary>

--- a/source/Components/AvalonDock.Themes.VS2010/Theme.xaml
+++ b/source/Components/AvalonDock.Themes.VS2010/Theme.xaml
@@ -1134,20 +1134,20 @@
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
 							<Setter TargetName="PART_ImgPinClose" Property="Source" Value="Images/PinClose_Dark.png" />
 						</MultiDataTrigger>
-						<!--BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true-->
+						<!--  BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true  -->
 						<MultiDataTrigger>
 							<MultiDataTrigger.Conditions>
 								<Condition Binding="{Binding Path=CanClose}" Value="false" />
-								<Condition Binding="{Binding Path=CanHide}" Value="true" />
+								<Condition Binding="{Binding Path=CanHide, FallbackValue=false}" Value="true" />
 							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Command" Value="{Binding Path=LayoutItem.HideCommand, RelativeSource={RelativeSource TemplatedParent}}" />
 							<Setter TargetName="DocumentCloseButton" Property="ToolTip" Value="{x:Static avalonDockProperties:Resources.Anchorable_Hide}" />
 						</MultiDataTrigger>
-						<!--BD: 17.08.2020 hide button if both CanClose=false and CanHide=false-->
+						<!--  BD: 17.08.2020 hide button if both CanClose=false and CanHide=false  -->
 						<MultiDataTrigger>
 							<MultiDataTrigger.Conditions>
 								<Condition Binding="{Binding Path=CanClose}" Value="false" />
-								<Condition Binding="{Binding Path=CanHide}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide, FallbackValue=false}" Value="false" />
 							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Collapsed" />
 						</MultiDataTrigger>

--- a/source/Components/AvalonDock.Themes.VS2013/Themes/Generic.xaml
+++ b/source/Components/AvalonDock.Themes.VS2013/Themes/Generic.xaml
@@ -68,7 +68,10 @@
 		Re-styling this in AvalonDock since the menu on the drop-down button for more documents is otherwise black
 		BugFix for Issue http://avalondock.codeplex.com/workitem/15743
 	-->
-	<Style x:Key="AvalonDockThemeVs2013MenuItemStyle" BasedOn="{StaticResource {x:Type MenuItem}}" TargetType="{x:Type MenuItem}">
+	<Style
+		x:Key="AvalonDockThemeVs2013MenuItemStyle"
+		BasedOn="{StaticResource {x:Type MenuItem}}"
+		TargetType="{x:Type MenuItem}">
 		<Setter Property="HeaderTemplate" Value="{Binding Path=Root.Manager.DocumentPaneMenuItemHeaderTemplate}" />
 		<Setter Property="HeaderTemplateSelector" Value="{Binding Path=Root.Manager.DocumentPaneMenuItemHeaderTemplateSelector}" />
 		<Setter Property="BorderThickness" Value="0" />
@@ -1425,20 +1428,20 @@
 						<DataTrigger Binding="{Binding Path=IsActive}" Value="true">
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
 						</DataTrigger>
-						<!--BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true-->
+						<!--  BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true  -->
 						<MultiDataTrigger>
 							<MultiDataTrigger.Conditions>
-							<Condition Binding="{Binding Path=CanClose}" Value="false" />
-								<Condition Binding="{Binding Path=CanHide}" Value="true" />
+								<Condition Binding="{Binding Path=CanClose}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide, FallbackValue=false}" Value="true" />
 							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Command" Value="{Binding Path=LayoutItem.HideCommand, RelativeSource={RelativeSource TemplatedParent}}" />
 							<Setter TargetName="DocumentCloseButton" Property="ToolTip" Value="{x:Static avalonDockProperties:Resources.Anchorable_Hide}" />
 						</MultiDataTrigger>
-						<!--BD: 17.08.2020 hide button if both CanClose=false and CanHide=false-->
+						<!--  BD: 17.08.2020 hide button if both CanClose=false and CanHide=false  -->
 						<MultiDataTrigger>
 							<MultiDataTrigger.Conditions>
 								<Condition Binding="{Binding Path=CanClose}" Value="false" />
-								<Condition Binding="{Binding Path=CanHide}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide, FallbackValue=false}" Value="false" />
 							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Collapsed" />
 						</MultiDataTrigger>

--- a/source/Components/AvalonDock/Themes/generic.xaml
+++ b/source/Components/AvalonDock/Themes/generic.xaml
@@ -799,20 +799,20 @@
 							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
 						</MultiDataTrigger>
-						<!--BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true-->
+						<!--  BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true  -->
 						<MultiDataTrigger>
 							<MultiDataTrigger.Conditions>
 								<Condition Binding="{Binding Path=CanClose}" Value="false" />
-								<Condition Binding="{Binding Path=CanHide}" Value="true" />
+								<Condition Binding="{Binding Path=CanHide, FallbackValue=false}" Value="true" />
 							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Command" Value="{Binding Path=LayoutItem.HideCommand, RelativeSource={RelativeSource TemplatedParent}}" />
 							<Setter TargetName="DocumentCloseButton" Property="ToolTip" Value="{x:Static avalonDockProperties:Resources.Anchorable_Hide}" />
 						</MultiDataTrigger>
-						<!--BD: 17.08.2020 hide button if both CanClose=false and CanHide=false-->
+						<!--  BD: 17.08.2020 hide button if both CanClose=false and CanHide=false  -->
 						<MultiDataTrigger>
 							<MultiDataTrigger.Conditions>
 								<Condition Binding="{Binding Path=CanClose}" Value="false" />
-								<Condition Binding="{Binding Path=CanHide}" Value="false" />
+								<Condition Binding="{Binding Path=CanHide, FallbackValue=false}" Value="false" />
 							</MultiDataTrigger.Conditions>
 							<Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Collapsed" />
 						</MultiDataTrigger>


### PR DESCRIPTION
Test Expectation:
1) Set `CanClose=False `on `LayoutDocumentItem` will make the Documents (x) button invisible
2) Set `CanClose=True `on `LayoutDocumentItem` will make the Documents (x) button visible and clicking on the (X) button will execute the `CloseCommand` (if bound)
