### PR TITLE
Fix the get owner DockingManagerWindow and Update drag and drop

### DIFF
--- a/source/Components/AvalonDock/Controls/DragService.cs
+++ b/source/Components/AvalonDock/Controls/DragService.cs
@@ -72,8 +72,6 @@ namespace AvalonDock.Controls
 		{
 			_floatingWindow = floatingWindow;
 			_manager = floatingWindow.Model.Root.Manager;
-
-			GetOverlayWindowHosts();
 		}
 
 		#endregion Constructors

--- a/source/Components/AvalonDock/Controls/DragService.cs
+++ b/source/Components/AvalonDock/Controls/DragService.cs
@@ -57,6 +57,7 @@ namespace AvalonDock.Controls
 		private IOverlayWindow _currentWindow;
 		private List<IDropArea> _currentWindowAreas = new List<IDropArea>();
 		private IDropTarget _currentDropTarget;
+		private bool _isDrag;
 
 		#endregion fields
 
@@ -89,7 +90,12 @@ namespace AvalonDock.Controls
 			////var floatingWindowModel = _floatingWindow.Model as LayoutFloatingWindow;
 			// TODO - pass in without DPI adjustment, screen co-ords, adjust inside the target window
 
-			GetOverlayWindowHosts();
+			if (!_isDrag)
+			{
+				GetOverlayWindowHosts();
+				_isDrag = true;
+			}
+
 			var newHost = _overlayWindowHosts.FirstOrDefault(oh => oh.HitTestScreen(dragPosition));
 
 			if (_currentHost != null || _currentHost != newHost)
@@ -113,7 +119,10 @@ namespace AvalonDock.Controls
 					if (_currentWindow != null)
 						_currentWindow.DragLeave(_floatingWindow);
 					if (_currentHost != null)
+					{
 						_currentHost.HideOverlayWindow();
+						GetOverlayWindowHosts();
+					}
 
 					_currentHost = null;
 				}
@@ -134,6 +143,8 @@ namespace AvalonDock.Controls
 					{
 						BringWindowToTop2(Window.GetWindow(dockingManager));
 					}
+
+					GetOverlayWindowHosts();
 
 					BringWindowToTop2(_floatingWindow);
 					if (_currentWindow is Window overlayWindow)
@@ -235,6 +246,7 @@ namespace AvalonDock.Controls
 
 			_currentWindow = null;
 			_currentHost = null;
+			_isDrag = false;
 		}
 
 		/// <summary>

--- a/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -301,11 +301,9 @@ namespace AvalonDock.Controls
 
 			// Usually, the overlay window is made a child of the main window. However, if the floating
 			// window being dragged isn't also a child of the main window (because OwnedByDockingManagerWindow
-			// is set to false to allow the parent window to be minimized independently of floating windows),
-			// this causes the floating window to be moved behind the main window. Just not setting the parent
-			// seems to work acceptably here in that case.
+			// is set to false to allow the parent window to be minimized independently of floating windows)
 			if (draggingWindow?.OwnedByDockingManagerWindow ?? true)
-				_overlayWindow.Owner = Window.GetWindow(this);
+				_overlayWindow.Owner = Window.GetWindow(_model.Root.Manager);
 			else
 				_overlayWindow.Owner = null;
 

