### PR TITLE
Prevents a known bug in WPF

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -536,6 +536,26 @@ namespace AvalonDock.Controls
 			base.OnInitialized(e);
 		}
 
+		protected override void OnClosing(CancelEventArgs e)
+        	{
+            		base.OnClosing(e);
+            		AssureOwnerIsNotMinimized();
+        	}
+
+        	/// <summary>
+		/// Prevents a known bug in WPF, which wronlgy minimizes the parent window, when closing this control
+        	/// </summary>
+        	private void AssureOwnerIsNotMinimized()
+        	{
+            		try
+            		{
+                		Owner?.Activate();
+            		}
+            		catch (Exception)
+            		{
+            		}
+        	}
+
 		#endregion Overrides
 
 		#region Private Methods


### PR DESCRIPTION
If a childwindow ist opened and closed and this control is closed the main window is minimized. The workaround with setting the owner to null is not working, therefor Activate is used https://stackoverflow.com/questions/19156373/closing-child-window-minimizes-parent