### PR TITLE
Simplified FloatingWindowContentHost to ContentControl

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -177,7 +177,7 @@ namespace AvalonDock.Controls
 			if (_dropAreas != null) return _dropAreas;
 			_dropAreas = new List<IDropArea>();
 			if (draggingWindow.Model is LayoutDocumentFloatingWindow) return _dropAreas;
-			var rootVisual = (Content as FloatingWindowContentHost).RootVisual;
+			var rootVisual = (Content as FloatingWindowContentHost).FindVisualTreeRoot();
 			foreach (var areaHost in rootVisual.FindVisualChildren<LayoutAnchorablePaneControl>())
 				_dropAreas.Add(new DropArea<LayoutAnchorablePaneControl>(areaHost, DropAreaType.AnchorablePane));
 			foreach (var areaHost in rootVisual.FindVisualChildren<LayoutDocumentPaneControl>())

--- a/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
@@ -291,7 +291,7 @@ namespace AvalonDock.Controls
 				}
 			}
 
-			var rootVisual = ((FloatingWindowContentHost)Content).RootVisual;
+			var rootVisual = ((FloatingWindowContentHost)Content).FindVisualTreeRoot();
 
 			foreach (var areaHost in rootVisual.FindVisualChildren<LayoutAnchorablePaneControl>())
 				_dropAreas.Add(new DropArea<LayoutAnchorablePaneControl>(areaHost, DropAreaType.AnchorablePane));

--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControlHelper.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControlHelper.cs
@@ -130,7 +130,7 @@ namespace AvalonDock.Controls
 		private static T GetLayoutControlByMousePosition<T>(LayoutFloatingWindowControl fwc) where T : FrameworkElement, ILayoutControl
 		{
 			var mousePosition = fwc.PointToScreenDPI(Mouse.GetPosition(fwc));
-			var rootVisual = ((LayoutFloatingWindowControl.FloatingWindowContentHost)fwc.Content).RootVisual;
+			var rootVisual = ((LayoutFloatingWindowControl.FloatingWindowContentHost)fwc.Content).FindVisualTreeRoot();
 
 			foreach (var areaHost in rootVisual.FindVisualChildren<T>())
 			{


### PR DESCRIPTION
This PR introduces a change to the base class of FloatingWindowContentHost by simplifying it to ContentControl. The purpose of this modification is to address the flickering issue of the floating window's title, which was described in bug #85.

- **What's changed:** Changed the base class of FloatingWindowContentHost from its custom implementation to the standard WPF ContentControl.
- **Reason for changes:** The flickering issue initially fixed by adding code to _HandleNCCalcSize had resurfaced after the code block was removed in PR #347 aimed at resolving bug #345. By simplifying the FloatingWindowContentHost to ContentControl, the flickering is eliminated without introducing new issues.
- **Impacts on existing functionality:** Preliminary testing shows that this change fixes the flickering issue without negatively affecting other functionalities.

**Additional Information:**
This change resolves issue #85 and does not reintroduce bug #345.