### PR TITLE
Fix a issue where the dragged window still appeared above the overlay window

### DIFF
--- a/source/Components/AvalonDock/Controls/DragService.cs
+++ b/source/Components/AvalonDock/Controls/DragService.cs
@@ -279,6 +279,8 @@ namespace AvalonDock.Controls
 
 		private void BringWindowToTop2(Window window)
 		{
+			if (window == null) return;
+
 			Win32Helper.SetWindowPos(new WindowInteropHelper(window).Handle,
 				IntPtr.Zero, 0, 0, 0, 0, Win32Helper.SetWindowPosFlags.IgnoreResize | Win32Helper.SetWindowPosFlags.IgnoreMove | Win32Helper.SetWindowPosFlags.DoNotActivate);
 		}

--- a/source/Components/AvalonDock/Controls/DragService.cs
+++ b/source/Components/AvalonDock/Controls/DragService.cs
@@ -196,6 +196,7 @@ namespace AvalonDock.Controls
 					if (_currentDropTarget != null)
 					{
 						_currentWindow.DragEnter(_currentDropTarget);
+						BringWindowToTop2((Window)_currentWindow);
 						return;
 					}
 				});


### PR DESCRIPTION
In some special cases, the floating window is still displayed above the overlay window.

![O {@{ L)1%9))FIT4ODB2OD](https://user-images.githubusercontent.com/62750690/209438306-0ef124a6-f977-4678-b2b1-a97b1a92f90d.png)
