### PR TITLE
Add anchorable hide and close notifications to DockingManager

### DIFF
--- a/source/AutomationTest/AvalonDockTest/AnchorablePaneTest.cs
+++ b/source/AutomationTest/AvalonDockTest/AnchorablePaneTest.cs
@@ -63,24 +63,15 @@ namespace AvalonDockTest
 			dockingManager.AnchorableHiding += (s, e) => isHidingRaised.Add(e.Anchorable);
 			dockingManager.AnchorableHidden += (s, e) => isHiddenRaised.Add(e.Anchorable);
 
-			// Get the visual items
-
-			LayoutAnchorableItem item2 = dockingManager.GetLayoutItemFromModel(windows.Screen2) as LayoutAnchorableItem;
-			LayoutAnchorableItem item3 = dockingManager.GetLayoutItemFromModel(windows.Screen3) as LayoutAnchorableItem;
-
-			Assert.IsNotNull(item2);
-			Assert.IsNotNull(item3);
-
 			// Ensure the items can be hidden and closed
-
-			item2.CanClose = true;
-			item3.CanClose = true;
-			item2.CanHide = true;
-			item3.CanHide = true;
+			windows.Screen2.CanHide = true;
+			windows.Screen3.CanHide = true;
+			windows.Screen2.CanClose = true;
+			windows.Screen3.CanClose = true;
 
 			// Hide item3
 
-			item3.HideCommand.Execute(null);
+			windows.Screen3.Hide();
 
 			// Ensure only item3 is hidden, and check the correct events were fired
 
@@ -99,7 +90,7 @@ namespace AvalonDockTest
 
 			// Close item2
 
-			item2.CloseCommand.Execute(null);
+			windows.Screen2.Close();
 
 			// Check the correct events were fired
 
@@ -148,24 +139,15 @@ namespace AvalonDockTest
 			};
 			dockingManager.AnchorableHidden += (s, e) => isHiddenRaised.Add(e.Anchorable);
 
-			// Get the visual items
-
-			LayoutAnchorableItem item2 = dockingManager.GetLayoutItemFromModel(windows.Screen2) as LayoutAnchorableItem;
-			LayoutAnchorableItem item3 = dockingManager.GetLayoutItemFromModel(windows.Screen3) as LayoutAnchorableItem;
-
-			Assert.IsNotNull(item2);
-			Assert.IsNotNull(item3);
-
 			// Ensure the items can be hidden and closed
+			windows.Screen2.CanHide = true;
+			windows.Screen3.CanHide = true;
+			windows.Screen2.CanClose = true;
+			windows.Screen3.CanClose = true;
 
-			item2.CanClose = true;
-			item3.CanClose = true;
-			item2.CanHide = true;
-			item3.CanHide = true;
+			// Hide Screen3
 
-			// Hide item3
-
-			item3.HideCommand.Execute(null);
+			windows.Screen3.Hide();
 
 			// Ensure nothing was hidden but cancelled instead, and check the correct events were fired
 
@@ -180,9 +162,9 @@ namespace AvalonDockTest
 
 			isHidingRaised.Clear();
 
-			// Close item2
+			// Close Screen2
 
-			item2.CloseCommand.Execute(null);
+			windows.Screen2.Close();
 
 			// Ensure nothing was closed, and check the correct events were fired
 
@@ -226,24 +208,13 @@ namespace AvalonDockTest
 			};
 			dockingManager.AnchorableHidden += (s, e) => isHiddenRaised.Add(e.Anchorable);
 
-			// Get the visual items
+			// Ensure the Screen3 can be hidden and closed
+			windows.Screen3.CanHide = true;
+			windows.Screen3.CanClose = true;
 
-			LayoutAnchorableItem item2 = dockingManager.GetLayoutItemFromModel(windows.Screen2) as LayoutAnchorableItem;
-			LayoutAnchorableItem item3 = dockingManager.GetLayoutItemFromModel(windows.Screen3) as LayoutAnchorableItem;
+			// Hide Screen3
 
