### PR TITLE
NullCheck for DragPoint

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -149,6 +149,8 @@ namespace AvalonDock.Controls
 
 		bool HitTest(Point dragPoint)
 		{
+			if (dragPoint == default(Point)) 
+				return false;
 			var detectionRect = new Rect(this.PointToScreenDPIWithoutFlowDirection(new Point()), this.TransformActualSizeToAncestor());
 			return detectionRect.Contains(dragPoint);
 		}

--- a/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
@@ -224,6 +224,8 @@ namespace AvalonDock.Controls
 
 		bool HitTest(Point dragPoint)
 		{
+			if (dragPoint == default(Point)) 
+				return false;
 			var detectionRect = new Rect(this.PointToScreenDPIWithoutFlowDirection(new Point()), this.TransformActualSizeToAncestor());
 			return detectionRect.Contains(dragPoint);
 		}

--- a/source/Components/AvalonDock/Controls/TransformExtentions.cs
+++ b/source/Components/AvalonDock/Controls/TransformExtentions.cs
@@ -1,4 +1,4 @@
-﻿/************************************************************************
+/************************************************************************
    AvalonDock
 
    Copyright (C) 2007-2013 Xceed Software Inc.
@@ -59,7 +59,10 @@ namespace AvalonDock.Controls
 
 		public static Point TransformToDeviceDPI(this Visual visual, Point pt)
 		{
-			Matrix m = PresentationSource.FromVisual(visual).CompositionTarget.TransformToDevice;
+			var compositionTarget = PresentationSource.FromVisual(visual).CompositionTarget;
+			if (compositionTarget == null)
+				return default;
+			Matrix m = compositionTarget.TransformToDevice;
 			return new Point(pt.X / m.M11, pt.Y / m.M22);
 		}
 


### PR DESCRIPTION
The following exception has been reported:

Der Objektverweis wurde nicht auf eine Objektinstanz festgelegt.

Full Exception:
   bei AvalonDock.Controls.TransformExtensions.TransformToDeviceDPI(Visual visual, Point pt)
   bei AvalonDock.DockingManager.AvalonDock.Controls.IOverlayWindowHost.HitTestScreen(Point dragPoint)
   bei AvalonDock.Controls.DragService.<>c__DisplayClass9_0.<UpdateMouseLocation>b__0(IOverlayWindowHost oh)
   bei System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   bei AvalonDock.Controls.DragService.UpdateMouseLocation(Point dragPosition)
   bei AvalonDock.Controls.DragService.Drop(Point dropLocation, Boolean& dropHandled)
   bei AvalonDock.Controls.LayoutFloatingWindowControl.FilterMessage(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)

   bei AvalonDock.Controls.LayoutAnchorableFloatingWindowControl.FilterMessage(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)

The pull request should fix this exception