### PR TITLE
Fix for #306 StartDraggingFloatingWindow

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutDocumentTabItem.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentTabItem.cs
@@ -109,6 +109,7 @@ namespace AvalonDock.Controls
 		protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
 		{
 			base.OnMouseLeftButtonDown(e);
+			CaptureMouse();
 			_allowDrag = false;
 			Model.IsActive = true;
 			if (Model is LayoutDocument layoutDocument && !layoutDocument.CanMove) return;

--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -334,6 +334,7 @@ namespace AvalonDock.Controls
 			}
 			else
 			{
+				CaptureMouse();
 				var windowHandle = new WindowInteropHelper(this).Handle;
 				var lParam = new IntPtr(((int)Left & 0xFFFF) | ((int)Top << 16));
 				Win32Helper.SendMessage(windowHandle, Win32Helper.WM_NCLBUTTONDOWN, new IntPtr(Win32Helper.HT_CAPTION), lParam);


### PR DESCRIPTION
Some time ago, i created an issue #306 where i mentions that method StartDraggingFloatingWindow do not sync mouse position with newly created window.

After some attempts i found out, that when i add CaptureMouse() to methods OnMouseLeftButtonDown (LayoutDocumentTabItem.cs) and AttachDrag (LayoutFloatingWindowControls.cs) it solves my issue