### PR TITLE
Migrate from netcoreapp3.0 to net5.0-windows

### DIFF
--- a/source/AutomationTest/AvalonDockTest/AvalonDockTest.csproj
+++ b/source/AutomationTest/AvalonDockTest/AvalonDockTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net452</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;net452</TargetFrameworks>
     <ProjectGuid>{FE4E16A2-876A-4356-9974-8A89C50B2A5A}</ProjectGuid>
     <RootNamespace>AvalonDockTest</RootNamespace>
     <AssemblyName>AvalonDockTest</AssemblyName>

--- a/source/AutomationTest/AvalonDockTest/AvalonDockTest.csproj
+++ b/source/AutomationTest/AvalonDockTest/AvalonDockTest.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0-windows;net452</TargetFrameworks>
     <ProjectGuid>{FE4E16A2-876A-4356-9974-8A89C50B2A5A}</ProjectGuid>
     <RootNamespace>AvalonDockTest</RootNamespace>
     <AssemblyName>AvalonDockTest</AssemblyName>

--- a/source/CaliburnDockTestApp/CaliburnDockTestApp.csproj
+++ b/source/CaliburnDockTestApp/CaliburnDockTestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>netcoreapp3.0;net4.5.2</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;net4.5.2</TargetFrameworks>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 

--- a/source/CaliburnDockTestApp/CaliburnDockTestApp.csproj
+++ b/source/CaliburnDockTestApp/CaliburnDockTestApp.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net5.0-windows;net4.5.2</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0-windows;net452</TargetFrameworks>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 

--- a/source/Components/AvalonDock.Themes.Aero/AvalonDock.Themes.Aero.csproj
+++ b/source/Components/AvalonDock.Themes.Aero/AvalonDock.Themes.Aero.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <RootNamespace>AvalonDock.Themes</RootNamespace>
-    <TargetFrameworks>net5.0-windows;net4</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0-windows;net40</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/source/Components/AvalonDock.Themes.Aero/AvalonDock.Themes.Aero.csproj
+++ b/source/Components/AvalonDock.Themes.Aero/AvalonDock.Themes.Aero.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <RootNamespace>AvalonDock.Themes</RootNamespace>
-    <TargetFrameworks>netcoreapp3.0;net4</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;net4</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/source/Components/AvalonDock.Themes.Expression/AvalonDock.Themes.Expression.csproj
+++ b/source/Components/AvalonDock.Themes.Expression/AvalonDock.Themes.Expression.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <RootNamespace>AvalonDock.Themes</RootNamespace>
-    <TargetFrameworks>net5.0-windows;net4</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0-windows;net40</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/source/Components/AvalonDock.Themes.Expression/AvalonDock.Themes.Expression.csproj
+++ b/source/Components/AvalonDock.Themes.Expression/AvalonDock.Themes.Expression.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <RootNamespace>AvalonDock.Themes</RootNamespace>
-    <TargetFrameworks>netcoreapp3.0;net4</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;net4</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/source/Components/AvalonDock.Themes.Metro/AvalonDock.Themes.Metro.csproj
+++ b/source/Components/AvalonDock.Themes.Metro/AvalonDock.Themes.Metro.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <RootNamespace>AvalonDock.Themes</RootNamespace>
-    <TargetFrameworks>netcoreapp3.0;net4</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;net4</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/source/Components/AvalonDock.Themes.Metro/AvalonDock.Themes.Metro.csproj
+++ b/source/Components/AvalonDock.Themes.Metro/AvalonDock.Themes.Metro.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <RootNamespace>AvalonDock.Themes</RootNamespace>
-    <TargetFrameworks>net5.0-windows;net4</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0-windows;net40</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -19,7 +19,7 @@
     <Authors>https://github.com/Dirkster99/AvalonDock</Authors>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Resource Include="**\*.png" />
   </ItemGroup>

--- a/source/Components/AvalonDock.Themes.VS2010/AvalonDock.Themes.VS2010.csproj
+++ b/source/Components/AvalonDock.Themes.VS2010/AvalonDock.Themes.VS2010.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <RootNamespace>AvalonDock.Themes</RootNamespace>
-    <TargetFrameworks>net5.0-windows;net4</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0-windows;net40</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/source/Components/AvalonDock.Themes.VS2010/AvalonDock.Themes.VS2010.csproj
+++ b/source/Components/AvalonDock.Themes.VS2010/AvalonDock.Themes.VS2010.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <RootNamespace>AvalonDock.Themes</RootNamespace>
-    <TargetFrameworks>netcoreapp3.0;net4</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;net4</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/source/Components/AvalonDock.Themes.VS2013/AvalonDock.Themes.VS2013.csproj
+++ b/source/Components/AvalonDock.Themes.VS2013/AvalonDock.Themes.VS2013.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <RootNamespace>AvalonDock.Themes</RootNamespace>
-    <TargetFrameworks>net5.0-windows;net4</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0-windows;net40</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/source/Components/AvalonDock.Themes.VS2013/AvalonDock.Themes.VS2013.csproj
+++ b/source/Components/AvalonDock.Themes.VS2013/AvalonDock.Themes.VS2013.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <RootNamespace>AvalonDock.Themes</RootNamespace>
-    <TargetFrameworks>netcoreapp3.0;net4</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;net4</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/source/Components/AvalonDock/AvalonDock.csproj
+++ b/source/Components/AvalonDock/AvalonDock.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <RootNamespace>AvalonDock</RootNamespace>
-    <TargetFrameworks>net5.0-windows;net4</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0-windows;net40</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>

