### PR TITLE
Fix Floating Window Closing Behavior and Visibility Handling

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -208,20 +208,14 @@ namespace AvalonDock.Controls
 		/// <inheritdoc />
 		protected override void OnClosed(EventArgs e)
 		{
-			var root = Model.Root;
-			if (root != null)
-			{
-				if (root is LayoutRoot layoutRoot) layoutRoot.Updated -= OnRootUpdated;
-				root.Manager.RemoveFloatingWindow(this);
-				root.CollectGarbage();
-			}
+			if (Model.Root is LayoutRoot layoutRoot) layoutRoot.Updated -= OnRootUpdated;
+			
 			if (_overlayWindow != null)
 			{
 				_overlayWindow.Close();
 				_overlayWindow = null;
 			}
 			base.OnClosed(e);
-			if (!CloseInitiatedByUser) root?.FloatingWindows.Remove(_model);
 
 			// We have to clear binding instead of creating a new empty binding.
 			BindingOperations.ClearBinding(_model, VisibilityProperty);

--- a/source/Components/AvalonDock/Controls/LayoutAnchorableItem.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorableItem.cs
@@ -69,6 +69,9 @@ namespace AvalonDock.Controls
 			set => SetValue(HideCommandProperty, value);
 		}
 
+		/// <summary>Gets a value indicating whether the <see cref="HideCommand"/> is the default value.</summary>
+		internal bool IsDefaultHideCommand => HideCommand == _defaultHideCommand;
+		
 		/// <summary>Handles changes to the <see cref="HideCommand"/> property.</summary>
 		private static void OnHideCommandChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) => ((LayoutAnchorableItem)d).OnHideCommandChanged(e);
 

--- a/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
@@ -150,17 +150,6 @@ namespace AvalonDock.Controls
 						}
 					}
 					break;
-
-				case Win32Helper.WM_CLOSE:
-					if (CloseInitiatedByUser)
-					{
-						// We want to force the window to go through our standard logic for closing.
-						// So, if the window close is initiated outside of our code (such as from the taskbar),
-						// we cancel that close and trigger our close logic instead.
-						this.CloseWindowCommand.Execute(null);
-						handled = true;
-					}
-					break;
 			}
 			return base.FilterMessage(hwnd, msg, wParam, lParam, ref handled);
 		}

--- a/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
@@ -157,20 +157,12 @@ namespace AvalonDock.Controls
 		/// <inheritdoc />
 		protected override void OnClosed(EventArgs e)
 		{
-			var root = Model.Root;
-			// MK sometimes root is null, prevent crash, or should it always be set??
-			if (root != null)
-			{
-				root.Manager.RemoveFloatingWindow(this);
-				root.CollectGarbage();
-			}
 			if (_overlayWindow != null)
 			{
 				_overlayWindow.Close();
 				_overlayWindow = null;
 			}
 			base.OnClosed(e);
-			if (!CloseInitiatedByUser) root?.FloatingWindows.Remove(_model);
 			_model.PropertyChanged -= Model_PropertyChanged;
 		}
 

--- a/source/Components/AvalonDock/Controls/LayoutItem.cs
+++ b/source/Components/AvalonDock/Controls/LayoutItem.cs
@@ -289,6 +289,9 @@ namespace AvalonDock.Controls
 			get => (ICommand)GetValue(CloseCommandProperty);
 			set => SetValue(CloseCommandProperty, value);
 		}
+		
+		/// <summary>Gets wether the <see cref="CloseCommand"/> property has its default value.</summary>
+		internal bool IsDefaultCloseCommand => CloseCommand == _defaultCloseCommand;
 
 		/// <summary>Handles changes to the <see cref="CloseCommand"/> property.</summary>
 		private static void OnCloseCommandChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) => ((LayoutItem)d).OnCloseCommandChanged(e);

--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -1990,6 +1990,12 @@ namespace AvalonDock
 
 		internal void ExecuteContentActivateCommand(LayoutContent content) => content.IsActive = true;
 
+		internal void RaiseDocumentClosing(DocumentClosingEventArgs e) => DocumentClosing?.Invoke(this, e);
+		
+		internal void RaiseAnchorableHiding(AnchorableHidingEventArgs e) => AnchorableHiding?.Invoke(this, e);
+
+		internal void RaiseAnchorableClosing(AnchorableClosingEventArgs e) => AnchorableClosing?.Invoke(this, e);
+
 		#endregion Internal Methods
 
 		#region Overrides

--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -1996,6 +1996,12 @@ namespace AvalonDock
 
 		internal void RaiseAnchorableClosing(AnchorableClosingEventArgs e) => AnchorableClosing?.Invoke(this, e);
 
+		internal void RaiseDocumentClosed(LayoutDocument document) => DocumentClosed?.Invoke(this, new DocumentClosedEventArgs(document));
+		
+		internal void RaiseAnchorableClosed(LayoutAnchorable anchorable) => AnchorableClosed?.Invoke(this, new AnchorableClosedEventArgs(anchorable));
+		
+		internal void RaiseAnchorableHidden(LayoutAnchorable anchorable) => AnchorableHidden?.Invoke(this, new AnchorableHiddenEventArgs(anchorable));
+		
 		#endregion Internal Methods
 
 		#region Overrides

