### PR TITLE
Fixes #309 Anchorable Header not visible in generic theme

### DIFF
--- a/source/Components/AvalonDock/Themes/generic.xaml
+++ b/source/Components/AvalonDock/Themes/generic.xaml
@@ -376,6 +376,8 @@
 		</Setter>
 	</Style>
 
+	<Style TargetType="{x:Type avalonDockControls:AnchorablePaneTitle}" BasedOn="{StaticResource AnchorablePaneTitleStyle}"/>
+	
 	<ControlTemplate x:Key="AnchorSideTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorSideControl}">
 		<ItemsControl Background="{TemplateBinding Background}" ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Children}">
 			<ItemsControl.ItemsPanel>


### PR DESCRIPTION
I've added a new style without a key based on the existing style. This has the benefits of keeping the style with the key so that other people can create their own styles based on this, but it also applies this style by default. I've tested this in the test app and it worked fine for me.