--- a/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
@@ -16,7 +16,6 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
-using System.Windows.Interop;
 
 namespace AvalonDock.Controls
 {
@@ -231,11 +230,9 @@ namespace AvalonDock.Controls
 
 			// Usually, the overlay window is made a child of the main window. However, if the floating
 			// window being dragged isn't also a child of the main window (because OwnedByDockingManagerWindow
-			// is set to false to allow the parent window to be minimized independently of floating windows),
-			// this causes the floating window to be moved behind the main window. Just not setting the parent
-			// seems to work acceptably here in that case.
+			// is set to false to allow the parent window to be minimized independently of floating windows)
 			if (draggingWindow?.OwnedByDockingManagerWindow ?? true)
-				_overlayWindow.Owner = Window.GetWindow(this);
+				_overlayWindow.Owner = Window.GetWindow(_model.Root.Manager);
 			else
 				_overlayWindow.Owner = null;
 

--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -52,12 +52,7 @@ namespace AvalonDock.Controls
 		/// </summary>
 		/// <see cref="TotalMargin"/>
 		private bool _isTotalMarginSet = false;
-
-		/// <summary>
-		/// This field is controlled by the DragService and is used to set whether to display in front of the main window.
-		/// </summary>
-		internal bool _canShowDragOnMainWindow;
-
+		
 		#endregion fields
 
 		#region Constructors

--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -53,6 +53,11 @@ namespace AvalonDock.Controls
 		/// <see cref="TotalMargin"/>
 		private bool _isTotalMarginSet = false;
 
+		/// <summary>
+		/// This field is controlled by the DragService and is used to set whether to display in front of the main window.
+		/// </summary>
+		internal bool _canShowDragOnMainWindow;
+
 		#endregion fields
 
 		#region Constructors

--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -1621,7 +1621,7 @@ namespace AvalonDock
 				{
 					//Owner = Window.GetWindow(this)
 				};
-				
+
 				newFW.UpdateOwnership();
 
 				// Fill list before calling Show (issue #254)
@@ -1665,7 +1665,7 @@ namespace AvalonDock
 				{
 					//Owner = Window.GetWindow(this)
 				};
-				
+
 				newFW.UpdateOwnership();
 
 				// Fill list before calling Show (issue #254)
@@ -2104,9 +2104,7 @@ namespace AvalonDock
 
 			// Usually, the overlay window is made a child of the main window. However, if the floating
 			// window being dragged isn't also a child of the main window (because OwnedByDockingManagerWindow
-			// is set to false to allow the parent window to be minimized independently of floating windows),
-			// this causes the floating window to be moved behind the main window. Just not setting the parent
-			// seems to work acceptably here in that case.
+			// is set to false to allow the parent window to be minimized independently of floating windows)
 			if (draggingWindow?.OwnedByDockingManagerWindow ?? true)
 				_overlayWindow.Owner = Window.GetWindow(this);
 			else

--- a/source/Components/AvalonDock/Win32Helper.cs
+++ b/source/Components/AvalonDock/Win32Helper.cs
@@ -323,9 +323,6 @@ namespace AvalonDock
 		[DllImport("user32.dll")]
 		internal static extern IntPtr GetTopWindow(IntPtr hWnd);
 
-		internal const uint GW_HWNDNEXT = 2;
-		internal const uint GW_HWNDPREV = 3;
-
 		[DllImport("user32.dll", SetLastError = true)]
 		internal static extern IntPtr GetWindow(IntPtr hWnd, uint uCmd);
 
@@ -338,6 +335,28 @@ namespace AvalonDock
 			GW_OWNER = 4,
 			GW_CHILD = 5,
 			GW_ENABLEDPOPUP = 6
+		}
+
+		public static bool GetWindowZOrder(IntPtr hwnd, out int zOrder)
+		{
+			var lowestHwnd = GetWindow(hwnd, (uint)GetWindow_Cmd.GW_HWNDLAST);
+
+			var z = 0;
+			var hwndTmp = lowestHwnd;
+			while (hwndTmp != IntPtr.Zero)
+			{
+				if (hwnd == hwndTmp)
+				{
+					zOrder = z;
+					return true;
+				}
+
+				hwndTmp = GetWindow(hwndTmp, (uint)GetWindow_Cmd.GW_HWNDPREV);
+				z++;
+			}
+
+			zOrder = int.MinValue;
+			return false;
 		}
 
 		internal static int MakeLParam(int LoWord, int HiWord)


### PR DESCRIPTION
See: pull https://github.com/Dirkster99/AvalonDock/pull/350  | issue https://github.com/Dirkster99/AvalonDock/issues/349

 
Before:
![image](https://user-images.githubusercontent.com/62750690/199236003-7d06ac79-68b1-40db-b518-ad1af67b29f5.png)
this = FloatingWindow, GetWindow(this) = self.
but, where DockingManagerWindow ?🤣

Now:
![image](https://user-images.githubusercontent.com/62750690/199237290-7dfb2fd3-97d4-45ba-a0a3-509c1da2bdd9.png)
Get DockingManagerWindow correctly