### PR TITLE
Skip mouse events of unloaded controls

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutDocumentTabItem.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentTabItem.cs
@@ -108,6 +108,8 @@ namespace AvalonDock.Controls
 		/// <inheritdoc />
 		protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
 		{
+			if (!IsLoaded) return;
+
 			base.OnMouseLeftButtonDown(e);
 			CaptureMouse();
 			_allowDrag = false;
@@ -121,6 +123,8 @@ namespace AvalonDock.Controls
 		/// <inheritdoc />
 		protected override void OnMouseMove(MouseEventArgs e)
 		{
+			if (!IsLoaded) return;
+
 			base.OnMouseMove(e);
 			_isMouseDown = Mouse.LeftButton == MouseButtonState.Pressed && _isMouseDown;
 			if (_isMouseDown)
@@ -160,6 +164,8 @@ namespace AvalonDock.Controls
 		/// <inheritdoc />
 		protected override void OnMouseLeftButtonUp(MouseButtonEventArgs e)
 		{
+			if (!IsLoaded) return;
+
 			_isMouseDown = false;
 			_allowDrag = false;
 			if (IsMouseCaptured) ReleaseMouseCapture();
@@ -169,6 +175,8 @@ namespace AvalonDock.Controls
 		/// <inheritdoc />
 		protected override void OnMouseLeave(MouseEventArgs e)
 		{
+			if (!IsLoaded) return;
+
 			base.OnMouseLeave(e);
 			_isMouseDown = false;
 		}
@@ -176,6 +184,8 @@ namespace AvalonDock.Controls
 		/// <inheritdoc />
 		protected override void OnMouseEnter(MouseEventArgs e)
 		{
+			if (!IsLoaded) return;
+
 			base.OnMouseEnter(e);
 			_isMouseDown = false;
 		}
@@ -183,11 +193,13 @@ namespace AvalonDock.Controls
 		/// <inheritdoc />
 		protected override void OnMouseDown(MouseButtonEventArgs e)
 		{
+			if (!IsLoaded) return;
+
 			if (LayoutItem != null && e.ChangedButton == MouseButton.Middle && LayoutItem.CloseCommand.CanExecute(null))
 			{
 				LayoutItem.CloseCommand.Execute(null);
 			}
-			
+
 			base.OnMouseDown(e);
 		}
 


### PR DESCRIPTION
Somehow mouse events are fired for unloaded tabitems resulting in a NullReferenceException
```
at AvalonDock.Controls.TransformExtensions.PointToScreenDPI(Visual visual, Point pt)
   at AvalonDock.Controls.TransformExtensions.GetScreenArea(FrameworkElement element)
   at AvalonDock.Controls.LayoutDocumentTabItem.UpdateDragDetails()
   at AvalonDock.Controls.LayoutDocumentTabItem.OnMouseMove(MouseEventArgs e)
   at System.Windows.RoutedEventArgs.InvokeHandler(Delegate handler, Object target)
...
```

This fixes the exception