### PR TITLE
Fix close from taskbar for floating window

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
@@ -1,4 +1,4 @@
-﻿/************************************************************************
+/************************************************************************
    AvalonDock
 
    Copyright (C) 2007-2013 Xceed Software Inc.
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Interop;
 
 namespace AvalonDock.Controls
 {
@@ -140,6 +141,17 @@ namespace AvalonDock.Controls
 							WindowChrome.GetWindowChrome(this).ShowSystemMenu = !handled;
 						else
 							WindowChrome.GetWindowChrome(this).ShowSystemMenu = false;
+					}
+					break;
+
+				case Win32Helper.WM_CLOSE:
+					if (CloseInitiatedByUser)
+					{
+						// We want to force the window to go through our standard logic for closing.
+						// So, if the window close is initiated outside of our code (such as from the taskbar),
+						// we cancel that close and trigger our close logic instead.
+						this.CloseWindowCommand.Execute(null);
+						handled = true;
 					}
 					break;
 			}

--- a/source/Components/AvalonDock/Win32Helper.cs
+++ b/source/Components/AvalonDock/Win32Helper.cs
@@ -1,4 +1,4 @@
-﻿/************************************************************************
+/************************************************************************
    AvalonDock
 
    Copyright (C) 2007-2013 Xceed Software Inc.
@@ -153,6 +153,7 @@ namespace AvalonDock
 		internal const int WM_INITMENUPOPUP = 0x0117;
 		internal const int WM_KEYDOWN = 0x0100;
 		internal const int WM_KEYUP = 0x0101;
+		internal const int WM_CLOSE = 0x10;
 
 		internal const int WA_INACTIVE = 0x0000;
 


### PR DESCRIPTION
This is a fix for Issue #287 

When configured to display floating windows in the taskbar, the close button in the taskbar does not function.  This is because it calls the Window.Close method directly and bypasses the close logic that is used elsewhere in the application.

This fix watches for the close event and forces it to use the normal logic.