### PR TITLE
Support custom style for LayoutAutoHideWindowControl's inner Grid

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutAutoHideWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAutoHideWindowControl.cs
@@ -86,6 +86,22 @@ namespace AvalonDock.Controls
 
 		#endregion AnchorableStyle
 
+		#region AnchorableGridStyle
+
+		/// <summary><see cref="AnchorableGridStyle"/> dependency property.</summary>
+		public static readonly DependencyProperty AnchorableGridStyleProperty = DependencyProperty.Register(nameof(AnchorableGridStyle), typeof(Style), typeof(LayoutAutoHideWindowControl),
+				new FrameworkPropertyMetadata(null));
+
+		/// <summary>Gets/sets the style to apply to the parent Grid of the <see cref="LayoutAnchorableControl"/> hosted in this auto hide window.</summary>
+		[Bindable(true), Description("Gets/sets the style to apply to the parent Grid of the LayoutAnchorableControl hosted in this auto hide window."), Category("Style")]
+		public Style AnchorableGridStyle
+		{
+			get => (Style)GetValue(AnchorableGridStyleProperty);
+			set => SetValue(AnchorableGridStyleProperty, value);
+		}
+
+		#endregion AnchorableGridStyle
+
 		#region Background
 
 		/// <summary><see cref="Background"/> dependency property.</summary>
@@ -280,8 +296,9 @@ namespace AvalonDock.Controls
 
 		private void CreateInternalGrid()
 		{
-			_internalGrid = new Grid { FlowDirection = FlowDirection.LeftToRight };
+			_internalGrid = new Grid { FlowDirection = FlowDirection.LeftToRight, Style = AnchorableGridStyle };
 			_internalGrid.SetBinding(Panel.BackgroundProperty, new Binding(nameof(Grid.Background)) { Source = this });
+			_internalGrid.SizeChanged += (e, s) => InvalidateMeasure();
 
 			_internalHost = new LayoutAnchorableControl { Model = _model, Style = AnchorableStyle };
 			_internalHost.SetBinding(FlowDirectionProperty, new Binding("Model.Root.Manager.FlowDirection") { Source = this });


### PR DESCRIPTION
**Summary**
This change adds support for specifying a custom style to be used for the `Grid` used as the parent container in `LayoutAutoHideWindowControl`.

**Description of the Problem**
Because of the way the inner `Grid` is created in `LayoutAutoHideWindowControl`, it is not possible to customize its style. (Adding a style allows applying a `RenderTransform`, which is needed to carry over the parent application's zoom to the `LayoutAutoHideWindowControl` content.)

**Proposed Solution**
This code adds a property to allow a custom style to be specified for the inner `Grid` that is created in `LayoutAutoHideWindowControl`. If the property is not set, the code will behave as before.