### PR TITLE
Support minimizing floating windows independently of main window

### DIFF
--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -1560,7 +1560,8 @@ namespace AvalonDock
 				{
 					//Owner = Window.GetWindow(this)
 				};
-				newFW.SetParentToMainWindowOf(this);
+				
+				newFW.UpdateOwnership();
 
 				// Fill list before calling Show (issue #254)
 				_fwList.Add(newFW);
@@ -1603,7 +1604,8 @@ namespace AvalonDock
 				{
 					//Owner = Window.GetWindow(this)
 				};
-				newFW.SetParentToMainWindowOf(this);
+				
+				newFW.UpdateOwnership();
 
 				// Fill list before calling Show (issue #254)
 				_fwList.Add(newFW);


### PR DESCRIPTION
The current behavior treats all the windows as a group.  Minimizing the main window will cause all the floating windows to be minimized.  Also, if you minimize a floating window, it is minimized but then is immediately restored.

Our users requested that the they have the ability to minimize the windows independently.  This is because they may need to minimize a single window that is in the way of another window, but they do not necessarily want to minimize all the other windows for the app.

In order to support this, this change adds 2 properties to the `LayoutFloatingWindowControl`:
- `AllowMinimize` which determines whether a floating window can be minimized.  Setting this to 'true' enables the ability to minimize the floating window while leaving the main window as it is.
- `OwnedByDockingManagerWindow` which determines whether the window is "owned" by the main window.  This determines whether the floating window should automatically minimize when the main window does or whether it should be left as is.

By separating it into 2 properties, developers have more control based on their specific needs.  

The default value for each property is set to leave the current behavior unchanged.