### PR TITLE
Removed call to CaptureMouse from LayoutFloatingWindowControl.

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -311,7 +311,6 @@ namespace AvalonDock.Controls
 			}
 			else
 			{
-				CaptureMouse();
 				var windowHandle = new WindowInteropHelper(this).Handle;
 				var lParam = new IntPtr(((int)Left & 0xFFFF) | ((int)Top << 16));
 				Win32Helper.SendMessage(windowHandle, Win32Helper.WM_NCLBUTTONDOWN, new IntPtr(Win32Helper.HT_CAPTION), lParam);


### PR DESCRIPTION
This fixes issue #458 although I'm not sure if it reintroduces issue #306. I have not seen the behavior described in #306 but I may not have large enough documents.