-			Assert.IsNotNull(item2);
-			Assert.IsNotNull(item3);
-
-			// Ensure the items can be hidden and closed
-
-			item2.CanClose = true;
-			item3.CanClose = true;
-			item2.CanHide = true;
-			item3.CanHide = true;
-
-			// Hide item3
-
-			item3.HideCommand.Execute(null);
+			windows.Screen3.Hide();
 
 			// Ensure nothing was hidden but cancelled instead, and check the correct events were fired
 

--- a/source/AutomationTest/AvalonDockTest/AnchorablePaneTest.cs
+++ b/source/AutomationTest/AvalonDockTest/AnchorablePaneTest.cs
@@ -1,4 +1,4 @@
-﻿namespace AvalonDockTest
+namespace AvalonDockTest
 {
 	using Microsoft.VisualStudio.TestTools.UnitTesting;
 	using Microsoft.VisualStudio.TestTools.UnitTesting.STAExtensions;
@@ -6,6 +6,10 @@
 	using AvalonDock.Layout;
 	using AvalonDockTest.TestHelpers;
 	using AvalonDockTest.views;
+	using AvalonDock;
+	using System.Collections.Generic;
+	using System.Linq;
+	using AvalonDock.Controls;
 
 	[STATestClass]
 	public class AnchorablePaneTest : AutomationTestBase
@@ -29,6 +33,230 @@
 			Assert.IsFalse(windows.Screen3.IsHidden);
 			ILayoutContainer actualContainer = windows.Screen3.Parent;
 			Assert.AreEqual(expectedContainer, actualContainer);
+		}
+
+		[STATestMethod]
+		public void AnchorablePaneHideCloseEventsFiredTest()
+		{
+			// Create the window with 2 LayoutAnchorable items
+
+			TestHost.SwitchToAppThread();
+
+			Task<AnchorablePaneTestWindow> taskResult = WindowHelpers.CreateInvisibleWindowAsync<AnchorablePaneTestWindow>();
+
+			taskResult.Wait();
+
+			AnchorablePaneTestWindow windows = taskResult.Result;
+			DockingManager dockingManager = windows.dockingManager;
+
+			// These lists hold a record of the anchorable hide and close events
+
+			List<LayoutAnchorable> isHidingRaised = new List<LayoutAnchorable>();
+			List<LayoutAnchorable> isHiddenRaised = new List<LayoutAnchorable>();
+			List<LayoutAnchorable> isClosingRaised = new List<LayoutAnchorable>();
+			List<LayoutAnchorable> isClosedRaised = new List<LayoutAnchorable>();
+
+			// Event handlers for the hide and close events
+
+			dockingManager.AnchorableClosing += (s, e) => isClosingRaised.Add(e.Anchorable);
+			dockingManager.AnchorableClosed += (s, e) => isClosedRaised.Add(e.Anchorable);
+			dockingManager.AnchorableHiding += (s, e) => isHidingRaised.Add(e.Anchorable);
+			dockingManager.AnchorableHidden += (s, e) => isHiddenRaised.Add(e.Anchorable);
+
+			// Get the visual items
+
+			LayoutAnchorableItem item2 = dockingManager.GetLayoutItemFromModel(windows.Screen2) as LayoutAnchorableItem;
+			LayoutAnchorableItem item3 = dockingManager.GetLayoutItemFromModel(windows.Screen3) as LayoutAnchorableItem;
+
+			Assert.IsNotNull(item2);
+			Assert.IsNotNull(item3);
+
+			// Ensure the items can be hidden and closed
+
+			item2.CanClose = true;
+			item3.CanClose = true;
+			item2.CanHide = true;
+			item3.CanHide = true;
+
+			// Hide item3
+
+			item3.HideCommand.Execute(null);
+
+			// Ensure only item3 is hidden, and check the correct events were fired
+
+			Assert.IsFalse(windows.Screen2.IsHidden);
+			Assert.IsTrue(windows.Screen3.IsHidden);
+			Assert.AreEqual(1, isHidingRaised.Count);
+			Assert.AreEqual(1, isHiddenRaised.Count);
+			Assert.AreEqual(0, isClosingRaised.Count);
+			Assert.AreEqual(0, isClosedRaised.Count);
+
+			Assert.AreEqual(windows.Screen3, isHidingRaised.First());
+			Assert.AreEqual(windows.Screen3, isHiddenRaised.First());
+
+			isHidingRaised.Clear();
+			isHiddenRaised.Clear();
+
+			// Close item2
+
+			item2.CloseCommand.Execute(null);
+
+			// Check the correct events were fired
+
+			Assert.AreEqual(0, isHidingRaised.Count);
+			Assert.AreEqual(0, isHiddenRaised.Count);
+			Assert.AreEqual(1, isClosingRaised.Count);
+			Assert.AreEqual(1, isClosedRaised.Count);
+
+			Assert.AreEqual(windows.Screen2, isClosingRaised.First());
+			Assert.AreEqual(windows.Screen2, isClosedRaised.First());
+		}
+
+		[STATestMethod]
+		public void AnchorablePaneHideCloseEventsCancelledTest()
+		{
+			// Create the window with 2 LayoutAnchorable items
+
+			TestHost.SwitchToAppThread();
+
+			Task<AnchorablePaneTestWindow> taskResult = WindowHelpers.CreateInvisibleWindowAsync<AnchorablePaneTestWindow>();
+
+			taskResult.Wait();
+
+			AnchorablePaneTestWindow windows = taskResult.Result;
+			DockingManager dockingManager = windows.dockingManager;
+
+			// These lists hold a record of the anchorable hide and close events
+
+			List<LayoutAnchorable> isHidingRaised = new List<LayoutAnchorable>();
+			List<LayoutAnchorable> isHiddenRaised = new List<LayoutAnchorable>();
+			List<LayoutAnchorable> isClosingRaised = new List<LayoutAnchorable>();
+			List<LayoutAnchorable> isClosedRaised = new List<LayoutAnchorable>();
+
+			// Event handlers for the hide and close events
+
+			dockingManager.AnchorableClosing += (s, e) =>
+			{
+				e.Cancel = true;
+				isClosingRaised.Add(e.Anchorable);
+			};
+			dockingManager.AnchorableClosed += (s, e) => isClosedRaised.Add(e.Anchorable);
+			dockingManager.AnchorableHiding += (s, e) =>
+			{
+				e.Cancel = true;
+				isHidingRaised.Add(e.Anchorable);
+			};
+			dockingManager.AnchorableHidden += (s, e) => isHiddenRaised.Add(e.Anchorable);
+
+			// Get the visual items
+
+			LayoutAnchorableItem item2 = dockingManager.GetLayoutItemFromModel(windows.Screen2) as LayoutAnchorableItem;
+			LayoutAnchorableItem item3 = dockingManager.GetLayoutItemFromModel(windows.Screen3) as LayoutAnchorableItem;
+
+			Assert.IsNotNull(item2);
+			Assert.IsNotNull(item3);
+
+			// Ensure the items can be hidden and closed
+
+			item2.CanClose = true;
+			item3.CanClose = true;
+			item2.CanHide = true;
+			item3.CanHide = true;
+
+			// Hide item3
+
+			item3.HideCommand.Execute(null);
+
+			// Ensure nothing was hidden but cancelled instead, and check the correct events were fired
+
+			Assert.IsFalse(windows.Screen2.IsHidden);
+			Assert.IsFalse(windows.Screen3.IsHidden);
+			Assert.AreEqual(1, isHidingRaised.Count);
+			Assert.AreEqual(0, isHiddenRaised.Count);
+			Assert.AreEqual(0, isClosingRaised.Count);
+			Assert.AreEqual(0, isClosedRaised.Count);
+
+			Assert.AreEqual(windows.Screen3, isHidingRaised.First());
+
+			isHidingRaised.Clear();
+
+			// Close item2
+
+			item2.CloseCommand.Execute(null);
+
+			// Ensure nothing was closed, and check the correct events were fired
+
+			Assert.AreEqual(0, isHidingRaised.Count);
+			Assert.AreEqual(0, isHiddenRaised.Count);
+			Assert.AreEqual(1, isClosingRaised.Count);
+			Assert.AreEqual(0, isClosedRaised.Count);
+
+			Assert.AreEqual(windows.Screen2, isClosingRaised.First());
+		}
+
+		[STATestMethod]
+		public void AnchorablePaneHideEventRedirectTest()
+		{
+			// Create the window with 2 LayoutAnchorable items
+
+			TestHost.SwitchToAppThread();
+
+			Task<AnchorablePaneTestWindow> taskResult = WindowHelpers.CreateInvisibleWindowAsync<AnchorablePaneTestWindow>();
+
+			taskResult.Wait();
+
+			AnchorablePaneTestWindow windows = taskResult.Result;
+			DockingManager dockingManager = windows.dockingManager;
+
+			// These lists hold a record of the anchorable hide and close events
+
+			List<LayoutAnchorable> isHidingRaised = new List<LayoutAnchorable>();
+			List<LayoutAnchorable> isHiddenRaised = new List<LayoutAnchorable>();
+			List<LayoutAnchorable> isClosingRaised = new List<LayoutAnchorable>();
+			List<LayoutAnchorable> isClosedRaised = new List<LayoutAnchorable>();
+
+			// Event handlers for the hide and close events
+
+			dockingManager.AnchorableClosing += (s, e) => isClosingRaised.Add(e.Anchorable);
+			dockingManager.AnchorableClosed += (s, e) => isClosedRaised.Add(e.Anchorable);
+			dockingManager.AnchorableHiding += (s, e) =>
+			{
+				e.CloseInsteadOfHide = true;
+				isHidingRaised.Add(e.Anchorable);
+			};
+			dockingManager.AnchorableHidden += (s, e) => isHiddenRaised.Add(e.Anchorable);
+
+			// Get the visual items
+
+			LayoutAnchorableItem item2 = dockingManager.GetLayoutItemFromModel(windows.Screen2) as LayoutAnchorableItem;
+			LayoutAnchorableItem item3 = dockingManager.GetLayoutItemFromModel(windows.Screen3) as LayoutAnchorableItem;
+
+			Assert.IsNotNull(item2);
+			Assert.IsNotNull(item3);
+
+			// Ensure the items can be hidden and closed
+
+			item2.CanClose = true;
+			item3.CanClose = true;
+			item2.CanHide = true;
+			item3.CanHide = true;
+
+			// Hide item3
+
+			item3.HideCommand.Execute(null);
+
+			// Ensure nothing was hidden but cancelled instead, and check the correct events were fired
+
+			Assert.IsFalse(windows.Screen2.IsHidden);
+			Assert.IsFalse(windows.Screen3.IsHidden);
+			Assert.AreEqual(1, isHidingRaised.Count);
+			Assert.AreEqual(0, isHiddenRaised.Count);
+			Assert.AreEqual(1, isClosingRaised.Count);
+			Assert.AreEqual(1, isClosedRaised.Count);
+
+			Assert.AreEqual(windows.Screen3, isHidingRaised.First());
+			Assert.AreEqual(windows.Screen3, isClosingRaised.First());
+			Assert.AreEqual(windows.Screen3, isClosedRaised.First());
 		}
 	}
 }

