### PR TITLE
281 floating window host: UI automation name

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -14,6 +14,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Documents;
@@ -701,6 +702,7 @@ namespace AvalonDock.Controls
 				});
 
 				_rootPresenter = new Border { Child = new AdornerDecorator { Child = Content }, Focusable = true };
+				AutomationProperties.SetName(_rootPresenter, "FloatingWindowHost");
 				_rootPresenter.SetBinding(Border.BackgroundProperty, new Binding(nameof(Background)) { Source = _owner });
 				_wpfContentHost.RootVisual = _rootPresenter;
 				_manager = _owner.Model.Root.Manager;


### PR DESCRIPTION
Fixed #281 

Location: LayoutFloatingWindowControl.cs

The issue was fixed by specifying the UI Automation name for the root visual in the host control. This causes the GenericRootAutomationPeer to default to getting that value instead of trying to use the Win32 API to get the value of a (possibly disposed) window.

I was not able to figure out how to solve the root cause which is caused by GCHandles to the Border (RootVisual) still hanging around after the window is closed. Since the UI Automation uses WeakReferences to check which elements are still alive, this issue could also be solved by clearing all references to the RootVisual object, but that is easier said than done.

I was not able to reproduce the issue with a simple UI that I can share. Probably this issue is caused by some unfortunate interactions between our UI Style library and AvalonDock - so the complex interactions of large systems.

Anyway, the fix seems low risk, so I hope you can accept it.