### PR TITLE
Support custom styles for LayoutGridResizerControl

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutGridControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutGridControl.cs
@@ -290,7 +290,21 @@ namespace AvalonDock.Controls
 		{
 			for (var iChild = 1; iChild < Children.Count; iChild++)
 			{
-				Children.Insert(iChild, new LayoutGridResizerControl { Cursor = this.Orientation == Orientation.Horizontal ? Cursors.SizeWE : Cursors.SizeNS });
+				var splitter = new LayoutGridResizerControl();
+
+				if (Orientation == Orientation.Horizontal)
+				{
+					splitter.Cursor = Cursors.SizeWE;
+					splitter.Style = _model.Root?.Manager?.GridSplitterVerticalStyle;
+				}
+				else
+				{
+					splitter.Cursor = Cursors.SizeNS;
+					splitter.Style = _model.Root?.Manager?.GridSplitterHorizontalStyle;
+				}
+
+
+				Children.Insert(iChild, splitter);
 				// TODO: MK Is this a bug????
 				iChild++;
 			}

--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -1104,6 +1104,59 @@ namespace AvalonDock
 
 		#endregion GridSplitterHeight
 
+		#region GridSplitterVerticalStyle
+
+		/// <summary>
+		/// GridSplitterVerticalStyle Dependency Property
+		/// </summary>
+		public static readonly DependencyProperty GridSplitterVerticalStyleProperty = DependencyProperty.Register("GridSplitterVerticalStyle", typeof(Style), typeof(DockingManager),
+				new FrameworkPropertyMetadata((Style)null));
+
+		/// <summary>
+		/// Gets or sets the GridSplitterVerticalStyle property.  This dependency property 
+		/// indicates the style to apply to the LayoutGridResizerControl when displayed vertically.
+		/// </summary>
+		public Style GridSplitterVerticalStyle
+		{
+			get
+			{
+				return (Style)GetValue(GridSplitterVerticalStyleProperty);
+			}
+			set
+			{
+				SetValue(GridSplitterVerticalStyleProperty, value);
+			}
+		}
+
+		#endregion
+
+		#region GridSplitterHorizontalStyle
+
+		/// <summary>
+		/// GridSplitterHorizontalStyle Dependency Property
+		/// </summary>
+		public static readonly DependencyProperty GridSplitterHorizontalStyleProperty = DependencyProperty.Register("GridSplitterHorizontalStyle", typeof(Style), typeof(DockingManager),
+				new FrameworkPropertyMetadata((Style)null));
+
+		/// <summary>
+		/// Gets or sets the GridSplitterHorizontalStyle property.  This dependency property 
+		/// indicates the style to apply to the LayoutGridResizerControl when displayed horizontally.
+		/// </summary>
+		public Style GridSplitterHorizontalStyle
+		{
+			get
+			{
+				return (Style)GetValue(GridSplitterHorizontalStyleProperty);
+			}
+			set
+			{
+				SetValue(GridSplitterHorizontalStyleProperty, value);
+			}
+		}
+
+		#endregion
+
+
 		#region DocumentPaneMenuItemHeaderTemplate
 
 		/// <summary><see cref="DocumentPaneMenuItemHeaderTemplate"/> dependency property.</summary>


### PR DESCRIPTION
**Summary**
This change adds support for specifying a custom style to be used for the generated vertical and horizontal grid resizers.

**Description of the Problem**
Although it is possible to apply a default style to all instances of the LayoutGridResizerControl, our styling team had the desire to apply a custom style to only the vertical style.  This was not currently possible, since there were no existing hooks for setting the style for this control. 

**Proposed Solution**
This code adds properties to allow custom styles to be specified for either the vertical or horizontal LayoutGridResizerControl that is created.  If the property is not set, the code will behave as before.