### PR TITLE
Fix the binding error in AnchorGroupTemplate

### DIFF
--- a/source/Components/AvalonDock.Themes.Aero/Theme.xaml
+++ b/source/Components/AvalonDock.Themes.Aero/Theme.xaml
@@ -481,15 +481,27 @@
 
 	<ControlTemplate x:Key="AvalonDock_ThemeAero_AnchorGroupTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorGroupControl}">
 		<ItemsControl ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Children}">
-			<ItemsControl.LayoutTransform>
-				<RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Model.Parent.Side, Converter={avalonDockConverters:AnchorSideToAngleConverter}}" />
-			</ItemsControl.LayoutTransform>
-			<ItemsControl.ItemsPanel>
-				<ItemsPanelTemplate>
-					<StackPanel Orientation="Horizontal" />
-				</ItemsPanelTemplate>
-			</ItemsControl.ItemsPanel>
-		</ItemsControl>
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal" />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.Style>
+                <Style TargetType="{x:Type ItemsControl}">
+                    <Style.Resources>
+                        <RotateTransform x:Key="LeftRightAnchorSideRotateTransform" Angle="90" />
+                    </Style.Resources>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding Path=Model.Parent.Side, RelativeSource={RelativeSource TemplatedParent}}" Value="Left">
+                            <Setter Property="LayoutTransform" Value="{StaticResource LeftRightAnchorSideRotateTransform}" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Path=Model.Parent.Side, RelativeSource={RelativeSource TemplatedParent}}" Value="Right">
+                            <Setter Property="LayoutTransform" Value="{StaticResource LeftRightAnchorSideRotateTransform}" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </ItemsControl.Style>
+        </ItemsControl>
 	</ControlTemplate>
 
 	<ControlTemplate x:Key="AvalonDock_ThemeAero_AnchorTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorControl}">

--- a/source/Components/AvalonDock.Themes.Expression/Theme.xaml
+++ b/source/Components/AvalonDock.Themes.Expression/Theme.xaml
@@ -485,14 +485,26 @@
 
 	<ControlTemplate x:Key="AvalonDock_Expression_AnchorGroupTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorGroupControl}">
 		<ItemsControl ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Children}">
-			<ItemsControl.LayoutTransform>
-				<RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Model.Parent.Side, Converter={avalonDockConverters:AnchorSideToAngleConverter}}" />
-			</ItemsControl.LayoutTransform>
 			<ItemsControl.ItemsPanel>
 				<ItemsPanelTemplate>
 					<StackPanel Orientation="Horizontal" />
 				</ItemsPanelTemplate>
 			</ItemsControl.ItemsPanel>
+			<ItemsControl.Style>
+				<Style TargetType="{x:Type ItemsControl}">
+					<Style.Resources>
+						<RotateTransform x:Key="LeftRightAnchorSideRotateTransform" Angle="90" />
+					</Style.Resources>
+					<Style.Triggers>
+						<DataTrigger Binding="{Binding Path=Model.Parent.Side, RelativeSource={RelativeSource TemplatedParent}}" Value="Left">
+							<Setter Property="LayoutTransform" Value="{StaticResource LeftRightAnchorSideRotateTransform}" />
+						</DataTrigger>
+						<DataTrigger Binding="{Binding Path=Model.Parent.Side, RelativeSource={RelativeSource TemplatedParent}}" Value="Right">
+							<Setter Property="LayoutTransform" Value="{StaticResource LeftRightAnchorSideRotateTransform}" />
+						</DataTrigger>
+					</Style.Triggers>
+				</Style>
+			</ItemsControl.Style>
 		</ItemsControl>
 	</ControlTemplate>
 

--- a/source/Components/AvalonDock.Themes.Metro/Theme.xaml
+++ b/source/Components/AvalonDock.Themes.Metro/Theme.xaml
@@ -491,14 +491,26 @@
 
 	<ControlTemplate x:Key="AvalonDock_ThemeMetro_AnchorGroupTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorGroupControl}">
 		<ItemsControl ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Children}">
