### PR TITLE
Add Null check for GetWindowChrome

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -256,11 +256,10 @@ namespace AvalonDock.Controls
 				case Win32Helper.WM_NCRBUTTONUP:
 					if (wParam.ToInt32() == Win32Helper.HT_CAPTION)
 					{
-						if (OpenContextMenu()) handled = true;
-
 						var windowChrome = WindowChrome.GetWindowChrome(this);
 						if (windowChrome != null)
 						{
+							if (OpenContextMenu()) handled = true;
 							windowChrome.ShowSystemMenu = _model.Root.Manager.ShowSystemMenu && !handled;
 						}
 					}

--- a/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -257,7 +257,12 @@ namespace AvalonDock.Controls
 					if (wParam.ToInt32() == Win32Helper.HT_CAPTION)
 					{
 						if (OpenContextMenu()) handled = true;
-						WindowChrome.GetWindowChrome(this).ShowSystemMenu = _model.Root.Manager.ShowSystemMenu && !handled;
+
+						var windowChrome = WindowChrome.GetWindowChrome(this);
+						if (windowChrome != null)
+						{
+							windowChrome.ShowSystemMenu = _model.Root.Manager.ShowSystemMenu && !handled;
+						}
 					}
 					break;
 			}

--- a/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
@@ -137,10 +137,15 @@ namespace AvalonDock.Controls
 					{
 						if (OpenContextMenu())
 							handled = true;
-						if (_model.Root.Manager.ShowSystemMenu)
-							WindowChrome.GetWindowChrome(this).ShowSystemMenu = !handled;
-						else
-							WindowChrome.GetWindowChrome(this).ShowSystemMenu = false;
+
+						var windowChrome = WindowChrome.GetWindowChrome(this);
+						if (windowChrome != null)
+						{
+							if (_model.Root.Manager.ShowSystemMenu)
+								windowChrome.ShowSystemMenu = !handled;
+							else
+								windowChrome.ShowSystemMenu = false;
+						}
 					}
 					break;
 

--- a/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
@@ -135,12 +135,12 @@ namespace AvalonDock.Controls
 				case Win32Helper.WM_NCRBUTTONUP:
 					if (wParam.ToInt32() == Win32Helper.HT_CAPTION)
 					{
-						if (OpenContextMenu())
-							handled = true;
-
 						var windowChrome = WindowChrome.GetWindowChrome(this);
 						if (windowChrome != null)
 						{
+							if (OpenContextMenu())
+								handled = true;
+
 							if (_model.Root.Manager.ShowSystemMenu)
 								windowChrome.ShowSystemMenu = !handled;
 							else


### PR DESCRIPTION
Null exception occurs when WindowChrome is not from AvalonDock

![image](https://user-images.githubusercontent.com/62750690/199023138-d2f3a9b4-e012-412c-8750-53e09ab66b8d.png)


https://user-images.githubusercontent.com/62750690/199029350-1dbf5090-7680-4899-b8ad-5bcc54d8fc86.mp4