--- a/source/Components/AvalonDock/AnchorableClosedEventArgs.cs
+++ b/source/Components/AvalonDock/AnchorableClosedEventArgs.cs
@@ -1,0 +1,35 @@
+/************************************************************************
+   AvalonDock
+
+   Copyright (C) 2007-2013 Xceed Software Inc.
+
+   This program is provided to you under the terms of the Microsoft Public
+   License (Ms-PL) as published at https://opensource.org/licenses/MS-PL
+ ************************************************************************/
+
+using AvalonDock.Layout;
+using System;
+
+namespace AvalonDock
+{
+	/// <summary>
+	/// Implements an event that can be raised to inform the client application about an
+	/// anchorable that been closed and removed its content (viewmodel) from the docking framework.
+	/// </summary>
+	public class AnchorableClosedEventArgs : EventArgs
+	{
+		/// <summary>
+		/// Class constructor from the anchorables layout model.
+		/// </summary>
+		/// <param name="document"></param>
+		public AnchorableClosedEventArgs(LayoutAnchorable anchorable)
+		{
+			Anchorable = anchorable;
+		}
+
+		/// <summary>
+		/// Gets the model of the anchorable that has been closed.
+		/// </summary>
+		public LayoutAnchorable Anchorable { get; private set; }
+	}
+}