-			<ItemsControl.LayoutTransform>
-				<RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Model.Parent.Side, Converter={avalonDockConverters:AnchorSideToAngleConverter}}" />
-			</ItemsControl.LayoutTransform>
 			<ItemsControl.ItemsPanel>
 				<ItemsPanelTemplate>
 					<StackPanel Orientation="Horizontal" />
 				</ItemsPanelTemplate>
 			</ItemsControl.ItemsPanel>
+			<ItemsControl.Style>
+				<Style TargetType="{x:Type ItemsControl}">
+					<Style.Resources>
+						<RotateTransform x:Key="LeftRightAnchorSideRotateTransform" Angle="90" />
+					</Style.Resources>
+					<Style.Triggers>
+						<DataTrigger Binding="{Binding Path=Model.Parent.Side, RelativeSource={RelativeSource TemplatedParent}}" Value="Left">
+							<Setter Property="LayoutTransform" Value="{StaticResource LeftRightAnchorSideRotateTransform}" />
+						</DataTrigger>
+						<DataTrigger Binding="{Binding Path=Model.Parent.Side, RelativeSource={RelativeSource TemplatedParent}}" Value="Right">
+							<Setter Property="LayoutTransform" Value="{StaticResource LeftRightAnchorSideRotateTransform}" />
+						</DataTrigger>
+					</Style.Triggers>
+				</Style>
+			</ItemsControl.Style>
 		</ItemsControl>
 	</ControlTemplate>
 

--- a/source/Components/AvalonDock.Themes.VS2010/Theme.xaml
+++ b/source/Components/AvalonDock.Themes.VS2010/Theme.xaml
@@ -545,14 +545,26 @@
 
 	<ControlTemplate x:Key="AvalonDock_ThemeVS2010_AnchorGroupTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorGroupControl}">
 		<ItemsControl ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Children}">
-			<ItemsControl.LayoutTransform>
-				<RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Model.Parent.Side, Converter={avalonDockConverters:AnchorSideToAngleConverter}}" />
-			</ItemsControl.LayoutTransform>
 			<ItemsControl.ItemsPanel>
 				<ItemsPanelTemplate>
 					<StackPanel Orientation="Horizontal" />
 				</ItemsPanelTemplate>
 			</ItemsControl.ItemsPanel>
+			<ItemsControl.Style>
+				<Style TargetType="{x:Type ItemsControl}">
+					<Style.Resources>
+						<RotateTransform x:Key="LeftRightAnchorSideRotateTransform" Angle="90" />
+					</Style.Resources>
+					<Style.Triggers>
+						<DataTrigger Binding="{Binding Path=Model.Parent.Side, RelativeSource={RelativeSource TemplatedParent}}" Value="Left">
+							<Setter Property="LayoutTransform" Value="{StaticResource LeftRightAnchorSideRotateTransform}" />
+						</DataTrigger>
+						<DataTrigger Binding="{Binding Path=Model.Parent.Side, RelativeSource={RelativeSource TemplatedParent}}" Value="Right">
+							<Setter Property="LayoutTransform" Value="{StaticResource LeftRightAnchorSideRotateTransform}" />
+						</DataTrigger>
+					</Style.Triggers>
+				</Style>
+			</ItemsControl.Style>
 		</ItemsControl>
 	</ControlTemplate>
 

--- a/source/Components/AvalonDock.Themes.VS2013/Themes/Generic.xaml
+++ b/source/Components/AvalonDock.Themes.VS2013/Themes/Generic.xaml
@@ -820,16 +820,28 @@
     </ControlTemplate>
 
     <ControlTemplate x:Key="AvalonDockThemeVs2013AnchorGroupTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorGroupControl}">
