### PR TITLE
Rename pt-BR to pt

### DIFF
--- a/source/Components/AvalonDock/Properties/Resources.pt.resx
+++ b/source/Components/AvalonDock/Properties/Resources.pt.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 


### PR DESCRIPTION
Some of our Portuguese users reported that they were seeing the strings in English, instead of Portuguese.

It appears that the branch has marked the Portuguese resource strings as 'pt-BR', which would be fine if there was a also a file for 'pt' to use as the fallback for Portuguese.  Since we don't have another resource file for Portuguese, we would like to move the Brazilian Portuguese translations to be the default for Portuguese.

