### PR TITLE
Revert "Issue 163: IsSelected vs IsActive behavior changed from 3.x to 4.1/4.2"

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutDocumentPaneControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentPaneControl.cs
@@ -68,14 +68,6 @@ namespace AvalonDock.Controls
 
 		#region Overrides
 
-		/*protected override void OnSelectionChanged(SelectionChangedEventArgs e)
-		{
-			base.OnSelectionChanged(e);
-
-			if (_model.SelectedContent != null)
-				_model.SelectedContent.IsActive = true;
-		}*/
-		
 		/// <summary>
 		/// Invoked when an unhandled <see cref="System.Windows.UIElement.MouseLeftButtonDown"/> routed
 		/// event is raised on this element. Implement this method to add class handling


### PR DESCRIPTION
Reverts Dirkster99/AvalonDock#243

I tested the test specification in  #243 before merging the Pull Request and after Merging it an found no difference in the outlined behavior:

> to reproduce the issue:
>
> Open the MVVM example, select the "Aero" theme (makes the steps in the ui easier)
> Open 2 documents. the 2 documents are displayed in 2 distinct tabs (correct)
> Change documents by clicking on the tab header, outside the text label (with aero theme, click on the spline on the left part of > the tab). The displayed tab changes (correct), the lower toolwindow (display of the document properties) does not change (incorrect).
> The lower toolwindow is bound on the ActiveDocument (defined by the "IsActive" flag), the displayed tab is based on the "IsSelected" flag.

So, I am sorry (should have test this more carefully - dahh ... - ) but I am gone have to revert this :-(