### PR TITLE
Fixing problems with tests running with XUnit StaFact

### DIFF
--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -1882,9 +1882,7 @@ namespace AvalonDock
 		/// <param name="e"></param>
 		private static void OnContextMenuPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		{
-			if (d.Dispatcher.CheckAccess() && 
-			    e.NewValue is ContextMenu contextMenu && 
-			    contextMenu.Dispatcher.CheckAccess())
+			if (e.NewValue is ContextMenu contextMenu)
 			{
 				contextMenu.Resources = ((DockingManager)d).Resources;
 			}

--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -1882,7 +1882,9 @@ namespace AvalonDock
 		/// <param name="e"></param>
 		private static void OnContextMenuPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		{
-			if (e.NewValue is ContextMenu contextMenu)
+			if (d.Dispatcher.CheckAccess() && 
+			    e.NewValue is ContextMenu contextMenu && 
+			    contextMenu.Dispatcher.CheckAccess())
 			{
 				contextMenu.Resources = ((DockingManager)d).Resources;
 			}

--- a/source/Components/AvalonDock/Themes/generic.xaml
+++ b/source/Components/AvalonDock/Themes/generic.xaml
@@ -662,8 +662,8 @@
 		<Setter Property="AnchorableHeaderTemplate" Value="{StaticResource AnchorableHeaderTemplate}" />
 		<Setter Property="DocumentTitleTemplate" Value="{StaticResource DocumentTitleTemplate}" />
 		<Setter Property="AnchorableTitleTemplate" Value="{StaticResource AnchorableTitleTemplate}" />
-		<Setter Property="AnchorableContextMenu" Value="{StaticResource AnchorableContextMenu}" />
-		<Setter Property="DocumentContextMenu" Value="{StaticResource DocumentContextMenu}" />
+		<Setter Property="AnchorableContextMenu" Value="{DynamicResource AnchorableContextMenu}" />
+		<Setter Property="DocumentContextMenu" Value="{DynamicResource DocumentContextMenu}" />
 		<Setter Property="DocumentPaneMenuItemHeaderTemplate" Value="{StaticResource DocumentHeaderTemplate}" />
 		<Setter Property="IconContentTemplate" Value="{StaticResource IconContentTemplate}" />
 		<Setter Property="Template">


### PR DESCRIPTION
I ran into a problem where my tests were failing when updating to version 4.30.0 or later. I got an exception in `DockingManager.OnContextMenuPropertyChanged()`. It was introduced as part of 
#170 to solve a problem with the context menu.

[Here](https://github.com/Dirkster99/AvalonDock/commit/64b30e7c548a5d764dbdfc93eafd529aa769b527#diff-3d578478402a239252f3c6d75949ba698d45443ddadb187191f58fc1249bb9b6R1802) is a link to the specific change (you will have to expand the diff of DockingManager to see the row).

My problem is that I'm running tests with the DockingManager in XUnit with [StaFact](https://github.com/AArnott/Xunit.StaFact). StaFact makes sure that the tests run on on STA thread. But it doesn't guarantee that all tests within a class runs on the _same_ STA thread. Hence `d` will have the test thread's dispatcher, but for some reason the `contextMenu` will have a dispatcher from a thread from a previous test (from within the same test class).

This is a hack (and I'm not sure if it should be merged) but the only way I can think of resolving this right now. @LyonJack (or someone else) do you have any ideas why the context menu end up on another thread? Is it somehow reused for multiple docking managers? Dependency properties are static so I can see how that could happen.