-        <ItemsControl ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Children}">
-            <ItemsControl.LayoutTransform>
-                <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Model.Parent.Side, Converter={avalonDockConverters:AnchorSideToAngleConverter}}" />
-            </ItemsControl.LayoutTransform>
-            <ItemsControl.ItemsPanel>
-                <ItemsPanelTemplate>
-                    <StackPanel Orientation="Horizontal" />
-                </ItemsPanelTemplate>
-            </ItemsControl.ItemsPanel>
-        </ItemsControl>
+		<ItemsControl ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Children}">
+			<ItemsControl.ItemsPanel>
+				<ItemsPanelTemplate>
+					<StackPanel Orientation="Horizontal" />
+				</ItemsPanelTemplate>
+			</ItemsControl.ItemsPanel>
+			<ItemsControl.Style>
+				<Style TargetType="{x:Type ItemsControl}">
+					<Style.Resources>
+						<RotateTransform x:Key="LeftRightAnchorSideRotateTransform" Angle="90" />
+					</Style.Resources>
+					<Style.Triggers>
+						<DataTrigger Binding="{Binding Path=Model.Parent.Side, RelativeSource={RelativeSource TemplatedParent}}" Value="Left">
+							<Setter Property="LayoutTransform" Value="{StaticResource LeftRightAnchorSideRotateTransform}" />
+						</DataTrigger>
+						<DataTrigger Binding="{Binding Path=Model.Parent.Side, RelativeSource={RelativeSource TemplatedParent}}" Value="Right">
+							<Setter Property="LayoutTransform" Value="{StaticResource LeftRightAnchorSideRotateTransform}" />
+						</DataTrigger>
+					</Style.Triggers>
+				</Style>
+			</ItemsControl.Style>
+		</ItemsControl>
     </ControlTemplate>
 
     <ControlTemplate x:Key="AvalonDockThemeVs2013AnchorTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorControl}">

--- a/source/Components/AvalonDock/Themes/generic.xaml
+++ b/source/Components/AvalonDock/Themes/generic.xaml
@@ -390,14 +390,26 @@
 
 	<ControlTemplate x:Key="AnchorGroupTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorGroupControl}">
 		<ItemsControl ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Children}">
-			<ItemsControl.LayoutTransform>
-				<RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Model.Parent.Side, Converter={avalonDockConverters:AnchorSideToAngleConverter}}" />
-			</ItemsControl.LayoutTransform>
 			<ItemsControl.ItemsPanel>
 				<ItemsPanelTemplate>
 					<StackPanel Orientation="Horizontal" />
 				</ItemsPanelTemplate>
 			</ItemsControl.ItemsPanel>
+			<ItemsControl.Style>
+				<Style TargetType="{x:Type ItemsControl}">
+					<Style.Resources>
+						<RotateTransform x:Key="LeftRightAnchorSideRotateTransform" Angle="90" />
+					</Style.Resources>
+					<Style.Triggers>
+						<DataTrigger Binding="{Binding Path=Model.Parent.Side, RelativeSource={RelativeSource TemplatedParent}}" Value="Left">
+							<Setter Property="LayoutTransform" Value="{StaticResource LeftRightAnchorSideRotateTransform}" />
+						</DataTrigger>
+						<DataTrigger Binding="{Binding Path=Model.Parent.Side, RelativeSource={RelativeSource TemplatedParent}}" Value="Right">
+							<Setter Property="LayoutTransform" Value="{StaticResource LeftRightAnchorSideRotateTransform}" />
+						</DataTrigger>
+					</Style.Triggers>
+				</Style>
+			</ItemsControl.Style>
 		</ItemsControl>
 	</ControlTemplate>
 


### PR DESCRIPTION
https://github.com/Dirkster99/AvalonDock/blob/1d4d30d9969236c3717b8a6f430809a230ff671a/source/Components/AvalonDock/Themes/generic.xaml#L393-L395

(Converter)
![20221226135008](https://user-images.githubusercontent.com/62750690/209509180-f831fce8-d6ec-449e-ba1f-b590d3d0e4d3.png)

(DataTriggers)
![20221226135234](https://user-images.githubusercontent.com/62750690/209509227-e5e3e53a-b698-4570-aa9b-f46737b8b881.png)

Binding errors are avoided by using data triggers instead of converter