### PR TITLE
A more complete fix to per-monitor DPI issues

### DIFF
--- a/source/Components/AvalonDock/Controls/DragService.cs
+++ b/source/Components/AvalonDock/Controls/DragService.cs
@@ -1,4 +1,4 @@
-﻿/************************************************************************
+/************************************************************************
    AvalonDock
 
    Copyright (C) 2007-2013 Xceed Software Inc.
@@ -85,13 +85,14 @@ namespace AvalonDock.Controls
 		internal void UpdateMouseLocation(Point dragPosition)
 		{
 			////var floatingWindowModel = _floatingWindow.Model as LayoutFloatingWindow;
+			// TODO - pass in without DPI adjustment, screen co-ords, adjust inside the target window
 
-			var newHost = _overlayWindowHosts.FirstOrDefault(oh => oh.HitTest(dragPosition));
+			var newHost = _overlayWindowHosts.FirstOrDefault(oh => oh.HitTestScreen(dragPosition));
 
 			if (_currentHost != null || _currentHost != newHost)
 			{
 				//is mouse still inside current overlay window host?
-				if ((_currentHost != null && !_currentHost.HitTest(dragPosition)) ||
+				if ((_currentHost != null && !_currentHost.HitTestScreen(dragPosition)) ||
 					_currentHost != newHost)
 				{
 					//esit drop target
@@ -125,7 +126,7 @@ namespace AvalonDock.Controls
 				return;
 
 			if (_currentDropTarget != null &&
-				!_currentDropTarget.HitTest(dragPosition))
+				!_currentDropTarget.HitTestScreen(dragPosition))
 			{
 				_currentWindow.DragLeave(_currentDropTarget);
 				_currentDropTarget = null;
@@ -134,8 +135,9 @@ namespace AvalonDock.Controls
 			List<IDropArea> areasToRemove = new List<IDropArea>();
 			_currentWindowAreas.ForEach(a =>
 			{
+				
 				//is mouse still inside this area?
-				if (!a.DetectionRect.Contains(dragPosition))
+				if (!a.DetectionRect.Contains(a.TransformToDeviceDPI(dragPosition)))
 				{
 					_currentWindow.DragLeave(a);
 					areasToRemove.Add(a);
@@ -146,7 +148,7 @@ namespace AvalonDock.Controls
 				_currentWindowAreas.Remove(a));
 
 			var areasToAdd =
-				_currentHost.GetDropAreas(_floatingWindow).Where(cw => !_currentWindowAreas.Contains(cw) && cw.DetectionRect.Contains(dragPosition)).ToList();
+				_currentHost.GetDropAreas(_floatingWindow).Where(cw => !_currentWindowAreas.Contains(cw) && cw.DetectionRect.Contains(cw.TransformToDeviceDPI(dragPosition))).ToList();
 
 			_currentWindowAreas.AddRange(areasToAdd);
 
@@ -160,7 +162,7 @@ namespace AvalonDock.Controls
 					if (_currentDropTarget != null)
 						return;
 
-					_currentDropTarget = _currentWindow.GetTargets().FirstOrDefault(dt => dt.HitTest(dragPosition));
+					_currentDropTarget = _currentWindow.GetTargets().FirstOrDefault(dt => dt.HitTestScreen(dragPosition));
 
 					if (_currentDropTarget != null)
 					{
@@ -185,6 +187,7 @@ namespace AvalonDock.Controls
 		/// is docked into a new visual tree position).</param>
 		internal void Drop(Point dropLocation, out bool dropHandled)
 		{
+			// TODO - pass in without DPI adjustment, screen co-ords, adjust inside the target window
 			dropHandled = false;
 
 			UpdateMouseLocation(dropLocation);

--- a/source/Components/AvalonDock/Controls/DropArea.cs
+++ b/source/Components/AvalonDock/Controls/DropArea.cs
@@ -1,4 +1,4 @@
-﻿/************************************************************************
+/************************************************************************
    AvalonDock
 
    Copyright (C) 2007-2013 Xceed Software Inc.
@@ -36,6 +36,8 @@ namespace AvalonDock.Controls
 
 		/// <summary> Gets the type of drop area for this drop target.</summary>
 		DropAreaType Type { get; }
+
+		Point TransformToDeviceDPI(Point dragPosition);
 	}
 
 	/// <inheritdoc />
@@ -69,6 +71,11 @@ namespace AvalonDock.Controls
 
 		/// <inheritdoc />
 		public DropAreaType Type { get; }
+
+		public Point TransformToDeviceDPI(Point dragPosition)
+		{
+			return AreaElement.TransformToDeviceDPI(dragPosition);
+		}
 
 		#endregion IDropArea
 

--- a/source/Components/AvalonDock/Controls/DropTarget.cs
+++ b/source/Components/AvalonDock/Controls/DropTarget.cs
@@ -1,4 +1,4 @@
-﻿/************************************************************************
+/************************************************************************
    AvalonDock
 
    Copyright (C) 2007-2013 Xceed Software Inc.
@@ -105,6 +105,11 @@ namespace AvalonDock.Controls
 		#endregion Overrides
 
 		#region Public Methods
+
+		public bool HitTestScreen(Point dragPoint)
+		{
+			return HitTest(_targetElement.TransformToDeviceDPI(dragPoint));
+		}
 
 		public void Drop(LayoutFloatingWindow floatingWindow)
 		{

--- a/source/Components/AvalonDock/Controls/IDropTarget.cs
+++ b/source/Components/AvalonDock/Controls/IDropTarget.cs
@@ -1,4 +1,4 @@
-﻿/************************************************************************
+/************************************************************************
    AvalonDock
 
    Copyright (C) 2007-2013 Xceed Software Inc.
@@ -48,7 +48,7 @@ namespace AvalonDock.Controls
 		/// <summary>Determines whether the <paramref name="dragPoint"/> is part of this drop target or not.</summary>
 		/// <param name="dragPoint">The point to test.</param>
 		/// <returns><c>true</c> if it is inside the target.</returns>
-		bool HitTest(Point dragPoint);
+		bool HitTestScreen(Point dragPoint);
 
 		/// <summary>
 		/// Method is invoked to complete a drag & drop operation with a (new) docking position

--- a/source/Components/AvalonDock/Controls/IOverlayWindowHost.cs
+++ b/source/Components/AvalonDock/Controls/IOverlayWindowHost.cs
@@ -1,4 +1,4 @@
-﻿/************************************************************************
+/************************************************************************
    AvalonDock
 
    Copyright (C) 2007-2013 Xceed Software Inc.
@@ -36,7 +36,7 @@ namespace AvalonDock.Controls
 		/// </summary>
 		/// <param name="dragPoint">The point to test.</param>
 		/// <returns><c>true</c> if inside window, otherwise <c>false</c>.</returns>
-		bool HitTest(Point dragPoint);
+		bool HitTestScreen(Point dragPoint);
 
 		/// <summary>
 		/// Is invoked by the <see cref="DragService"/> of a <see cref="LayoutFloatingWindowControl"/>

--- a/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -156,12 +156,13 @@ namespace AvalonDock.Controls
 			_dropAreas = null;
 			_overlayWindow.Owner = null;
 			_overlayWindow.HideDropTargets();
+			_overlayWindow.Close();
+			_overlayWindow = null;
 		}
 
 		IOverlayWindow IOverlayWindowHost.ShowOverlayWindow(LayoutFloatingWindowControl draggingWindow)
 		{
 			CreateOverlayWindow();
-			_overlayWindow.Owner = draggingWindow;
 			_overlayWindow.EnableDropTargets();
 			_overlayWindow.Show();
 			return _overlayWindow;
@@ -297,6 +298,7 @@ namespace AvalonDock.Controls
 		private void CreateOverlayWindow()
 		{
 			if (_overlayWindow == null) _overlayWindow = new OverlayWindow(this);
+			_overlayWindow.Owner = Window.GetWindow(this);
 			var rectWindow = new Rect(this.PointToScreenDPIWithoutFlowDirection(new Point()), this.TransformActualSizeToAncestor());
 			_overlayWindow.Left = rectWindow.Left;
 			_overlayWindow.Top = rectWindow.Top;

--- a/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -1,4 +1,4 @@
-﻿/************************************************************************
+/************************************************************************
    AvalonDock
 
    Copyright (C) 2007-2013 Xceed Software Inc.
@@ -140,7 +140,12 @@ namespace AvalonDock.Controls
 
 		#region IOverlayWindowHost
 
-		bool IOverlayWindowHost.HitTest(Point dragPoint)
+		bool IOverlayWindowHost.HitTestScreen(Point dragPoint)
+		{
+			return HitTest(this.TransformToDeviceDPI(dragPoint));
+		}
+
+		bool HitTest(Point dragPoint)
 		{
 			var detectionRect = new Rect(this.PointToScreenDPIWithoutFlowDirection(new Point()), this.TransformActualSizeToAncestor());
 			return detectionRect.Contains(dragPoint);

--- a/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
@@ -228,6 +228,7 @@ namespace AvalonDock.Controls
 		private void CreateOverlayWindow()
 		{
 			if (_overlayWindow == null) _overlayWindow = new OverlayWindow(this);
+			_overlayWindow.Owner = Window.GetWindow(this);
 			var rectWindow = new Rect(this.PointToScreenDPIWithoutFlowDirection(new Point()), this.TransformActualSizeToAncestor());
 			_overlayWindow.Left = rectWindow.Left;
 			_overlayWindow.Top = rectWindow.Top;
@@ -238,7 +239,6 @@ namespace AvalonDock.Controls
 		IOverlayWindow IOverlayWindowHost.ShowOverlayWindow(LayoutFloatingWindowControl draggingWindow)
 		{
 			CreateOverlayWindow();
-			_overlayWindow.Owner = draggingWindow;
 			_overlayWindow.EnableDropTargets();
 			_overlayWindow.Show();
 			return _overlayWindow;
@@ -249,6 +249,8 @@ namespace AvalonDock.Controls
 			_dropAreas = null;
 			_overlayWindow.Owner = null;
 			_overlayWindow.HideDropTargets();
+			_overlayWindow.Close();
+			_overlayWindow = null;
 		}
 
 		public IEnumerable<IDropArea> GetDropAreas(LayoutFloatingWindowControl draggingWindow)

--- a/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
@@ -210,7 +210,12 @@ namespace AvalonDock.Controls
 			base.OnClosing(e);
 		}
 
-		bool IOverlayWindowHost.HitTest(Point dragPoint)
+		bool IOverlayWindowHost.HitTestScreen(Point dragPoint)
+		{
+			return HitTest(this.TransformToDeviceDPI(dragPoint));
+		}
+
+		bool HitTest(Point dragPoint)
 		{
 			var detectionRect = new Rect(this.PointToScreenDPIWithoutFlowDirection(new Point()), this.TransformActualSizeToAncestor());
 			return detectionRect.Contains(dragPoint);

--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -606,12 +606,22 @@ namespace AvalonDock.Controls
 			var windowHandle = new WindowInteropHelper(this).Handle;
 			var mousePosition = this.PointToScreenDPI(Mouse.GetPosition(this));
 
+			var area = this.GetScreenArea();
+
 			// BugFix Issue #6
 			// This code is initializes the drag when content (document or toolwindow) is dragged
 			// A second chance back up plan if DragDelta is not set
 			if (DragDelta == default) DragDelta = new Point(3, 3);
 			Left = mousePosition.X - DragDelta.X;                 // BugFix Issue #6
 			Top = mousePosition.Y - DragDelta.Y;
+
+			if (this.GetScreenArea().Size != area.Size) // setting the top/left co-ordinates has changed the size - this means moving to a screen with a different DPI. Recalculate mouse position based on new DPI to avoid wrong drag location
+			{
+				mousePosition = this.PointToScreenDPI(Mouse.GetPosition(this));
+				Left = mousePosition.X - DragDelta.X;
+				Top = mousePosition.Y - DragDelta.Y;
+			}
+
 			_attachDrag = false;
 			Show();
 			var lParam = new IntPtr(((int)mousePosition.X & 0xFFFF) | ((int)mousePosition.Y << 16));

--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -364,7 +364,7 @@ namespace AvalonDock.Controls
 
 					if (_dragService != null)
 					{
-						var mousePosition = this.TransformToDeviceDPI(Win32Helper.GetMousePosition());
+						var mousePosition = (Win32Helper.GetMousePosition());
 						_dragService.Drop(mousePosition, out var dropFlag);
 						_dragService = null;
 						SetIsDragging(false);
@@ -658,7 +658,7 @@ namespace AvalonDock.Controls
 				_dragService = new DragService(this);
 				SetIsDragging(true);
 			}
-			var mousePosition = this.TransformToDeviceDPI(Win32Helper.GetMousePosition());
+			var mousePosition = (Win32Helper.GetMousePosition());
 			_dragService.UpdateMouseLocation(mousePosition);
 		}
 

--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -613,6 +613,7 @@ namespace AvalonDock.Controls
 			Left = mousePosition.X - DragDelta.X;                 // BugFix Issue #6
 			Top = mousePosition.Y - DragDelta.Y;
 			_attachDrag = false;
+			Show();
 			var lParam = new IntPtr(((int)mousePosition.X & 0xFFFF) | ((int)mousePosition.Y << 16));
 			Win32Helper.SendMessage(windowHandle, Win32Helper.WM_NCLBUTTONDOWN, new IntPtr(Win32Helper.HT_CAPTION), lParam);
 		}

--- a/source/Components/AvalonDock/Controls/LayoutGridControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutGridControl.cs
@@ -637,7 +637,7 @@ namespace AvalonDock.Controls
 				Left = ptTopLeftScreen.X,
 				Top = ptTopLeftScreen.Y,
 				ShowActivated = false,
-				//Owner = Window.GetWindow(this),
+				Owner = Window.GetWindow(this),
 				Content = panelHostResizer
 			};
 			_resizerWindowHost.Loaded += (s, e) => _resizerWindowHost.SetParentToMainWindowOf(this);

--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -2091,6 +2091,7 @@ namespace AvalonDock
 		{
 			if (_overlayWindow == null)
 				_overlayWindow = new OverlayWindow(this);
+			_overlayWindow.Owner = Window.GetWindow(this);
 			var rectWindow = new Rect(this.PointToScreenDPIWithoutFlowDirection(new Point()), this.TransformActualSizeToAncestor());
 			_overlayWindow.Left = rectWindow.Left;
 			_overlayWindow.Top = rectWindow.Top;

--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -1408,7 +1408,12 @@ namespace AvalonDock
 		#region IOverlayWindowHost Interface
 
 		/// <inheritdoc/>
-		bool IOverlayWindowHost.HitTest(Point dragPoint)
+		bool IOverlayWindowHost.HitTestScreen(Point dragPoint)
+		{
+			return HitTest(this.TransformToDeviceDPI(dragPoint));
+		}
+
+		bool HitTest(Point dragPoint)
 		{
 			try
 			{
@@ -1430,6 +1435,7 @@ namespace AvalonDock
 		IOverlayWindow IOverlayWindowHost.ShowOverlayWindow(LayoutFloatingWindowControl draggingWindow)
 		{
 			CreateOverlayWindow();
+			// keep this, it sets the parent for splitter to get the dpi right
 			_overlayWindow.Owner = draggingWindow;
 			_overlayWindow.EnableDropTargets();
 			_overlayWindow.Show();
@@ -2090,8 +2096,11 @@ namespace AvalonDock
 		private void CreateOverlayWindow()
 		{
 			if (_overlayWindow == null)
+			{
 				_overlayWindow = new OverlayWindow(this);
-			_overlayWindow.Owner = Window.GetWindow(this);
+				_overlayWindow.Owner = Window.GetWindow(this);
+			}
+
 			var rectWindow = new Rect(this.PointToScreenDPIWithoutFlowDirection(new Point()), this.TransformActualSizeToAncestor());
 			_overlayWindow.Left = rectWindow.Left;
 			_overlayWindow.Top = rectWindow.Top;

--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -1435,8 +1435,6 @@ namespace AvalonDock
 		IOverlayWindow IOverlayWindowHost.ShowOverlayWindow(LayoutFloatingWindowControl draggingWindow)
 		{
 			CreateOverlayWindow();
-			// keep this, it sets the parent for splitter to get the dpi right
-			_overlayWindow.Owner = draggingWindow;
 			_overlayWindow.EnableDropTargets();
 			_overlayWindow.Show();
 			return _overlayWindow;
@@ -1448,6 +1446,8 @@ namespace AvalonDock
 			_areas = null;
 			_overlayWindow.Owner = null;
 			_overlayWindow.HideDropTargets();
+			_overlayWindow.Close();
+			_overlayWindow = null;
 		}
 
 		/// <inheritdoc/>
@@ -2098,8 +2098,8 @@ namespace AvalonDock
 			if (_overlayWindow == null)
 			{
 				_overlayWindow = new OverlayWindow(this);
-				_overlayWindow.Owner = Window.GetWindow(this);
 			}
+			_overlayWindow.Owner = Window.GetWindow(this);
 
 			var rectWindow = new Rect(this.PointToScreenDPIWithoutFlowDirection(new Point()), this.TransformActualSizeToAncestor());
 			_overlayWindow.Left = rectWindow.Left;


### PR DESCRIPTION
https://github.com/Dirkster99/AvalonDock/issues/321

This now covers all cases that I can find. There are still issues if the application does not declare per-monitor DPI awareness and the docking host window is split over two monitors with different DPIs, but these existed already, and I don't think it is possible to solve that sort of issue *without* being per monitor DPI aware.

A number of changes are needed, largely taking into account the fact that a floating window can have a different DPI to the main docking window in a per-monitor DPI aware application:

* The drag service needs to work in raw screen co-ordinates and let each window it hit tests do its own conversion into DPI scaled co-ordinates, since the conversion may be different on a per window basis. I renamed HitTest() to HitTestScreen to reflect this and added a TransformToDeviceDPI to IDropArea to support this
* The overlay windows *must* be owned by the thing they are sitting over, rather than the thing being dragged, to get the right DPI. Otherwise they show in the wrong place. Also, caching the overlay window by detaching the owner and then re-using later is bad, since while the window is cached, the owner may change DPI, which the overlay window will not reflect when it is re-used. I have changed the code to stop caching them to avoid this
* When a LayoutFloatingWindow control is shown for the first time, setting its position may cause it to be on a different screen, which can change its DPI, which in turn moves the position a long way from the mouse. We cannot use the DPIChangedEvent to detect this, since it is not present in net40. Instead I measure the screen size of the window before/after setting the position. If the size changes, presumably the DPI has changed, and I re-do the position calculations in the new DPI. This makes the window drag away from the docking area correctly even if it drags straight onto a different DPI screen

I have tested on Win10 (21H1) with the TestApp set to each of

*PerMonitor V2 DPI Awareness
*PerMonitor DPI Awareness
*System DPI Awareness
*No DPI Awareness

The first two seem to work correctly in all cases (docking window on high DPI, floating on low, vice versa, docking window split across high and low, floating on either high or low). The last two still have issues, but the same issues are seen with the code before my changes.

Win8 and earlier did not have per-monitor DPI, so any changes made here should have no effect on them (because the DPI would always be the same for all windows).


