### PR TITLE
Optional show hidden LayoutAnchorable on hover

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutAnchorControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorControl.cs
@@ -138,6 +138,7 @@ namespace AvalonDock.Controls
 		{
 			base.OnMouseEnter(e);
 
+			// If the model wants to auto-show itself on hover then initiate the show action
 			if (!e.Handled && _model.CanShowOnHover)
 			{
 				_openUpTimer = new DispatcherTimer(DispatcherPriority.ApplicationIdle);

--- a/source/Components/AvalonDock/Controls/LayoutAnchorControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorControl.cs
@@ -138,7 +138,7 @@ namespace AvalonDock.Controls
 		{
 			base.OnMouseEnter(e);
 
-			if (!e.Handled)
+			if (!e.Handled && _model.CanShowOnHover)
 			{
 				_openUpTimer = new DispatcherTimer(DispatcherPriority.ApplicationIdle);
 				_openUpTimer.Interval = TimeSpan.FromMilliseconds(400);

--- a/source/Components/AvalonDock/Layout/LayoutContent.cs
+++ b/source/Components/AvalonDock/Layout/LayoutContent.cs
@@ -466,6 +466,13 @@ namespace AvalonDock.Layout
 
 		private bool _canShowOnHover = true;
 
+		/// <summary>
+		/// Set to false to disable the behavior of auto-showing
+		/// a <see cref="LayoutAnchorableControl"/> on mouse over.
+		/// When true, hovering the mouse over an anchorable tab 
+		/// will cause the anchorable to show itself.
+		/// </summary>
+		/// <remarks>Defaults to true</remarks>
 		public bool CanShowOnHover
 		{
 			get => _canShowOnHover;

--- a/source/Components/AvalonDock/Layout/LayoutContent.cs
+++ b/source/Components/AvalonDock/Layout/LayoutContent.cs
@@ -462,6 +462,23 @@ namespace AvalonDock.Layout
 
 		#endregion CanFloat
 
+		#region CanShowOnHover
+
+		private bool _canShowOnHover = true;
+
+		public bool CanShowOnHover
+		{
+			get => _canShowOnHover;
+			set
+			{
+				if (value == _canShowOnHover) return;
+				_canShowOnHover = value;
+				RaisePropertyChanged(nameof(CanShowOnHover));
+			}
+		}
+
+		#endregion CanShowOnHover
+
 		#region IsEnabled
 
 		private bool _isEnabled = true;
@@ -531,6 +548,8 @@ namespace AvalonDock.Layout
 				CanFloat = bool.Parse(reader.Value);
 			if (reader.MoveToAttribute(nameof(LastActivationTimeStamp)))
 				LastActivationTimeStamp = DateTime.Parse(reader.Value, CultureInfo.InvariantCulture);
+			if (reader.MoveToAttribute(nameof(CanShowOnHover)))
+				CanShowOnHover = bool.Parse(reader.Value);
 
 			reader.Read();
 		}
@@ -569,6 +588,8 @@ namespace AvalonDock.Layout
 			if (!CanFloat) writer.WriteAttributeString(nameof(CanFloat), CanFloat.ToString());
 
 			if (LastActivationTimeStamp != null) writer.WriteAttributeString(nameof(LastActivationTimeStamp), LastActivationTimeStamp.Value.ToString(CultureInfo.InvariantCulture));
+
+			if (!CanShowOnHover) writer.WriteAttributeString(nameof(CanShowOnHover), CanShowOnHover.ToString());
 
 			if (_previousContainer is ILayoutPaneSerializable paneSerializable)
 			{

--- a/source/TestApp/MainWindow.xaml
+++ b/source/TestApp/MainWindow.xaml
@@ -121,7 +121,6 @@
                         <LayoutAnchorablePane>
                             <LayoutAnchorable
                                 Title="Tool Window 1"
-                                CanShowOnHover="True"
                                 ContentId="toolWindow1"
                                 Hiding="OnToolWindow1Hiding">
                                 <StackPanel MinHeight="450">

--- a/source/TestApp/MainWindow.xaml
+++ b/source/TestApp/MainWindow.xaml
@@ -121,6 +121,7 @@
                         <LayoutAnchorablePane>
                             <LayoutAnchorable
                                 Title="Tool Window 1"
+                                CanShowOnHover="True"
                                 ContentId="toolWindow1"
                                 Hiding="OnToolWindow1Hiding">
                                 <StackPanel MinHeight="450">


### PR DESCRIPTION
For our use case we would like the option to not auto-show a LayoutAnchorable
on mouse over (via mouse enter). This adds a new property to provide an option
to disable the auto-show behavior. Serialization support included.

Is there a better way to handle this?