### PR TITLE
fix crash if some assembly not allow GetTypes()

### DIFF
--- a/source/Components/AvalonDock/Layout/LayoutRoot.cs
+++ b/source/Components/AvalonDock/Layout/LayoutRoot.cs
@@ -653,9 +653,19 @@ namespace AvalonDock.Layout
 
 		internal static Type FindType(string name)
 		{
-			foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-				foreach (var type in assembly.GetTypes())
-					if (type.Name.Equals(name)) return type;
+			var avalonAssembly = Assembly.GetAssembly(typeof(LayoutRoot));
+
+			foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().OrderBy(a => a != avalonAssembly))
+				try
+				{
+					foreach (var type in assembly.GetTypes())
+						if (type.Name.Equals(name))
+							return type;
+				}
+				catch (ReflectionTypeLoadException)
+				{
+				}
+
 			return null;
 		}
 

--- a/source/Components/AvalonDock/Layout/LayoutRoot.cs
+++ b/source/Components/AvalonDock/Layout/LayoutRoot.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Windows.Controls;
 using System.Windows.Markup;


### PR DESCRIPTION
i.e. in Microsoft.Practices.Unity, Version=2.1.505.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
this comes up after migration from xceed AvalonDock version 2.

Additional to that I prioritize the AvalonDock assembly, because this is the most used.