### PR TITLE
Fixes #362 DockingManager with a Viewbox ancestor does not properly render auto-hidden LayoutAnchorables

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutAutoHideWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAutoHideWindowControl.cs
@@ -9,6 +9,7 @@
 
 using AvalonDock.Layout;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -44,6 +45,8 @@ namespace AvalonDock.Controls
 		private Border _resizerGhost = null;
 		private Window _resizerWindowHost = null;
 		private Vector _initialStartPoint;
+		private List<FrameworkElement> _sizeChangedListeningControls;
+		private SizeChangedEventHandler _sizeChangedHandler;
 
 		#endregion fields
 
@@ -59,6 +62,7 @@ namespace AvalonDock.Controls
 
 		internal LayoutAutoHideWindowControl()
 		{
+			_sizeChangedHandler = ViewboxZoomChanged;
 		}
 
 		#endregion Constructors
@@ -116,6 +120,8 @@ namespace AvalonDock.Controls
 			_manager = _model.Root.Manager;
 			CreateInternalGrid();
 			_model.PropertyChanged += _model_PropertyChanged;
+			SetLayoutTransform();
+			StartListeningToViewboxZoomChange();
 			Visibility = Visibility.Visible;
 			InvalidateMeasure();
 			UpdateWindowPos();
@@ -124,6 +130,8 @@ namespace AvalonDock.Controls
 
 		internal void Hide()
 		{
+			StopListeningToViewboxZoomChange();
+
 			if (_model == null) return;
 			_model.PropertyChanged -= _model_PropertyChanged;
 			RemoveInternalGrid();
@@ -212,6 +220,61 @@ namespace AvalonDock.Controls
 		{
 			if (e.PropertyName != nameof(LayoutAnchorable.IsAutoHidden)) return;
 			if (!_model.IsAutoHidden) _manager.HideAutoHideWindow(_anchor);
+		}
+
+		private Transform ChildLayoutTransform
+		{
+			get
+			{
+				var viewboxes = _manager.GetParents().OfType<Viewbox>().ToList();
+
+				if (viewboxes.Any())
+				{
+					if (_manager.TransformToAncestor(viewboxes[viewboxes.Count - 1]) is Transform transform)
+					{
+						if (!transform.Value.IsIdentity)
+						{
+							var origin = transform.Transform(new Point());
+
+							var newTransformGroup = new TransformGroup();
+							newTransformGroup.Children.Add(transform);
+							newTransformGroup.Children.Add(new TranslateTransform(-origin.X, -origin.Y));
+							return newTransformGroup;
+						}
+					}
+				}
+
+				return Transform.Identity;
+			}
+		}
+
+		private void SetLayoutTransform()
+		{
+			// We refresh this each time either:
+			// 1) The window is created.
+			// 2) An ancestor Viewbox changes its zoom (the Viewbox or its child changes size)
+			// We would also want to refresh when the visual tree changes such that an ancestor Viewbox is added, removed, or changed. However, this is completely unnecessary
+			// because the LayoutAutoHideWindowControl closes if a visual ancestor is changed: DockingManager.Unloaded handler calls _autoHideWindowManager?.HideAutoWindow()
+			if (ChildLayoutTransform is Transform transform && _internalHostPresenter.LayoutTransform.Value != transform.Value)
+			{
+				LayoutTransform = (Transform)transform.Inverse;
+				_internalHostPresenter.LayoutTransform = transform;
+			}
+		}
+		private void StartListeningToViewboxZoomChange()
+		{
+			StopListeningToViewboxZoomChange();
+			_sizeChangedListeningControls = _manager.GetParents().OfType<Viewbox>().SelectMany(x => new[] { x, x.Child }).OfType<FrameworkElement>().Distinct().ToList();
+			_sizeChangedListeningControls.ForEach(x => x.SizeChanged += _sizeChangedHandler);
+		}
+		private void StopListeningToViewboxZoomChange()
+		{
+			_sizeChangedListeningControls?.ForEach(x => x.SizeChanged -= _sizeChangedHandler);
+			_sizeChangedListeningControls?.Clear();
+		}
+		private void ViewboxZoomChanged(object sender, SizeChangedEventArgs e)
+		{
+			SetLayoutTransform();
 		}
 
 		private void CreateInternalGrid()
@@ -351,11 +414,13 @@ namespace AvalonDock.Controls
 			var trToWnd = TransformToAncestor(rootVisual);
 			//var transformedDelta = trToWnd.Transform(new Point(e.HorizontalChange, e.VerticalChange)) - trToWnd.Transform(new Point());
 
+			var deltaPoint = ChildLayoutTransform.Inverse.Transform(new Point(Canvas.GetLeft(_resizerGhost) - _initialStartPoint.X, Canvas.GetTop(_resizerGhost) - _initialStartPoint.Y));
+
 			double delta;
 			if (_side == AnchorSide.Right || _side == AnchorSide.Left)
-				delta = Canvas.GetLeft(_resizerGhost) - _initialStartPoint.X;
+				delta = deltaPoint.X;
 			else
-				delta = Canvas.GetTop(_resizerGhost) - _initialStartPoint.Y;
+				delta = deltaPoint.Y;
 
 			switch (_side)
 			{
@@ -400,6 +465,10 @@ namespace AvalonDock.Controls
 
 			var trToWnd = TransformToAncestor(rootVisual);
 			var transformedDelta = trToWnd.Transform(new Point(e.HorizontalChange, e.VerticalChange)) - trToWnd.Transform(new Point());
+			if (ChildLayoutTransform is Transform transform && !transform.Value.IsIdentity)
+			{
+				transformedDelta = transform.Transform(new Point() + transformedDelta) - new Point();
+			}
 
 			if (_side == AnchorSide.Right || _side == AnchorSide.Left)
 			{


### PR DESCRIPTION
In this PR, we add logic to detect when the `DockingManager` is a descendent of one more `Viewbox` controls. We then adjust the `LayoutTransform` of the `LayoutAutoHideWindowControl` and its child as necessary to make the child have the correct zoom and behave as if the window were a descendent of the `DockingManager`. Additionally, we make a small fix to dragging the window to resize it.

We update the `LayoutTransform` when the `LayoutAutoHideWindowControl` is shown and when any of its descendents' `Viewbox`es or their direct children's size changes.