### PR TITLE
Fix per-monitor DPI related issues 

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -613,6 +613,7 @@ namespace AvalonDock.Controls
 			Left = mousePosition.X - DragDelta.X;                 // BugFix Issue #6
 			Top = mousePosition.Y - DragDelta.Y;
 			_attachDrag = false;
+			Show();
 			var lParam = new IntPtr(((int)mousePosition.X & 0xFFFF) | ((int)mousePosition.Y << 16));
 			Win32Helper.SendMessage(windowHandle, Win32Helper.WM_NCLBUTTONDOWN, new IntPtr(Win32Helper.HT_CAPTION), lParam);
 		}

--- a/source/Components/AvalonDock/Controls/LayoutGridControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutGridControl.cs
@@ -637,7 +637,7 @@ namespace AvalonDock.Controls
 				Left = ptTopLeftScreen.X,
 				Top = ptTopLeftScreen.Y,
 				ShowActivated = false,
-				//Owner = Window.GetWindow(this),
+				Owner = Window.GetWindow(this),
 				Content = panelHostResizer
 			};
 			_resizerWindowHost.Loaded += (s, e) => _resizerWindowHost.SetParentToMainWindowOf(this);

--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -2091,6 +2091,7 @@ namespace AvalonDock
 		{
 			if (_overlayWindow == null)
 				_overlayWindow = new OverlayWindow(this);
+			_overlayWindow.Owner = Window.GetWindow(this);
 			var rectWindow = new Rect(this.PointToScreenDPIWithoutFlowDirection(new Point()), this.TransformActualSizeToAncestor());
 			_overlayWindow.Left = rectWindow.Left;
 			_overlayWindow.Top = rectWindow.Top;


### PR DESCRIPTION
Fix per-monitor DPI related issues noted in https://github.com/Dirkster99/AvalonDock/issues/321
* Incorrect splitter placement on high dpi monitor, 
* incorrect docking overlay placement on high dpi monitor, 
* window undocked by dragging does not show until drag complete on high dpi monitor

The first two require the owner window to be set to ensure that the newly created window is assigned to the same screen (and hence the same DPI scaling) as the main docking window, otherwise the position/size that has been set up is interpreted wrongly by windows.

The third seems to be some sort of order of window events received thing. Comparing the order of callbacks and windows messages in dragging out the same window on normal and high DPI, the ordering was different and WM_SHOWWINDOW never showed up for the high dpi case, which gave the idea of adding a call to 'Show' which seems to fix the problem. Unfortunately I don't have a full understanding of what is going on in this case.