### PR TITLE
Additional Null-Check in TransformToDeviceDPI

### DIFF
--- a/source/Components/AvalonDock/Controls/TransformExtentions.cs
+++ b/source/Components/AvalonDock/Controls/TransformExtentions.cs
@@ -59,7 +59,7 @@ namespace AvalonDock.Controls
 
 		public static Point TransformToDeviceDPI(this Visual visual, Point pt)
 		{
-			var compositionTarget = PresentationSource.FromVisual(visual).CompositionTarget;
+			var compositionTarget = PresentationSource.FromVisual(visual)?.CompositionTarget ?? null;
 			if (compositionTarget == null)
 				return default;
 			Matrix m = compositionTarget.TransformToDevice;


### PR DESCRIPTION
Avoid the following NullException:
<html>
<body>
<!--StartFragment-->

TransformExtensions TransformToDeviceDPI: First Chance Exception: System.NullReferenceException: Der Objektverweis wurde nicht auf eine Objektinstanz festgelegt.
--
bei AvalonDock.Controls.TransformExtensions.TransformToDeviceDPI(Visual visual, Point pt)
bei AvalonDock.DockingManager.AvalonDock.Controls.IOverlayWindowHost.HitTestScreen(Point dragPoint)
bei AvalonDock.Controls.DragService.<>c__DisplayClass9_0.<UpdateMouseLocation>b__0(IOverlayWindowHost oh)
bei System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
bei AvalonDock.Controls.DragService.UpdateMouseLocation(Point dragPosition)
bei AvalonDock.Controls.LayoutFloatingWindowControl.UpdateDragPosition()
bei AvalonDock.Controls.LayoutFloatingWindowControl.FilterMessage(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
bei AvalonDock.Controls.LayoutAnchorableFloatingWindowControl.FilterMessage(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
bei System.Windows.Interop.HwndSource.PublicHooksFilterMessage(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
bei MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
bei MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
bei System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
bei System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)

<!--EndFragment-->
</body>
</html>