--- a/source/Components/AvalonDock/Layout/LayoutAnchorable.cs
+++ b/source/Components/AvalonDock/Layout/LayoutAnchorable.cs
@@ -646,6 +646,13 @@ namespace AvalonDock.Layout
 		//	_canClose = _canCloseValueBeforeInternalSet;
 		//}
 
+		internal bool TestCanHide()
+		{
+			var args = new CancelEventArgs();
+			OnHiding(args);
+			return !args.Cancel;
+		}
+		
 		#endregion Internal Methods
 
 		#region Private Methods

--- a/source/Components/AvalonDock/Layout/LayoutDocumentPaneGroup.cs
+++ b/source/Components/AvalonDock/Layout/LayoutDocumentPaneGroup.cs
@@ -8,6 +8,7 @@
  ************************************************************************/
 
 using System;
+using System.Linq;
 using System.Windows.Controls;
 using System.Windows.Markup;
 
@@ -60,9 +61,10 @@ namespace AvalonDock.Layout
 		#endregion Properties
 
 		#region Overrides
-
+		
 		/// <inheritdoc />
-		protected override bool GetVisibility() => true;
+		protected override bool GetVisibility() => 
+			Children.Count > 0 && Children.Any(c => c.IsVisible);
 
 		/// <inheritdoc />
 		public override void WriteXml(System.Xml.XmlWriter writer)

--- a/source/Components/AvalonDock/Win32Helper.cs
+++ b/source/Components/AvalonDock/Win32Helper.cs
@@ -153,7 +153,6 @@ namespace AvalonDock
 		internal const int WM_INITMENUPOPUP = 0x0117;
 		internal const int WM_KEYDOWN = 0x0100;
 		internal const int WM_KEYUP = 0x0101;
-		internal const int WM_CLOSE = 0x10;
 
 		internal const int WA_INACTIVE = 0x0000;
 


### PR DESCRIPTION
This pull request addresses several issues related to closing floating windows (LayoutAnchorableFloatingWindowControl and LayoutDocumentFloatingWindowControl) using standard Windows mechanisms (Taskbar 'X' button, Alt+F4) and improves visibility handling for floating document windows.

**Related issues this might solve:**
#368 

**Bugs Fixed:**

1.  **Incorrect Closing Logic via OS Commands (Alt+F4, Taskbar 'X'):** The previous implementation had flaws in handling standard OS close commands for floating windows:
    *   Floating document windows (`LayoutDocumentFloatingWindowControl`) could potentially bypass parts of the standard AvalonDock closing validation and execution logic when closed via OS commands.
    *   Floating anchorable windows (`LayoutAnchorableFloatingWindowControl`) lacked specific handling for OS close commands, potentially leading to the window being destroyed directly by the OS, bypassing AvalonDock's hide/close logic entirely.
    *   In both cases, custom `CloseCommand` or `HideCommand` overrides (e.g., set via styles) could be ignored when closing through OS mechanisms.
2.  **Floating Document Window Visibility:** `LayoutDocumentFloatingWindowControl` lacked the mechanism to automatically hide its WPF window view when its underlying model became effectively invisible (e.g., all contained anchorables were hidden). Conversely, it couldn't automatically reappear when the model became visible again. This resulted in empty floating windows remaining visible after closing via the taskbar 'X' if they contained only hidden anchorables.
3.  **Incorrect Visibility Calculation:** `LayoutDocumentPaneGroup.GetVisibility()` always returned `true`, preventing the correct propagation of visibility changes up the layout tree, which contributed to the floating document window visibility issue.

**Summary of Changes:**

*   **Refactored `OnClosing` Methods:** The `OnClosing` overrides in both `LayoutAnchorableFloatingWindowControl` and `LayoutDocumentFloatingWindowControl` have been substantially rewritten to serve as the single, reliable entry point for user-initiated window closing.
    *   They now correctly distinguish between `LayoutDocument` and `LayoutAnchorable` children during validation and execution phases.
    *   Proper validation logic is used, including checking `CanClose`/`CanHide` properties, internal `TestCanClose`/`TestCanHide`, specific manager events (`DocumentClosing`, `AnchorableClosing`, `AnchorableHiding` via new helper methods), and command `CanExecute`.
    *   The appropriate action (close or hide) is executed for each content type, respecting custom commands (`CloseCommand`/`HideCommand`) first, then falling back to default internal logic, and finally raising the correct corresponding manager events (`DocumentClosed`, `AnchorableClosed`, `AnchorableHidden`).
    *   The closing of the WPF Window itself (`e.Cancel = true`) is now correctly cancelled **only if** at least one child element was hidden and none were closed permanently, ensuring the floating container persists for hidden items.
*   **Added Visibility Handling to `LayoutDocumentFloatingWindowControl`:** Implemented `EnableBindings`/`DisableBindings` and added event handlers (`_model_IsVisibleChanged`, `Model_PropertyChanged` for `IsVisible`), mirroring `LayoutAnchorableFloatingWindowControl`. This ensures the window's `Visibility` now correctly synchronizes with its model's `IsVisible` state, allowing it to hide and reappear automatically.
*   **Corrected `LayoutDocumentPaneGroup.GetVisibility()`:** Fixed the method to return `true` only when it contains visible children, enabling correct visibility updates in the layout hierarchy.
*   **Cleanup:** Removed redundant `WM_CLOSE` handling. 
