### PR TITLE
Fix NavigatorWindow not working if there is only one document

### DIFF
--- a/source/Components/AvalonDock/Controls/NavigatorWindow.cs
+++ b/source/Components/AvalonDock/Controls/NavigatorWindow.cs
@@ -58,15 +58,19 @@ namespace AvalonDock.Controls
 			SetAnchorables(_manager.Layout.Descendents().OfType<LayoutAnchorable>().Where(a => a.IsVisible).Select(d => (LayoutAnchorableItem)_manager.GetLayoutItemFromModel(d)).ToArray());
 			SetDocuments(_manager.Layout.Descendents().OfType<LayoutDocument>().OrderByDescending(d => d.LastActivationTimeStamp.GetValueOrDefault()).Select(d => (LayoutDocumentItem)_manager.GetLayoutItemFromModel(d)).ToArray());
 			_internalSetSelectedDocument = false;
-			if (Documents.Length > 1)
+			if (Documents.Length > 0)
 			{
-				InternalSetSelectedDocument(Documents[1]);
+				InternalSetSelectedDocument(Documents[0]);
 				_isSelectingDocument = true;
 			}
-			else if (Anchorables.Count() > 1)
+			else
 			{
-				InternalSetSelectedAnchorable(Anchorables.ToArray()[1]);
-				_isSelectingDocument = false;
+				var anchorable = Anchorables.FirstOrDefault();
+				if (anchorable != null)
+				{
+					InternalSetSelectedAnchorable(anchorable);
+					_isSelectingDocument = false;
+				}
 			}
 			DataContext = this;
 			Loaded += OnLoaded;


### PR DESCRIPTION
See https://github.com/icsharpcode/ILSpy/issues/2577.

The issue is that NavigatorWindow expects at least two documents and/or anchorables, otherwise it will not focus the listbox(es) correctly and further not allow the user to switch between documents/anchorables. The only way to exit the window is by using a mouse. However, some people may not be able to use a mouse or might use tools (e.g. Screen Readers, Voice Commands) that work solely by emulating key presses.