### PR TITLE
Added additional NullChecks in OnClosed LayoutAnchorableFloatingWindowControls.cs

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -208,11 +208,11 @@ namespace AvalonDock.Controls
 		/// <inheritdoc />
 		protected override void OnClosed(EventArgs e)
 		{
-			var root = Model.Root;
+			var root = Model?.Root;
 			if (root != null)
 			{
 				if (root is LayoutRoot layoutRoot) layoutRoot.Updated -= OnRootUpdated;
-				root.Manager.RemoveFloatingWindow(this);
+				root.Manager?.RemoveFloatingWindow(this);
 				root.CollectGarbage();
 			}
 			if (_overlayWindow != null)


### PR DESCRIPTION
Added additional NullChecks, because  NullReferenceExceptions can occur in this method

https://github.com/Dirkster99/AvalonDock/issues/437