--- a/source/Components/AvalonDock/AnchorableClosingEventArgs.cs
+++ b/source/Components/AvalonDock/AnchorableClosingEventArgs.cs
@@ -1,0 +1,35 @@
+/************************************************************************
+   AvalonDock
+
+   Copyright (C) 2007-2013 Xceed Software Inc.
+
+   This program is provided to you under the terms of the Microsoft Public
+   License (Ms-PL) as published at https://opensource.org/licenses/MS-PL
+ ************************************************************************/
+
+using AvalonDock.Layout;
+using System.ComponentModel;
+
+namespace AvalonDock
+{
+	/// <summary>
+	/// Implements a Cancelable event that can be raised to ask the client application whether closing this anchorable
+	/// and removing its content (viewmodel) is OK or not.
+	/// </summary>
+	public class AnchorableClosingEventArgs : CancelEventArgs
+	{
+		/// <summary>
+		/// Class constructor from the anchorable layout model.
+		/// </summary>
+		/// <param name="document"></param>
+		public AnchorableClosingEventArgs(LayoutAnchorable anchorable)
+		{
+			Anchorable = anchorable;
+		}
+
+		/// <summary>
+		/// Gets the model of the anchorable that is about to be closed.
+		/// </summary>
+		public LayoutAnchorable Anchorable { get; private set; }
+	}
+}

