### PR TITLE
FixDockAsDocument  fix bug with CanExecute and Execute for DockAsDocu…

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutDocumentItem.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentItem.cs
@@ -1,4 +1,4 @@
-﻿/************************************************************************
+/************************************************************************
    AvalonDock
 
    Copyright (C) 2007-2013 Xceed Software Inc.
@@ -98,6 +98,11 @@ namespace AvalonDock.Controls
 		{
 			_document = null;
 			base.Detach();
+		}
+
+		protected override bool CanExecuteDockAsDocumentCommand()
+		{
+			return (LayoutElement != null && LayoutElement.FindParent<LayoutDocumentPane>() != null && LayoutElement.IsFloating);
 		}
 
 		#endregion Overrides

--- a/source/Components/AvalonDock/Layout/LayoutContent.cs
+++ b/source/Components/AvalonDock/Layout/LayoutContent.cs
@@ -647,7 +647,7 @@ namespace AvalonDock.Layout
         public void DockAsDocument()
 		{
 			if (!(Root is LayoutRoot root)) throw new InvalidOperationException();
-			if (Parent is LayoutDocumentPane) return;
+			if (!(Parent is LayoutDocumentPane || Parent is LayoutAnchorablePane)) return;
 
 			if (PreviousContainer is LayoutDocumentPane)
 			{

--- a/source/Components/AvalonDock/Layout/LayoutContent.cs
+++ b/source/Components/AvalonDock/Layout/LayoutContent.cs
@@ -647,7 +647,6 @@ namespace AvalonDock.Layout
         public void DockAsDocument()
 		{
 			if (!(Root is LayoutRoot root)) throw new InvalidOperationException();
-			if (!(Parent is LayoutDocumentPane || Parent is LayoutAnchorablePane)) return;
 
 			if (PreviousContainer is LayoutDocumentPane)
 			{


### PR DESCRIPTION
DockAsTabbedDocument button works for anchorable window but doesn't work for document window when window is undocked button disabled