### PR TITLE
Optimize the selection logic of navigation window documents and anchorables

### DIFF
--- a/source/Components/AvalonDock/Controls/NavigatorWindow.cs
+++ b/source/Components/AvalonDock/Controls/NavigatorWindow.cs
@@ -154,18 +154,11 @@ namespace AvalonDock.Controls
 		/// <summary>Provides derived classes an opportunity to handle changes to the <see cref="SelectedDocument"/> property.</summary>
 		protected virtual void OnSelectedDocumentChanged(DependencyPropertyChangedEventArgs e)
 		{
-			if (_internalSetSelectedDocument || SelectedDocument == null)
+			if (!_internalSetSelectedDocument && SelectedDocument != null && SelectedDocument.ActivateCommand.CanExecute(null))
 			{
-				return;
+				SelectedAnchorable = null;
+				CloseAndActiveSelected();
 			}
-
-			if (!SelectedDocument.ActivateCommand.CanExecute(null))
-			{
-				return;
-			}
-
-			Close();
-			SelectedDocument.ActivateCommand.Execute(null);
 		}
 
 		#endregion SelectedDocument
@@ -190,13 +183,10 @@ namespace AvalonDock.Controls
 		/// <summary>Provides derived classes an opportunity to handle changes to the <see cref="SelectedAnchorable"/> property.</summary>
 		protected virtual void OnSelectedAnchorableChanged(DependencyPropertyChangedEventArgs e)
 		{
-			if (_internalSetSelectedAnchorable) return;
-			// TODO: What goes on here??
-			var selectedAnchorable = e.NewValue as LayoutAnchorableItem;
-			if (SelectedAnchorable != null && SelectedAnchorable.ActivateCommand.CanExecute(null))
+			if (!_internalSetSelectedAnchorable && SelectedAnchorable != null && SelectedAnchorable.ActivateCommand.CanExecute(null))
 			{
-				Close();
-				SelectedAnchorable.ActivateCommand.Execute(null);
+				SelectedDocument = null;
+				CloseAndActiveSelected();
 			}
 		}
 
@@ -240,10 +230,12 @@ namespace AvalonDock.Controls
 							if (isListOfDocuments)
 							{
 								container.IsKeyboardFocusedChanged += DocumentsItemContainer_IsKeyboardFocusedChanged;
+								container.PreviewMouseLeftButtonDown += DocumentsItemContainer_PreviewMouseLeftButtonDown;
 							}
 							else
 							{
 								container.IsKeyboardFocusedChanged += AnchorablesItemContainer_IsKeyboardFocusedChanged;
+                                container.PreviewMouseLeftButtonDown += AnchorablesItemContainer_PreviewMouseLeftButtonDown;
 							}
 						}
 					}
@@ -262,7 +254,29 @@ namespace AvalonDock.Controls
 			}
 		}
 
+		private void AnchorablesItemContainer_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+		{
+			ListBoxItem item = (ListBoxItem)sender;
+			if (item.IsKeyboardFocused)
+			{
+				_internalSetSelectedAnchorable = true;
+				item.IsSelected = true;
+				_internalSetSelectedAnchorable = false;
+			}
+		}
+
 		private void DocumentsItemContainer_IsKeyboardFocusedChanged(object sender, DependencyPropertyChangedEventArgs e)
+		{
+			ListBoxItem item = (ListBoxItem)sender;
+			if (item.IsKeyboardFocused)
+			{
+				_internalSetSelectedDocument = true;
+				item.IsSelected = true;
+				_internalSetSelectedDocument = false;
+			}
+		}
+
+		private void DocumentsItemContainer_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
 		{
 			ListBoxItem item = (ListBoxItem)sender;
 			if (item.IsKeyboardFocused)


### PR DESCRIPTION
Fix error when clicking AnchorableItem/DocumentItem Optimize interaction logic, do not directly switch to DockItem when key switching, close navigation window and switch to DockItem when left mouse button is pressed to select item