--- a/source/Components/AvalonDock/AnchorableHiddenEventArgs.cs
+++ b/source/Components/AvalonDock/AnchorableHiddenEventArgs.cs
@@ -1,0 +1,35 @@
+/************************************************************************
+   AvalonDock
+
+   Copyright (C) 2007-2013 Xceed Software Inc.
+
+   This program is provided to you under the terms of the Microsoft Public
+   License (Ms-PL) as published at https://opensource.org/licenses/MS-PL
+ ************************************************************************/
+
+using AvalonDock.Layout;
+using System;
+
+namespace AvalonDock
+{
+	/// <summary>
+	/// Implements an event that can be raised to inform the client application about an
+	/// anchorable that been hidden.
+	/// </summary>
+	public class AnchorableHiddenEventArgs : EventArgs
+	{
+		/// <summary>
+		/// Class constructor from the anchorables layout model.
+		/// </summary>
+		/// <param name="document"></param>
+		public AnchorableHiddenEventArgs(LayoutAnchorable anchorable)
+		{
+			Anchorable = anchorable;
+		}
+
+		/// <summary>
+		/// Gets the model of the anchorable that has been hidden.
+		/// </summary>
+		public LayoutAnchorable Anchorable { get; private set; }
+	}
+}

--- a/source/Components/AvalonDock/AnchorableHidingEventArgs.cs
+++ b/source/Components/AvalonDock/AnchorableHidingEventArgs.cs
@@ -1,0 +1,40 @@
+/************************************************************************
+   AvalonDock
+
+   Copyright (C) 2007-2013 Xceed Software Inc.
+
+   This program is provided to you under the terms of the Microsoft Public
+   License (Ms-PL) as published at https://opensource.org/licenses/MS-PL
+ ************************************************************************/
+
+using AvalonDock.Layout;
+using System.ComponentModel;
+
+namespace AvalonDock
+{
+	/// <summary>
+	/// Implements a Cancelable event that can be raised to ask the client application whether hiding this anchorable
+	/// is OK or not.
+	/// </summary>
+	public class AnchorableHidingEventArgs : CancelEventArgs
+	{
+		/// <summary>
+		/// Class constructor from the anchorable layout model.
+		/// </summary>
+		/// <param name="document"></param>
+		public AnchorableHidingEventArgs(LayoutAnchorable anchorable)
+		{
+			Anchorable = anchorable;
+		}
+
+		/// <summary>
+		/// Gets the model of the anchorable that is about to be hidden.
+		/// </summary>
+		public LayoutAnchorable Anchorable { get; private set; }
+
+		/// <summary>
+		/// Gets or sets a value indicating whether an anchorable should be closed instead of hidden
+		/// </summary>
+		public bool CloseInsteadOfHide { get; set; }
+	}
+}

