### PR TITLE
Fix window going behind main window when dragging

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -162,7 +162,7 @@ namespace AvalonDock.Controls
 
 		IOverlayWindow IOverlayWindowHost.ShowOverlayWindow(LayoutFloatingWindowControl draggingWindow)
 		{
-			CreateOverlayWindow();
+			CreateOverlayWindow(draggingWindow);
 			_overlayWindow.EnableDropTargets();
 			_overlayWindow.Show();
 			return _overlayWindow;
@@ -295,10 +295,20 @@ namespace AvalonDock.Controls
 			if (!IsVisible && _model.IsVisible) Show();
 		}
 
-		private void CreateOverlayWindow()
+		private void CreateOverlayWindow(LayoutFloatingWindowControl draggingWindow)
 		{
 			if (_overlayWindow == null) _overlayWindow = new OverlayWindow(this);
-			_overlayWindow.Owner = Window.GetWindow(this);
+
+			// Usually, the overlay window is made a child of the main window. However, if the floating
+			// window being dragged isn't also a child of the main window (because OwnedByDockingManagerWindow
+			// is set to false to allow the parent window to be minimized independently of floating windows),
+			// this causes the floating window to be moved behind the main window. Just not setting the parent
+			// seems to work acceptably here in that case.
+			if (draggingWindow?.OwnedByDockingManagerWindow ?? true)
+				_overlayWindow.Owner = Window.GetWindow(this);
+			else
+				_overlayWindow.Owner = null;
+
 			var rectWindow = new Rect(this.PointToScreenDPIWithoutFlowDirection(new Point()), this.TransformActualSizeToAncestor());
 			_overlayWindow.Left = rectWindow.Left;
 			_overlayWindow.Top = rectWindow.Top;

--- a/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
@@ -225,10 +225,20 @@ namespace AvalonDock.Controls
 
 		private OverlayWindow _overlayWindow = null;
 
-		private void CreateOverlayWindow()
+		private void CreateOverlayWindow(LayoutFloatingWindowControl draggingWindow)
 		{
 			if (_overlayWindow == null) _overlayWindow = new OverlayWindow(this);
-			_overlayWindow.Owner = Window.GetWindow(this);
+
+			// Usually, the overlay window is made a child of the main window. However, if the floating
+			// window being dragged isn't also a child of the main window (because OwnedByDockingManagerWindow
+			// is set to false to allow the parent window to be minimized independently of floating windows),
+			// this causes the floating window to be moved behind the main window. Just not setting the parent
+			// seems to work acceptably here in that case.
+			if (draggingWindow?.OwnedByDockingManagerWindow ?? true)
+				_overlayWindow.Owner = Window.GetWindow(this);
+			else
+				_overlayWindow.Owner = null;
+
 			var rectWindow = new Rect(this.PointToScreenDPIWithoutFlowDirection(new Point()), this.TransformActualSizeToAncestor());
 			_overlayWindow.Left = rectWindow.Left;
 			_overlayWindow.Top = rectWindow.Top;
@@ -238,7 +248,7 @@ namespace AvalonDock.Controls
 
 		IOverlayWindow IOverlayWindowHost.ShowOverlayWindow(LayoutFloatingWindowControl draggingWindow)
 		{
-			CreateOverlayWindow();
+			CreateOverlayWindow(draggingWindow);
 			_overlayWindow.EnableDropTargets();
 			_overlayWindow.Show();
 			return _overlayWindow;

--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -1436,7 +1436,7 @@ namespace AvalonDock
 		/// <inheritdoc/>
 		IOverlayWindow IOverlayWindowHost.ShowOverlayWindow(LayoutFloatingWindowControl draggingWindow)
 		{
-			CreateOverlayWindow();
+			CreateOverlayWindow(draggingWindow);
 			_overlayWindow.EnableDropTargets();
 			_overlayWindow.Show();
 			return _overlayWindow;
@@ -2095,13 +2095,22 @@ namespace AvalonDock
 			SetAutoHideWindow(new LayoutAutoHideWindowControl());
 		}
 
-		private void CreateOverlayWindow()
+		private void CreateOverlayWindow(LayoutFloatingWindowControl draggingWindow = null)
 		{
 			if (_overlayWindow == null)
 			{
 				_overlayWindow = new OverlayWindow(this);
 			}
-			_overlayWindow.Owner = Window.GetWindow(this);
+
+			// Usually, the overlay window is made a child of the main window. However, if the floating
+			// window being dragged isn't also a child of the main window (because OwnedByDockingManagerWindow
+			// is set to false to allow the parent window to be minimized independently of floating windows),
+			// this causes the floating window to be moved behind the main window. Just not setting the parent
+			// seems to work acceptably here in that case.
+			if (draggingWindow?.OwnedByDockingManagerWindow ?? true)
+				_overlayWindow.Owner = Window.GetWindow(this);
+			else
+				_overlayWindow.Owner = null;
 
 			var rectWindow = new Rect(this.PointToScreenDPIWithoutFlowDirection(new Point()), this.TransformActualSizeToAncestor());
 			_overlayWindow.Left = rectWindow.Left;


### PR DESCRIPTION
This is a proposed fix for https://github.com/Dirkster99/AvalonDock/issues/349.

The ownership of the OverlayWindow was changed in https://github.com/Dirkster99/AvalonDock/pull/326. This works great when the overlay window is a child of the main window. However, if the floating window being dragged isn't also a child of the main window (because OwnedByDockingManagerWindow is set to false to allow the parent window to be minimized independently of floating windows), this causes the floating window to be moved behind the main window. 

This issue is resolved by not setting the Owner of the OverlayWindow. These changes clear the owner only in the case where the OwnedByDockingManagerWindow is set to false for the window. Otherwise, it maintains the existing behavior.