--- a/source/Components/AvalonDock/AvalonDock.csproj
+++ b/source/Components/AvalonDock/AvalonDock.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <RootNamespace>AvalonDock</RootNamespace>
-    <TargetFrameworks>netcoreapp3.0;net4</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;net4</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
@@ -19,7 +19,7 @@
     <Authors>https://github.com/Dirkster99/AvalonDock</Authors>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net.5.0-windows|AnyCPU'">
     <DefineConstants />
   </PropertyGroup>
 

--- a/source/MLibTest/MLibTest/MLibTest.csproj
+++ b/source/MLibTest/MLibTest/MLibTest.csproj
@@ -1,12 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>netcoreapp3.0;net4.5.2</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;net4.5.2</TargetFrameworks>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net5.0-windows|AnyCPU'">
     <DefineConstants />
   </PropertyGroup>
 
@@ -15,7 +15,7 @@
     <None Remove="Demos\Images\property-blue.png" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0-windows'">
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
       <Version>1.1.19</Version>
     </PackageReference>

--- a/source/MLibTest/MLibTest/MLibTest.csproj
+++ b/source/MLibTest/MLibTest/MLibTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net5.0-windows;net4.5.2</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0-windows;net452</TargetFrameworks>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 
@@ -20,6 +20,12 @@
       <Version>1.1.19</Version>
     </PackageReference>
   </ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+		<PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
+			<Version>1.1.19</Version>
+		</PackageReference>
+	</ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Dirkster.ColorPickerLib" Version="1.6.0" />

--- a/source/MLibTest/MLibTest_Components/ServiceLocator/ServiceLocator.csproj
+++ b/source/MLibTest/MLibTest_Components/ServiceLocator/ServiceLocator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net4.5</TargetFrameworks>
+    <TargetFrameworks>net5.0;net4.5</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/source/MLibTest/MLibTest_Components/ServiceLocator/ServiceLocator.csproj
+++ b/source/MLibTest/MLibTest_Components/ServiceLocator/ServiceLocator.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net4.5</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0;net45</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/source/MLibTest/MLibTest_Components/Settings/SettingsModel/SettingsModel.csproj
+++ b/source/MLibTest/MLibTest_Components/Settings/SettingsModel/SettingsModel.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net4.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
@@ -10,7 +10,13 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net4.0'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="System.Security.Cryptography.ProtectedData">
+			<Version>4.6.0</Version>
+		</PackageReference>
+	</ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
     <Reference Include="System.Security"/>
   </ItemGroup>
 

--- a/source/MLibTest/MLibTest_Components/Settings/SettingsModel/SettingsModel.csproj
+++ b/source/MLibTest/MLibTest_Components/Settings/SettingsModel/SettingsModel.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net4.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net4.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="System.Security.Cryptography.ProtectedData">
       <Version>4.6.0</Version>
     </PackageReference>

--- a/source/MVVMTestApp/MVVMTestApp.csproj
+++ b/source/MVVMTestApp/MVVMTestApp.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net5.0-windows;net4</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0-windows;net40</TargetFrameworks>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 

--- a/source/MVVMTestApp/MVVMTestApp.csproj
+++ b/source/MVVMTestApp/MVVMTestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>netcoreapp3.0;net4</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;net4</TargetFrameworks>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 

--- a/source/TestApp/TestApp.csproj
+++ b/source/TestApp/TestApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
     <PropertyGroup>
         <RootNamespace>TestApp</RootNamespace>
-        <TargetFrameworks>netcoreapp3.0;net40</TargetFrameworks>
+        <TargetFrameworks>net5.0-windows;net40</TargetFrameworks>
         <UseWPF>true</UseWPF>
         <UseWindowsForms>true</UseWindowsForms>
         <ApplicationIcon />

--- a/source/TestApp/TestApp.csproj
+++ b/source/TestApp/TestApp.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
     <PropertyGroup>
         <RootNamespace>TestApp</RootNamespace>
-        <TargetFrameworks>net5.0-windows;net40</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.0;net5.0-windows;net40</TargetFrameworks>
         <UseWPF>true</UseWPF>
         <UseWindowsForms>true</UseWindowsForms>
         <ApplicationIcon />

--- a/source/WinFormsTestApp/WinFormsTestApp.csproj
+++ b/source/WinFormsTestApp/WinFormsTestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net5.0-windows;net4.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0-windows;net40</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <StartupObject>AvalonDock.WinFormsTestApp.Program</StartupObject>

--- a/source/WinFormsTestApp/WinFormsTestApp.csproj
+++ b/source/WinFormsTestApp/WinFormsTestApp.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>netcoreapp3.0;net4.0</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;net4.0</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <StartupObject>AvalonDock.WinFormsTestApp.Program</StartupObject>


### PR DESCRIPTION
This PR aims to migrate Dirkster.AvalonDock from targetting netcoreapp3.0 to net5.0 and net5.0-windows.

Fixes #213

The first step of changing target framework is done and everything seems to work. However there are lots of warnings and I have not yet checked if they are present in netcoreapp3.0. We might want to do more maintenance work. 

Let me know what you think when you have tried it out. 