--- a/source/Components/AvalonDock/Controls/LayoutAnchorableItem.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorableItem.cs
@@ -276,7 +276,7 @@ namespace AvalonDock.Controls
 				{
 					switch (Visibility)
 					{
-						case Visibility.Hidden: case Visibility.Collapsed: _anchorable.Hide(false); break;
+						case Visibility.Hidden: case Visibility.Collapsed: _anchorable.HideAnchorable(false); break;
 						case Visibility.Visible: _anchorable.Show(); break;
 					}
 				}

--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -1962,9 +1962,8 @@ namespace AvalonDock
 			}
 			if (hidingArgs?.Cancel == true) return;
 
-			model.Hide();
-
-			AnchorableHidden?.Invoke(this, new AnchorableHiddenEventArgs(model));
+			if(model.HideAnchorable(true))
+				AnchorableHidden?.Invoke(this, new AnchorableHiddenEventArgs(model));
 		}
 
 		internal void ExecuteAutoHideCommand(LayoutAnchorable _anchorable) => _anchorable.ToggleAutoHide();

--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -115,6 +115,20 @@ namespace AvalonDock
 		/// <summary>Event fired after a document is closed.</summary>
 		public event EventHandler<DocumentClosedEventArgs> DocumentClosed;
 
+		/// <summary>Event fired when an anchorable is about to be closed.</summary>
+		/// <remarks>Subscribers have the opportuniy to cancel the operation.</remarks>
+		public event EventHandler<AnchorableClosingEventArgs> AnchorableClosing;
+
+		/// <summary>Event fired after an anchorable is closed</summary>
+		public event EventHandler<AnchorableClosedEventArgs> AnchorableClosed;
+
+		/// <summary>Event fired when an anchorable is about to be hidden.</summary>
+		/// <remarks>Subscribers have the opportuniy to cancel the operation.</remarks>
+		public event EventHandler<AnchorableHidingEventArgs> AnchorableHiding;
+
+		/// <summary>Event fired after an anchorable is hidden</summary>
+		public event EventHandler<AnchorableHiddenEventArgs> AnchorableHidden;
+
 		/// <summary>Event is raised when <see cref="ActiveContent"/> changes.</summary>
 		/// <seealso cref="ActiveContent"/>
 		public event EventHandler ActiveContentChanged;
@@ -1922,11 +1936,36 @@ namespace AvalonDock
 		internal void ExecuteCloseCommand(LayoutAnchorable anchorable)
 		{
 			if (!(anchorable is LayoutAnchorable model)) return;
-			model.CloseAnchorable();
-			RemoveViewFromLogicalChild(anchorable);
+
+			AnchorableClosingEventArgs closingArgs = null;
+			AnchorableClosing?.Invoke(this, closingArgs = new AnchorableClosingEventArgs(model));
+			if (closingArgs?.Cancel == true)
+				return;
+
+			if (model.CloseAnchorable())
+			{
+				RemoveViewFromLogicalChild(model);
+				AnchorableClosed?.Invoke(this, new AnchorableClosedEventArgs(model));
+			}
 		}
 
-		internal void ExecuteHideCommand(LayoutAnchorable anchorable) => anchorable?.Hide();
+		internal void ExecuteHideCommand(LayoutAnchorable anchorable)
+		{
+			if (!(anchorable is LayoutAnchorable model)) return;
+
+			AnchorableHidingEventArgs hidingArgs = null;
+			AnchorableHiding?.Invoke(this, hidingArgs = new AnchorableHidingEventArgs(model));
+			if (hidingArgs?.CloseInsteadOfHide == true)
+			{
+				ExecuteCloseCommand(model);
+				return;
+			}
+			if (hidingArgs?.Cancel == true) return;
+
+			model.Hide();
+
+			AnchorableHidden?.Invoke(this, new AnchorableHiddenEventArgs(model));
+		}
 
 		internal void ExecuteAutoHideCommand(LayoutAnchorable _anchorable) => _anchorable.ToggleAutoHide();
 

