### PR TITLE
Adjust GetSide to allow for multiple anchorable panes on the left or top

### DIFF
--- a/source/Components/AvalonDock/Layout/Extensions.cs
+++ b/source/Components/AvalonDock/Layout/Extensions.cs
@@ -1,4 +1,4 @@
-﻿/************************************************************************
+/************************************************************************
    AvalonDock
 
    Copyright (C) 2007-2013 Xceed Software Inc.
@@ -70,8 +70,8 @@ namespace AvalonDock.Layout
 				if (layoutPanel != null && layoutPanel.Children.Count > 0)
 				{
 					if (layoutPanel.Orientation == System.Windows.Controls.Orientation.Horizontal)
-						return layoutPanel.Children[0].Equals(element) || layoutPanel.Children[0].Descendents().Contains(element) ? AnchorSide.Left : AnchorSide.Right;
-					return layoutPanel.Children[0].Equals(element) || layoutPanel.Children[0].Descendents().Contains(element) ? AnchorSide.Top : AnchorSide.Bottom;
+						return element.InAnchorablePaneAtStartOfPanel(layoutPanel) ? AnchorSide.Left : AnchorSide.Right;
+					return element.InAnchorablePaneAtStartOfPanel(layoutPanel) ? AnchorSide.Top : AnchorSide.Bottom;
 				}
 			}
 			Debug.Fail("Unable to find the side for an element, possible layout problem!");
@@ -114,6 +114,24 @@ namespace AvalonDock.Layout
 				paneInsideFloatingWindow.FloatingTop = monitorInfo.Work.Top + 10;
 			if (paneInsideFloatingWindow.FloatingTop + paneInsideFloatingWindow.FloatingHeight > monitorInfo.Work.Bottom)
 				paneInsideFloatingWindow.FloatingTop = monitorInfo.Work.Bottom - (paneInsideFloatingWindow.FloatingHeight + 10);
+		}
+
+		private static bool InAnchorablePaneAtStartOfPanel(this ILayoutElement element, LayoutPanel layoutPanel)
+		{
+			foreach (var child in layoutPanel.Children)
+			{
+				if (!(child is LayoutAnchorablePane || child is LayoutAnchorablePaneGroup))
+				{
+					return false;
+				}
+
+				if (child.Equals(element) || child.Descendents().Contains(element))
+				{
+					return true;
+				}
+			}
+
+			return false;
 		}
 
 		#endregion Internal Methods


### PR DESCRIPTION
When the auto hide button is clicked for an anchorable window, the GetSide method determines the side it should use. The existing logic requires that it be the first child in order to go to the left side.

Our users are finding this behavior confusing. When they dock multiple anchorable windows side-by-side on the left, they expect all of them to go to the left side when clicking the auto hide. However, some of them will shift to the right. The following video shows this behavior in the TestApp:

https://github.com/Dirkster99/AvalonDock/assets/565423/fced71de-8540-4d7f-800b-fcba7a4c73e2

This change expands the logic for determining the left (or top side) to include any anchorable pane that is at the beginning of the children collection, rather than just the first child. The following video shows the adjusted behavior in the TestApp:

https://github.com/Dirkster99/AvalonDock/assets/565423/77de0a9a-2a01-4644-8a75-d25088d0310e

