### PR TITLE
Fix deserialized layout document close.

### DIFF
--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -2230,6 +2230,7 @@ namespace AvalonDock
 					var documentsToRemove = Layout.Descendents().OfType<LayoutDocument>().Where(d => e.OldItems.Contains(d.Content)).ToArray();
 					foreach (var documentToRemove in documentsToRemove)
 					{
+						documentToRemove.Content = null;
 						documentToRemove.Parent.RemoveChild(documentToRemove);
 						RemoveViewFromLogicalChild(documentToRemove);
 					}

--- a/source/Components/AvalonDock/Layout/LayoutElement.cs
+++ b/source/Components/AvalonDock/Layout/LayoutElement.cs
@@ -109,6 +109,20 @@ namespace AvalonDock.Layout
 
 		#endregion Public Methods
 
+		#region Internal Methods
+
+		/// <summary>
+		/// When deserializing layout enclosing element parent is set later than this parent
+		/// We need to update it, otherwise when deleting this element <see cref="LayoutRoot.ElementRemoved" /> will no be called
+		/// </summary>
+		internal void FixCachedRootOnDeserialize()
+		{
+			if (_root == null)
+				_root = Root;
+		}
+
+		#endregion Internal Methods
+
 		#region protected methods
 
 		/// <summary>Provides derived classes an opportunity to handle execute code before to the <see cref="Parent"/> property changes.</summary>

--- a/source/Components/AvalonDock/Layout/Serialization/LayoutSerializer.cs
+++ b/source/Components/AvalonDock/Layout/Serialization/LayoutSerializer.cs
@@ -60,6 +60,8 @@ namespace AvalonDock.Layout.Serialization
 
 		protected virtual void FixupLayout(LayoutRoot layout)
 		{
+			foreach (var element in layout.Descendents().OfType<LayoutElement>()) element.FixCachedRootOnDeserialize();
+
 			//fix container panes
 			foreach (var lcToAttach in layout.Descendents().OfType<ILayoutPreviousContainer>().Where(lc => lc.PreviousContainerId != null))
 			{


### PR DESCRIPTION
Recently I mentioned that `LayoutElement._root` doesn't have correct value after deserialization. When we deserialize layout from xml enclosing element is not finished with yet and therefore doesn't have correct parent yet.
This state prevents `LayoutRoot.ElementRemoved` from being called on close, which leads to skipped call to `DockingManager.CollectLayoutItemsDeleted`. 

Also I mentioned that documents closed via deletion from `DockingManager.DocumentsSource` did not have their `Content` property set to null. Though we do it for `AnchorablesSource` and in `ExecuteCloseCommand`, so I added it. 