--- a/source/Components/AvalonDock/Layout/LayoutAnchorable.cs
+++ b/source/Components/AvalonDock/Layout/LayoutAnchorable.cs
@@ -280,7 +280,16 @@ namespace AvalonDock.Layout
 		}
 
 		/// <inheritdoc />
-		public override void Close() => CloseAnchorable();
+		public override void Close()
+		{
+			if (Root?.Manager != null)
+			{
+				var dockingManager = Root.Manager;
+				dockingManager.ExecuteCloseCommand(this);
+			}
+			else
+				CloseAnchorable();
+		}
 
 #if TRACE
 		/// <inheritdoc />
@@ -298,24 +307,31 @@ namespace AvalonDock.Layout
 		#endregion Overrides
 
 		#region Public Methods
+		public void Hide()
+		{
+			if (Root?.Manager is DockingManager dockingManager)
+				dockingManager.ExecuteHideCommand(this);
+			else
+				HideAnchorable(true);
+		}
 
 		/// <summary>Hide this contents.</summary>
 		/// <remarks>Add this content to <see cref="ILayoutRoot.Hidden"/> collection of parent root.</remarks>
 		/// <param name="cancelable"></param>
-		public void Hide(bool cancelable = true)
+		internal bool HideAnchorable(bool cancelable)
 		{
 			if (!IsVisible)
 			{
 				IsSelected = true;
 				IsActive = true;
-				return;
+				return false;
 			}
 
 			if (cancelable)
 			{
 				var args = new CancelEventArgs();
 				OnHiding(args);
-				if (args.Cancel) return;
+				if (args.Cancel) return false;
 			}
 
 			RaisePropertyChanging(nameof(IsHidden));
@@ -330,6 +346,8 @@ namespace AvalonDock.Layout
 			RaisePropertyChanged(nameof(IsVisible));
 			RaisePropertyChanged(nameof(IsHidden));
 			NotifyIsVisibleChanged();
+
+			return true;
 		}
 
 		/// <summary>Show the content.</summary>

--- a/source/Components/AvalonDock/Layout/LayoutAnchorable.cs
+++ b/source/Components/AvalonDock/Layout/LayoutAnchorable.cs
@@ -608,11 +608,12 @@ namespace AvalonDock.Layout
 
 		#region Internal Methods
 
-		internal void CloseAnchorable()
+		internal bool CloseAnchorable()
 		{
-			if (!TestCanClose()) return;
+			if (!TestCanClose()) return false;
 			if (IsAutoHidden) ToggleAutoHide();
 			CloseInternal();
+			return true;
 		}
 
 		// BD: 17.08.2020 Remove that bodge and handle CanClose=false && CanHide=true in XAML

--- a/source/Components/AvalonDock/Layout/Serialization/LayoutSerializer.cs
+++ b/source/Components/AvalonDock/Layout/Serialization/LayoutSerializer.cs
@@ -89,10 +89,10 @@ namespace AvalonDock.Layout.Serialization
 					else if (args.Content != null)
 						lcToFix.Content = args.Content;
 					else if (args.Model.Content != null)
-						lcToFix.Hide(false);           // hide layoutanchorable if client app supplied no content
+						lcToFix.HideAnchorable(false);   // hide layoutanchorable if client app supplied no content
 				}
 				else if (previousAchorable == null)  // No Callback and no provious document -> skip this
-					lcToFix.Hide(false);
+					lcToFix.HideAnchorable(false);
 				else
 				{   // No Callback but previous anchoreable available -> load content from previous document
 					lcToFix.Content = previousAchorable.Content;


### PR DESCRIPTION
This change adds close and hide events to DockingManager for anchorables. This brings anchorables inline with documents (LayoutDocument) as documents already have this functionality in DockingManager.
The reason for this change is so I can use a custom PrismLibrary region adapter for DockingManager. A PrismLibrary region adapter needs to track when controls are visibly removed from a parent, which in this case is DockingManager. Sample region adapters for other parent panels can be found [in this repo](https://github.com/PrismLibrary/Prism/tree/master/src/Wpf/Prism.Wpf/Regions).
This code is a port from a custom version of the old AvalonDock that I have been using with PrismLibrary for many years. I have added unit tests for the new functionality.