### PR TITLE
Add to LayoutDocument CanHide property returning false

### DIFF
--- a/source/Components/AvalonDock/Layout/LayoutDocument.cs
+++ b/source/Components/AvalonDock/Layout/LayoutDocument.cs
@@ -42,6 +42,9 @@ namespace AvalonDock.Layout
 			}
 		}
 
+		/// <summary>Documents can't be just hidden so always return false.</summary>
+		public bool CanHide => false;
+
 		/// <summary>Gets whether a document is visible or not.</summary>
 		public bool IsVisible
 		{


### PR DESCRIPTION
Hi Dirk, here's my alternative idea for fixing #196. Adding CanHide always returning false to LayoutDocument seems safe change. That would also avoid Binding warnings that would otherwise occur due to missing property in LayoutDocument:
`System.Windows.Data Warning: 40 : BindingExpression path error: 'CanHide' property not found on 'object' ''LayoutDocument' (HashCode=42353227)'. BindingExpression:Path=CanHide; DataItem='LayoutDocument' (HashCode=42353227); target element is 'LayoutDocumentTabItem' (Name=''); target property is 'NoTarget' (type 'Object')
`