### PR TITLE
Aded LayoutItem null check when processing mouseMiddleClickButton

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutDocumentTabItem.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentTabItem.cs
@@ -182,7 +182,11 @@ namespace AvalonDock.Controls
 		/// <inheritdoc />
 		protected override void OnMouseDown(MouseButtonEventArgs e)
 		{
-			if (e.ChangedButton == MouseButton.Middle && LayoutItem.CloseCommand.CanExecute(null)) LayoutItem.CloseCommand.Execute(null);
+			if (LayoutItem != null && e.ChangedButton == MouseButton.Middle && LayoutItem.CloseCommand.CanExecute(null))
+			{
+				LayoutItem.CloseCommand.Execute(null);
+			}
+			
 			base.OnMouseDown(e);
 		}
 


### PR DESCRIPTION
Just added a nullcheck before invoking the close command. Also added braces to the if statement for clarity.