### PR TITLE
Fix: binding errors in Generic.xaml for VS2013 theme

### DIFF
--- a/source/Components/AvalonDock.Themes.VS2013/Themes/Generic.xaml
+++ b/source/Components/AvalonDock.Themes.VS2013/Themes/Generic.xaml
@@ -1,23 +1,23 @@
 <!--
-	************************************************************************
-	AvalonDock
-	
-	Copyright (C) 2007-2013 Xceed Software Inc.
-	
-	This program is provided to you under the terms of the Microsoft Public
-	License (Ms-PL) as published at https://opensource.org/licenses/MS-PL
-	************************************************************************
+    ************************************************************************
+    AvalonDock
+    
+    Copyright (C) 2007-2013 Xceed Software Inc.
+    
+    This program is provided to you under the terms of the Microsoft Public
+    License (Ms-PL) as published at https://opensource.org/licenses/MS-PL
+    ************************************************************************
 -->
 
 <ResourceDictionary
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:avalonDock="clr-namespace:AvalonDock;assembly=AvalonDock"
-	xmlns:avalonDockControls="clr-namespace:AvalonDock.Controls;assembly=AvalonDock"
-	xmlns:avalonDockConverters="clr-namespace:AvalonDock.Converters;assembly=AvalonDock"
-	xmlns:avalonDockProperties="clr-namespace:AvalonDock.Properties;assembly=AvalonDock"
-	xmlns:reskeys="clr-namespace:AvalonDock.Themes.VS2013.Themes"
-	xmlns:shell="clr-namespace:Microsoft.Windows.Shell;assembly=AvalonDock">
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:avalonDock="clr-namespace:AvalonDock;assembly=AvalonDock"
+    xmlns:avalonDockControls="clr-namespace:AvalonDock.Controls;assembly=AvalonDock"
+    xmlns:avalonDockConverters="clr-namespace:AvalonDock.Converters;assembly=AvalonDock"
+    xmlns:avalonDockProperties="clr-namespace:AvalonDock.Properties;assembly=AvalonDock"
+    xmlns:reskeys="clr-namespace:AvalonDock.Themes.VS2013.Themes"
+    xmlns:shell="clr-namespace:Microsoft.Windows.Shell;assembly=AvalonDock">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/AvalonDock.Themes.VS2013;component/OverlayButtons.xaml" />
         <ResourceDictionary Source="/AvalonDock.Themes.VS2013;component/Themes/Menu/MenuItem.xaml" />
@@ -65,10 +65,13 @@
     </Style>	-->
 
     <!--
-		Re-styling this in AvalonDock since the menu on the drop-down button for more documents is otherwise black
-		BugFix for Issue http://avalondock.codeplex.com/workitem/15743
-	-->
-    <Style x:Key="AvalonDockThemeVs2013MenuItemStyle" BasedOn="{StaticResource {x:Type MenuItem}}" TargetType="{x:Type MenuItem}">
+        Re-styling this in AvalonDock since the menu on the drop-down button for more documents is otherwise black
+        BugFix for Issue http://avalondock.codeplex.com/workitem/15743
+    -->
+    <Style
+        x:Key="AvalonDockThemeVs2013MenuItemStyle"
+        BasedOn="{StaticResource {x:Type MenuItem}}"
+        TargetType="{x:Type MenuItem}">
         <Setter Property="HeaderTemplate" Value="{Binding Path=Root.Manager.DocumentPaneMenuItemHeaderTemplate}" />
         <Setter Property="HeaderTemplateSelector" Value="{Binding Path=Root.Manager.DocumentPaneMenuItemHeaderTemplateSelector}" />
         <Setter Property="BorderThickness" Value="0" />
@@ -80,9 +83,9 @@
         <Setter Property="IconTemplateSelector" Value="{Binding Path=Root.Manager.IconContentTemplateSelector}" />
         <Setter Property="Command" Value="{Binding Path=., Converter={avalonDockConverters:ActivateCommandLayoutItemFromLayoutModelConverter}}" />
         <!--
-			Retemplate ControlTemplate of MenuItem to get rid of blue'ish highlighting colors on menu item
-			https://stackoverflow.com/questions/34888636/change-background-color-of-menuitem-on-mouseover
-		-->
+            Retemplate ControlTemplate of MenuItem to get rid of blue'ish highlighting colors on menu item
+            https://stackoverflow.com/questions/34888636/change-background-color-of-menuitem-on-mouseover
+        -->
     </Style>
 
     <!--
@@ -148,9 +151,9 @@
             <Setter.Value>
                 <ControlTemplate TargetType="ToggleButton">
                     <Border
-						Background="{TemplateBinding Background}"
-						BorderBrush="{TemplateBinding BorderBrush}"
-						BorderThickness="{TemplateBinding BorderThickness}">
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}">
                         <ContentPresenter />
                     </Border>
                 </ControlTemplate>
@@ -178,9 +181,9 @@
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
                     <Border
-						Background="{TemplateBinding Background}"
-						BorderBrush="{TemplateBinding BorderBrush}"
-						BorderThickness="{TemplateBinding BorderThickness}">
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}">
                         <ContentPresenter />
                     </Border>
                 </ControlTemplate>
@@ -191,80 +194,80 @@
     <!--  DocumentPaneControlStyle  -->
     <Style x:Key="AvalonDockThemeVs2013DocumentPaneControlStyle" TargetType="{x:Type avalonDockControls:LayoutDocumentPaneControl}">
         <Setter Property="BorderBrush" Value="{x:Null}" />
-		<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.TabBackground}}" />
-		<Setter Property="Template">
+        <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.TabBackground}}" />
+        <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutDocumentPaneControl}">
                     <Grid
-						ClipToBounds="true"
-						KeyboardNavigation.TabNavigation="Local"
-						SnapsToDevicePixels="true">
+                        ClipToBounds="true"
+                        KeyboardNavigation.TabNavigation="Local"
+                        SnapsToDevicePixels="true">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
                         <!--  Following border is required to catch mouse events  -->
                         <Border Grid.RowSpan="2" Background="Transparent" />
-						<Grid
-							Margin="1,0"
-							Grid.Row="0"
-							Panel.ZIndex="1"
-							Visibility="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type avalonDockControls:LayoutDocumentPaneControl}}, Path=Model.ShowHeader, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
-							<Grid.ColumnDefinitions>
-								<ColumnDefinition />
-								<ColumnDefinition Width="Auto" />
-							</Grid.ColumnDefinitions>
-							<Border
-								x:Name="BD"
-								Grid.ColumnSpan="2"
-								BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedActiveBackground}}"
-								BorderThickness="0,0,0,2" />
-							<avalonDockControls:DocumentPaneTabPanel
-								x:Name="HeaderPanel"
-								Grid.Row="0"
-								Grid.Column="0"
-								Margin="0"
-								IsItemsHost="true"
-								KeyboardNavigation.TabIndex="1" />
-							<avalonDockControls:DropDownButton
-								x:Name="MenuDropDownButton"
+                        <Grid
+                            Grid.Row="0"
+                            Margin="1,0"
+                            Panel.ZIndex="1"
+                            Visibility="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type avalonDockControls:LayoutDocumentPaneControl}}, Path=Model.ShowHeader, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Border
+                                x:Name="BD"
+                                Grid.ColumnSpan="2"
+                                BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedActiveBackground}}"
+                                BorderThickness="0,0,0,2" />
+                            <avalonDockControls:DocumentPaneTabPanel
+                                x:Name="HeaderPanel"
+                                Grid.Row="0"
+                                Grid.Column="0"
+                                Margin="0"
+                                IsItemsHost="true"
+                                KeyboardNavigation.TabIndex="1" />
+                            <avalonDockControls:DropDownButton
+                                x:Name="MenuDropDownButton"
+                                Grid.Column="1"
                                 Width="14"
                                 Height="14"
                                 Margin="0,0,-1,5"
-								Grid.Column="1"
-								VerticalAlignment="Bottom"
-								Focusable="False"
-								Style="{StaticResource AvalonDockThemeVs2013ToolButtonStyle}">
-								<avalonDockControls:DropDownButton.DropDownContextMenu>
-									<avalonDockControls:ContextMenuEx ItemsSource="{Binding Model.ChildrenSorted, RelativeSource={RelativeSource TemplatedParent}}" />
-								</avalonDockControls:DropDownButton.DropDownContextMenu>
-								<Path
-									x:Name="MenuDropDownButtonImage"
-									Height="8"
-									HorizontalAlignment="Center"
-									VerticalAlignment="Center"
-									Data="{DynamicResource PinDocMenu}"
-									Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellOverflowButtonDefaultGlyph}}"
-									Stretch="Uniform" />
-							</avalonDockControls:DropDownButton>
-						</Grid>
-						<Border
-							x:Name="ContentPanel"
-							Grid.Row="1"
-							Grid.Column="0"
-							HorizontalAlignment="Stretch"
-							VerticalAlignment="Stretch"
-							Background="{TemplateBinding Background}"
-							BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}"
-							BorderThickness="1,0,1,1"
-							KeyboardNavigation.DirectionalNavigation="Contained"
-							KeyboardNavigation.TabIndex="2"
-							KeyboardNavigation.TabNavigation="Cycle">
+                                VerticalAlignment="Bottom"
+                                Focusable="False"
+                                Style="{StaticResource AvalonDockThemeVs2013ToolButtonStyle}">
+                                <avalonDockControls:DropDownButton.DropDownContextMenu>
+                                    <avalonDockControls:ContextMenuEx ItemsSource="{Binding Model.ChildrenSorted, RelativeSource={RelativeSource TemplatedParent}}" />
+                                </avalonDockControls:DropDownButton.DropDownContextMenu>
+                                <Path
+                                    x:Name="MenuDropDownButtonImage"
+                                    Height="8"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Data="{DynamicResource PinDocMenu}"
+                                    Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellOverflowButtonDefaultGlyph}}"
+                                    Stretch="Uniform" />
+                            </avalonDockControls:DropDownButton>
+                        </Grid>
+                        <Border
+                            x:Name="ContentPanel"
+                            Grid.Row="1"
+                            Grid.Column="0"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}"
+                            BorderThickness="1,0,1,1"
+                            KeyboardNavigation.DirectionalNavigation="Contained"
+                            KeyboardNavigation.TabIndex="2"
+                            KeyboardNavigation.TabNavigation="Cycle">
                             <ContentPresenter
-								x:Name="PART_SelectedContentHost"
-								Margin="0"
-								ContentSource="SelectedContent"
-								SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                x:Name="PART_SelectedContentHost"
+                                Margin="0"
+                                ContentSource="SelectedContent"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -297,10 +300,10 @@
                             <Setter TargetName="MenuDropDownButton" Property="Visibility" Value="Collapsed" />
                         </DataTrigger>
 
-						<DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Model.ShowHeader}" Value="False">
-							<Setter TargetName="ContentPanel" Property="BorderThickness" Value="1" />
-						</DataTrigger>
-					</ControlTemplate.Triggers>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Model.ShowHeader}" Value="False">
+                            <Setter TargetName="ContentPanel" Property="BorderThickness" Value="1" />
+                        </DataTrigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -319,17 +322,17 @@
                             <ControlTemplate TargetType="{x:Type TabItem}">
                                 <Grid SnapsToDevicePixels="true">
                                     <Border
-										x:Name="Bd"
-										Background="{TemplateBinding Background}"
-										BorderBrush="{Binding Background, RelativeSource={RelativeSource Self}}"
-										BorderThickness="0,0,0,2" />
+                                        x:Name="Bd"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{Binding Background, RelativeSource={RelativeSource Self}}"
+                                        BorderThickness="0,0,0,2" />
                                     <ContentPresenter
-										x:Name="Content"
-										HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
-										VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
-										ContentSource="Header"
-										RecognizesAccessKey="True"
-										SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                        x:Name="Content"
+                                        HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
+                                        VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
+                                        ContentSource="Header"
+                                        RecognizesAccessKey="True"
+                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                                 </Grid>
                                 <ControlTemplate.Triggers>
                                     <Trigger Property="Selector.IsSelected" Value="true">
@@ -411,9 +414,9 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutAnchorablePaneControl}">
                     <Grid
-						ClipToBounds="true"
-						KeyboardNavigation.TabNavigation="Local"
-						SnapsToDevicePixels="true">
+                        ClipToBounds="true"
+                        KeyboardNavigation.TabNavigation="Local"
+                        SnapsToDevicePixels="true">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="*" />
                             <RowDefinition Height="Auto" />
@@ -421,29 +424,29 @@
                         <!--  Following border is required to catch mouse events  -->
                         <Border Grid.RowSpan="2" Background="Transparent" />
                         <Border
-							x:Name="ContentPanel"
-							Grid.Row="0"
-							Grid.Column="0"
-							Margin="0"
-							Background="{TemplateBinding Background}"
-							BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}"
-							BorderThickness="0"
-							KeyboardNavigation.DirectionalNavigation="Contained"
-							KeyboardNavigation.TabIndex="2"
-							KeyboardNavigation.TabNavigation="Cycle">
+                            x:Name="ContentPanel"
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            Margin="0"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}"
+                            BorderThickness="0"
+                            KeyboardNavigation.DirectionalNavigation="Contained"
+                            KeyboardNavigation.TabIndex="2"
+                            KeyboardNavigation.TabNavigation="Cycle">
                             <ContentPresenter
-								x:Name="PART_SelectedContentHost"
-								Margin="{TemplateBinding Padding}"
-								ContentSource="SelectedContent"
-								SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                x:Name="PART_SelectedContentHost"
+                                Margin="{TemplateBinding Padding}"
+                                ContentSource="SelectedContent"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Border>
                         <avalonDockControls:AnchorablePaneTabPanel
-							x:Name="HeaderPanel"
-							Grid.Row="1"
-							Margin="0"
-							Panel.ZIndex="1"
-							IsItemsHost="true"
-							KeyboardNavigation.TabIndex="1" />
+                            x:Name="HeaderPanel"
+                            Grid.Row="1"
+                            Margin="0"
+                            Panel.ZIndex="1"
+                            IsItemsHost="true"
+                            KeyboardNavigation.TabIndex="1" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="false">
@@ -467,31 +470,31 @@
                             <ControlTemplate TargetType="{x:Type TabItem}">
                                 <Grid SnapsToDevicePixels="true">
                                     <Border
-										x:Name="SelectedBD"
-										Margin="1,-1,1,0"
-										BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabSelectedActiveBackground}}"
-										BorderThickness="0,1,0,0"
-										Visibility="Collapsed" />
+                                        x:Name="SelectedBD"
+                                        Margin="1,-1,1,0"
+                                        BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowTabSelectedActiveBackground}}"
+                                        BorderThickness="0,1,0,0"
+                                        Visibility="Collapsed" />
                                     <Border
-										x:Name="Bd"
-										Margin="0"
-										Background="{TemplateBinding Background}"
-										BorderBrush="{TemplateBinding Background}"
-										BorderThickness="1,0,1,1">
+                                        x:Name="Bd"
+                                        Margin="0"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding Background}"
+                                        BorderThickness="1,0,1,1">
                                         <ContentPresenter
-											x:Name="Content"
-											Margin="6,1,6,3"
-											HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
-											VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
-											ContentSource="Header"
-											RecognizesAccessKey="True"
-											SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                            x:Name="Content"
+                                            Margin="6,1,6,3"
+                                            HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
+                                            VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
+                                            ContentSource="Header"
+                                            RecognizesAccessKey="True"
+                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                                     </Border>
                                 </Grid>
                                 <ControlTemplate.Triggers>
                                     <Trigger Property="Selector.IsSelected" Value="true">
-										<Setter TargetName="SelectedBD" Property="Visibility" Value="Visible" />
-										<Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}" />
+                                        <Setter TargetName="SelectedBD" Property="Visibility" Value="Visible" />
+                                        <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}" />
                                         <Setter Property="Panel.ZIndex" Value="1" />
                                     </Trigger>
 
@@ -566,134 +569,140 @@
             <Setter.Value>
                 <ControlTemplate>
                     <Border
-						Background="{TemplateBinding Background}"
-						BorderBrush="{TemplateBinding BorderBrush}"
-						BorderThickness="{TemplateBinding BorderThickness}">
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}">
                         <Grid Margin="2,2,3,3">
-							<Grid.ColumnDefinitions>
-								<ColumnDefinition Width="*" />
-								<ColumnDefinition Width="Auto" />
-								<ColumnDefinition Width="Auto" />
-								<ColumnDefinition Width="Auto" />
-							</Grid.ColumnDefinitions>
-							<Rectangle
-								x:Name="DragHandleGeometryPlaceholder"
-								Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveGrip}}"
-								Visibility="Collapsed" />
-							<DockPanel>
-								<Border
-									Padding="2,0,4,0"
-									HorizontalAlignment="Left"
-									Background="{TemplateBinding Background}">
-									<avalonDockControls:DropDownControlArea
-										DropDownContextMenu="{Binding Model.Root.Manager.AnchorableContextMenu, RelativeSource={RelativeSource TemplatedParent}}"
-										DropDownContextMenuDataContext="{Binding Path=LayoutItem, RelativeSource={RelativeSource TemplatedParent}}"
-										Style="{DynamicResource DropDownControlArea}">
-										<ContentPresenter
-											x:Name="Header"
-											Content="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}"
-											ContentTemplate="{Binding Model.Root.Manager.AnchorableTitleTemplate, RelativeSource={RelativeSource TemplatedParent}}"
-											ContentTemplateSelector="{Binding Model.Root.Manager.AnchorableTitleTemplateSelector, RelativeSource={RelativeSource TemplatedParent}}"
-											TextElement.Foreground="{TemplateBinding Foreground}" />
-									</avalonDockControls:DropDownControlArea>
-								</Border>
-								<Rectangle
-									x:Name="DragHandleTexture"
-									Height="5"
-									Margin="4,0,2,0"
-									VerticalAlignment="Center"
-									UseLayoutRounding="True"
-									RenderOptions.BitmapScalingMode="NearestNeighbor">
-									<Rectangle.Fill>
-										<DrawingBrush
-											TileMode="Tile"
-											Viewbox="0,0,4,4"
-											ViewboxUnits="Absolute"
-											Viewport="0,0,4,4"
-											ViewportUnits="Absolute">
-											<DrawingBrush.Drawing>
-												<GeometryDrawing Brush="{Binding Fill, ElementName=DragHandleGeometryPlaceholder, Mode=OneWay, Converter={avalonDockConverters:NullToDoNothingConverter}}">
-													<GeometryDrawing.Geometry>
-														<GeometryGroup>
-															<GeometryGroup.Children>
-																<RectangleGeometry Rect="0,0,1,1" />
-																<RectangleGeometry Rect="2,2,1,1" />
-															</GeometryGroup.Children>
-														</GeometryGroup>
-													</GeometryDrawing.Geometry>
-												</GeometryDrawing>
-											</DrawingBrush.Drawing>
-										</DrawingBrush>
-									</Rectangle.Fill>
-								</Rectangle>
-							</DockPanel>
-							<avalonDockControls:DropDownButton
-								x:Name="MenuDropDownButton"
-								Grid.Column="1"
-								Margin="1,1,1,0"
-								Width="15"
-                                Height="15"
-								VerticalAlignment="Center"
-								DropDownContextMenu="{Binding Model.Root.Manager.AnchorableContextMenu, RelativeSource={RelativeSource TemplatedParent}}"
-								DropDownContextMenuDataContext="{Binding Path=LayoutItem, RelativeSource={RelativeSource TemplatedParent}}"
-								Focusable="False"
-								Style="{StaticResource AvalonDockThemeVs2013ToolButtonStyle}"
-								ToolTip="{x:Static avalonDockProperties:Resources.Anchorable_CxMenu_Hint}">
-                                <Path
-									x:Name="PART_ImgMenuPin"
-									Margin="0,0,0,1"
-									Width="8"
-									Height="8"
-									Data="{DynamicResource PinMenu}"
-									Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveGlyph}}"
-									Stretch="Uniform" />
-                            </avalonDockControls:DropDownButton>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Rectangle
+                                x:Name="DragHandleGeometryPlaceholder"
+                                Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveGrip}}"
+                                Visibility="Collapsed" />
+                            <DockPanel>
+                                <Border
+                                    Padding="2,0,4,0"
+                                    HorizontalAlignment="Left"
+                                    Background="{TemplateBinding Background}">
+                                    <avalonDockControls:DropDownControlArea
+                                        DropDownContextMenu="{Binding Model.Root.Manager.AnchorableContextMenu, RelativeSource={RelativeSource TemplatedParent}}"
+                                        DropDownContextMenuDataContext="{Binding Path=LayoutItem, RelativeSource={RelativeSource TemplatedParent}}"
+                                        Style="{DynamicResource DropDownControlArea}">
+                                        <ContentPresenter
+                                            x:Name="Header"
+                                            Content="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}"
+                                            ContentTemplate="{Binding Model.Root.Manager.AnchorableTitleTemplate, RelativeSource={RelativeSource TemplatedParent}}"
+                                            ContentTemplateSelector="{Binding Model.Root.Manager.AnchorableTitleTemplateSelector, RelativeSource={RelativeSource TemplatedParent}}"
+                                            TextElement.Foreground="{TemplateBinding Foreground}" />
+                                    </avalonDockControls:DropDownControlArea>
+                                </Border>
+                                <Rectangle
+                                    x:Name="DragHandleTexture"
+                                    Height="5"
+                                    Margin="4,0,2,0"
+                                    VerticalAlignment="Center"
+                                    RenderOptions.BitmapScalingMode="NearestNeighbor"
+                                    UseLayoutRounding="True">
+                                    <Rectangle.Fill>
+                                        <DrawingBrush
+                                            TileMode="Tile"
+                                            Viewbox="0,0,4,4"
+                                            ViewboxUnits="Absolute"
+                                            Viewport="0,0,4,4"
+                                            ViewportUnits="Absolute">
+                                            <DrawingBrush.Drawing>
 
-							<Button
-								x:Name="PART_AutoHidePin"
-								Grid.Column="2"
-								Margin="1,1,1,0"
-								Width="15"
-                                Height="15"
-								HorizontalAlignment="Center"
-								VerticalAlignment="Center"
-								Command="{Binding Path=LayoutItem.AutoHideCommand, RelativeSource={RelativeSource TemplatedParent}}"
-								Focusable="False"
-								Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
-								ToolTip="{x:Static avalonDockProperties:Resources.Anchorable_BtnAutoHide_Hint}"
-								Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
-								<Path
-									x:Name="PART_ImgAutoHidePin"
-									UseLayoutRounding="True"
-									RenderOptions.BitmapScalingMode="NearestNeighbor"
-									Width="11"
-									Height="11"
-									Data="{DynamicResource PinAutoHide}"
-									Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveGlyph}}"
-									Stretch="Uniform" />
-							</Button>
-							<Button
-								x:Name="PART_HidePin"
-								Grid.Column="3"
-								Margin="0,1,1,0"
+                                                <!--  FIX: Replace the binding with a direct resource reference  -->
+                                                <GeometryDrawing Brush="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveGrip}}">
+
+                                                    <!--  ERROR HERE  -->
+                                                    <!--<GeometryDrawing Brush="{Binding Fill, ElementName=DragHandleGeometryPlaceholder, Mode=OneWay, Converter={avalonDockConverters:NullToDoNothingConverter}}">-->
+
+                                                    <GeometryDrawing.Geometry>
+                                                        <GeometryGroup>
+                                                            <GeometryGroup.Children>
+                                                                <RectangleGeometry Rect="0,0,1,1" />
+                                                                <RectangleGeometry Rect="2,2,1,1" />
+                                                            </GeometryGroup.Children>
+                                                        </GeometryGroup>
+                                                    </GeometryDrawing.Geometry>
+                                                </GeometryDrawing>
+                                            </DrawingBrush.Drawing>
+                                        </DrawingBrush>
+                                    </Rectangle.Fill>
+                                </Rectangle>
+                            </DockPanel>
+                            <avalonDockControls:DropDownButton
+                                x:Name="MenuDropDownButton"
+                                Grid.Column="1"
                                 Width="15"
                                 Height="15"
-								HorizontalAlignment="Center"
-								VerticalAlignment="Center"
-								Command="{Binding Path=LayoutItem.HideCommand, RelativeSource={RelativeSource TemplatedParent}}"
-								Focusable="False"
-								Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
-								ToolTip="{x:Static avalonDockProperties:Resources.Anchorable_BtnClose_Hint}"
-								Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
+                                Margin="1,1,1,0"
+                                VerticalAlignment="Center"
+                                DropDownContextMenu="{Binding Model.Root.Manager.AnchorableContextMenu, RelativeSource={RelativeSource TemplatedParent}}"
+                                DropDownContextMenuDataContext="{Binding Path=LayoutItem, RelativeSource={RelativeSource TemplatedParent}}"
+                                Focusable="False"
+                                Style="{StaticResource AvalonDockThemeVs2013ToolButtonStyle}"
+                                ToolTip="{x:Static avalonDockProperties:Resources.Anchorable_CxMenu_Hint}">
                                 <Path
-									x:Name="PART_ImgHidePin"
-									Width="10"
-									Height="10"
-									Margin="1,0,0,1"
-									VerticalAlignment="Center"
-									Data="{DynamicResource PinClose}"
-									Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveGlyph}}"
-									Stretch="Uniform" />
+                                    x:Name="PART_ImgMenuPin"
+                                    Width="8"
+                                    Height="8"
+                                    Margin="0,0,0,1"
+                                    Data="{DynamicResource PinMenu}"
+                                    Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveGlyph}}"
+                                    Stretch="Uniform" />
+                            </avalonDockControls:DropDownButton>
+
+                            <Button
+                                x:Name="PART_AutoHidePin"
+                                Grid.Column="2"
+                                Width="15"
+                                Height="15"
+                                Margin="1,1,1,0"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Command="{Binding Path=LayoutItem.AutoHideCommand, RelativeSource={RelativeSource TemplatedParent}}"
+                                Focusable="False"
+                                Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
+                                ToolTip="{x:Static avalonDockProperties:Resources.Anchorable_BtnAutoHide_Hint}"
+                                Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
+                                <Path
+                                    x:Name="PART_ImgAutoHidePin"
+                                    Width="11"
+                                    Height="11"
+                                    Data="{DynamicResource PinAutoHide}"
+                                    Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveGlyph}}"
+                                    RenderOptions.BitmapScalingMode="NearestNeighbor"
+                                    Stretch="Uniform"
+                                    UseLayoutRounding="True" />
+                            </Button>
+                            <Button
+                                x:Name="PART_HidePin"
+                                Grid.Column="3"
+                                Width="15"
+                                Height="15"
+                                Margin="0,1,1,0"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Command="{Binding Path=LayoutItem.HideCommand, RelativeSource={RelativeSource TemplatedParent}}"
+                                Focusable="False"
+                                Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
+                                ToolTip="{x:Static avalonDockProperties:Resources.Anchorable_BtnClose_Hint}"
+                                Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
+                                <Path
+                                    x:Name="PART_ImgHidePin"
+                                    Width="10"
+                                    Height="10"
+                                    Margin="1,0,0,1"
+                                    VerticalAlignment="Center"
+                                    Data="{DynamicResource PinClose}"
+                                    Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveGlyph}}"
+                                    Stretch="Uniform" />
                             </Button>
 
                         </Grid>
@@ -811,53 +820,53 @@
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
                     <StackPanel
-						MinWidth="6"
-						MinHeight="6"
-						Orientation="{Binding Path=Model.Side, RelativeSource={RelativeSource AncestorType={x:Type avalonDockControls:LayoutAnchorSideControl}, Mode=FindAncestor}, Converter={avalonDockConverters:AnchorSideToOrientationConverter}}" />
+                        MinWidth="6"
+                        MinHeight="6"
+                        Orientation="{Binding Path=Model.Side, RelativeSource={RelativeSource AncestorType={x:Type avalonDockControls:LayoutAnchorSideControl}, Mode=FindAncestor}, Converter={avalonDockConverters:AnchorSideToOrientationConverter}}" />
                 </ItemsPanelTemplate>
             </ItemsControl.ItemsPanel>
         </ItemsControl>
     </ControlTemplate>
 
     <ControlTemplate x:Key="AvalonDockThemeVs2013AnchorGroupTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorGroupControl}">
-		<ItemsControl ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Children}">
-			<ItemsControl.ItemsPanel>
-				<ItemsPanelTemplate>
-					<StackPanel Orientation="Horizontal" />
-				</ItemsPanelTemplate>
-			</ItemsControl.ItemsPanel>
-			<ItemsControl.Style>
-				<Style TargetType="{x:Type ItemsControl}">
-					<Style.Resources>
-						<RotateTransform x:Key="LeftRightAnchorSideRotateTransform" Angle="90" />
-					</Style.Resources>
-					<Style.Triggers>
-						<DataTrigger Binding="{Binding Path=Model.Parent.Side, RelativeSource={RelativeSource TemplatedParent}}" Value="Left">
-							<Setter Property="LayoutTransform" Value="{StaticResource LeftRightAnchorSideRotateTransform}" />
-						</DataTrigger>
-						<DataTrigger Binding="{Binding Path=Model.Parent.Side, RelativeSource={RelativeSource TemplatedParent}}" Value="Right">
-							<Setter Property="LayoutTransform" Value="{StaticResource LeftRightAnchorSideRotateTransform}" />
-						</DataTrigger>
-					</Style.Triggers>
-				</Style>
-			</ItemsControl.Style>
-		</ItemsControl>
+        <ItemsControl ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Children}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal" />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.Style>
+                <Style TargetType="{x:Type ItemsControl}">
+                    <Style.Resources>
+                        <RotateTransform x:Key="LeftRightAnchorSideRotateTransform" Angle="90" />
+                    </Style.Resources>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding Path=Model.Parent.Side, RelativeSource={RelativeSource TemplatedParent}}" Value="Left">
+                            <Setter Property="LayoutTransform" Value="{StaticResource LeftRightAnchorSideRotateTransform}" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Path=Model.Parent.Side, RelativeSource={RelativeSource TemplatedParent}}" Value="Right">
+                            <Setter Property="LayoutTransform" Value="{StaticResource LeftRightAnchorSideRotateTransform}" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </ItemsControl.Style>
+        </ItemsControl>
     </ControlTemplate>
 
     <ControlTemplate x:Key="AvalonDockThemeVs2013AnchorTemplate" TargetType="{x:Type avalonDockControls:LayoutAnchorControl}">
-		<Border
-			x:Name="Bd"
-			Margin="0,0,12,0"
-			Padding="0,6,0,4"
-			Background="{DynamicResource {x:Static reskeys:ResourceKeys.AutoHideTabDefaultBackground}}"
-			BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.AutoHideTabDefaultBorder}}"
-			BorderThickness="0,0,0,6"
-			TextOptions.TextFormattingMode="Display"
-			TextElement.Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.AutoHideTabDefaultText}}">
-			<ContentPresenter
-				Content="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}"
-				ContentTemplate="{Binding AnchorableHeaderTemplate, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}"
-				ContentTemplateSelector="{Binding AnchorableHeaderTemplateSelector, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}" />
+        <Border
+            x:Name="Bd"
+            Margin="0,0,12,0"
+            Padding="0,6,0,4"
+            Background="{DynamicResource {x:Static reskeys:ResourceKeys.AutoHideTabDefaultBackground}}"
+            BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.AutoHideTabDefaultBorder}}"
+            BorderThickness="0,0,0,6"
+            TextElement.Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.AutoHideTabDefaultText}}"
+            TextOptions.TextFormattingMode="Display">
+            <ContentPresenter
+                Content="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}"
+                ContentTemplate="{Binding AnchorableHeaderTemplate, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}"
+                ContentTemplateSelector="{Binding AnchorableHeaderTemplateSelector, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}" />
         </Border>
         <ControlTemplate.Triggers>
             <Trigger Property="Side" Value="Right">
@@ -887,88 +896,88 @@
                 <ControlTemplate TargetType="{x:Type avalonDockControls:OverlayWindow}">
                     <Canvas x:Name="PART_DropTargetsContainer" Opacity="0.9">
                         <!--
-							Drop target rectangle that is displayed before a document or tool window
-							is dropped into a drop target location
-						-->
+                            Drop target rectangle that is displayed before a document or tool window
+                            is dropped into a drop target location
+                        -->
                         <Path
-							x:Name="PART_PreviewBox"
-							Fill="{DynamicResource {x:Static reskeys:ResourceKeys.PreviewBoxBackgroundBrushKey}}"
-							Stroke="{DynamicResource {x:Static reskeys:ResourceKeys.PreviewBoxBorderBrushKey}}"
-							StrokeThickness="0.5" />
+                            x:Name="PART_PreviewBox"
+                            Fill="{DynamicResource {x:Static reskeys:ResourceKeys.PreviewBoxBackgroundBrushKey}}"
+                            Stroke="{DynamicResource {x:Static reskeys:ResourceKeys.PreviewBoxBorderBrushKey}}"
+                            StrokeThickness="0.5" />
 
                         <!--
-							Outmost Outter 4 overlay buttons that are displayed at border of MainWindow
-							when user drags tool window over another tool window or document and the
-							AvalonDock air space contains additional document(s) and tool windows (s).
-						-->
+                            Outmost Outter 4 overlay buttons that are displayed at border of MainWindow
+                            when user drags tool window over another tool window or document and the
+                            AvalonDock air space contains additional document(s) and tool windows (s).
+                        -->
                         <Grid x:Name="PART_DockingManagerDropTargets">
                             <ContentControl
-								x:Name="PART_DockingManagerDropTargetLeft"
-								Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-								Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-								Margin="10"
-								HorizontalAlignment="Left"
-								VerticalAlignment="Center"
-								HorizontalContentAlignment="Stretch"
-								VerticalContentAlignment="Stretch"
-								Background="Transparent"
-								BorderBrush="Transparent"
-								Content="{StaticResource DockAnchorableLeft}" />
+                                x:Name="PART_DockingManagerDropTargetLeft"
+                                Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                Margin="10"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                HorizontalContentAlignment="Stretch"
+                                VerticalContentAlignment="Stretch"
+                                Background="Transparent"
+                                BorderBrush="Transparent"
+                                Content="{StaticResource DockAnchorableLeft}" />
 
                             <ContentControl
-								x:Name="PART_DockingManagerDropTargetRight"
-								Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-								Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-								Margin="10"
-								HorizontalAlignment="Right"
-								VerticalAlignment="Center"
-								HorizontalContentAlignment="Stretch"
-								VerticalContentAlignment="Stretch"
-								Background="Transparent"
-								BorderBrush="Transparent"
-								Content="{StaticResource DockAnchorableRight}" />
+                                x:Name="PART_DockingManagerDropTargetRight"
+                                Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                Margin="10"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Center"
+                                HorizontalContentAlignment="Stretch"
+                                VerticalContentAlignment="Stretch"
+                                Background="Transparent"
+                                BorderBrush="Transparent"
+                                Content="{StaticResource DockAnchorableRight}" />
 
                             <ContentControl
-								x:Name="PART_DockingManagerDropTargetBottom"
-								Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-								Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-								Margin="10"
-								HorizontalAlignment="Center"
-								VerticalAlignment="Bottom"
-								HorizontalContentAlignment="Stretch"
-								VerticalContentAlignment="Stretch"
-								Background="Transparent"
-								BorderBrush="Transparent"
-								Content="{StaticResource DockAnchorableBottom}" />
+                                x:Name="PART_DockingManagerDropTargetBottom"
+                                Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                Margin="10"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Bottom"
+                                HorizontalContentAlignment="Stretch"
+                                VerticalContentAlignment="Stretch"
+                                Background="Transparent"
+                                BorderBrush="Transparent"
+                                Content="{StaticResource DockAnchorableBottom}" />
 
                             <ContentControl
-								x:Name="PART_DockingManagerDropTargetTop"
-								Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-								Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-								Margin="10"
-								HorizontalAlignment="Center"
-								VerticalAlignment="Top"
-								HorizontalContentAlignment="Stretch"
-								VerticalContentAlignment="Stretch"
-								Background="Transparent"
-								BorderBrush="Transparent"
-								Content="{StaticResource DockAnchorableTop}" />
+                                x:Name="PART_DockingManagerDropTargetTop"
+                                Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                Margin="10"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Top"
+                                HorizontalContentAlignment="Stretch"
+                                VerticalContentAlignment="Stretch"
+                                Background="Transparent"
+                                BorderBrush="Transparent"
+                                Content="{StaticResource DockAnchorableTop}" />
 
                         </Grid>
 
                         <!--
-							Is displayed as center cross with a max of 5 buttons when a toolwindow is
-							dragged over another tool window
-						-->
+                            Is displayed as center cross with a max of 5 buttons when a toolwindow is
+                            dragged over another tool window
+                        -->
                         <Grid x:Name="PART_AnchorablePaneDropTargets">
                             <!--  Gray Star Background  -->
                             <Path
-								Height="122"
-								Data="{DynamicResource DockPaneEmpty}"
-								Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBackgroundBrushKey}}"
-								Stretch="Uniform"
-								Stroke="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBorderBrushKey}}"
-								StrokeThickness="1" />
+                                Height="122"
+                                Data="{DynamicResource DockPaneEmpty}"
+                                Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBackgroundBrushKey}}"
+                                Stretch="Uniform"
+                                Stroke="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBorderBrushKey}}"
+                                StrokeThickness="1" />
                             <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition />
@@ -982,61 +991,61 @@
                                 </Grid.RowDefinitions>
                                 <!--  Inner 5 buttons of star shapped control  -->
                                 <ContentControl
-									x:Name="PART_AnchorablePaneDropTargetTop"
-									Grid.Row="0"
-									Grid.Column="1"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentAsAnchorableTop}" />
+                                    x:Name="PART_AnchorablePaneDropTargetTop"
+                                    Grid.Row="0"
+                                    Grid.Column="1"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentAsAnchorableTop}" />
                                 <ContentControl
-									x:Name="PART_AnchorablePaneDropTargetRight"
-									Grid.Row="1"
-									Grid.Column="2"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentAsAnchorableRight}" />
+                                    x:Name="PART_AnchorablePaneDropTargetRight"
+                                    Grid.Row="1"
+                                    Grid.Column="2"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentAsAnchorableRight}" />
                                 <ContentControl
-									x:Name="PART_AnchorablePaneDropTargetBottom"
-									Grid.Row="2"
-									Grid.Column="1"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentAsAnchorableBottom}" />
+                                    x:Name="PART_AnchorablePaneDropTargetBottom"
+                                    Grid.Row="2"
+                                    Grid.Column="1"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentAsAnchorableBottom}" />
                                 <ContentControl
-									x:Name="PART_AnchorablePaneDropTargetLeft"
-									Grid.Row="1"
-									Grid.Column="0"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentAsAnchorableLeft}" />
+                                    x:Name="PART_AnchorablePaneDropTargetLeft"
+                                    Grid.Row="1"
+                                    Grid.Column="0"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentAsAnchorableLeft}" />
                                 <!--  Center button of star shapped control  -->
                                 <ContentControl
-									x:Name="PART_AnchorablePaneDropTargetInto"
-									Grid.Row="1"
-									Grid.Column="1"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentInside}" />
+                                    x:Name="PART_AnchorablePaneDropTargetInto"
+                                    Grid.Row="1"
+                                    Grid.Column="1"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentInside}" />
                             </Grid>
                         </Grid>
 
@@ -1045,12 +1054,12 @@
 
                             <!--  Gray Star Background  -->
                             <Path
-								Height="122"
-								Data="{DynamicResource DockPaneEmpty}"
-								Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBackgroundBrushKey}}"
-								Stretch="Uniform"
-								Stroke="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBorderBrushKey}}"
-								StrokeThickness="1" />
+                                Height="122"
+                                Data="{DynamicResource DockPaneEmpty}"
+                                Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBackgroundBrushKey}}"
+                                Stretch="Uniform"
+                                Stroke="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBorderBrushKey}}"
+                                StrokeThickness="1" />
 
                             <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <Grid.ColumnDefinitions>
@@ -1065,61 +1074,61 @@
                                 </Grid.RowDefinitions>
                                 <!--  Inner 5 buttons of star shapped control  -->
                                 <ContentControl
-									x:Name="PART_DocumentPaneDropTargetTop"
-									Grid.Row="0"
-									Grid.Column="1"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentTop}" />
+                                    x:Name="PART_DocumentPaneDropTargetTop"
+                                    Grid.Row="0"
+                                    Grid.Column="1"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentTop}" />
                                 <ContentControl
-									x:Name="PART_DocumentPaneDropTargetRight"
-									Grid.Row="1"
-									Grid.Column="2"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentRight}" />
+                                    x:Name="PART_DocumentPaneDropTargetRight"
+                                    Grid.Row="1"
+                                    Grid.Column="2"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentRight}" />
                                 <ContentControl
-									x:Name="PART_DocumentPaneDropTargetBottom"
-									Grid.Row="2"
-									Grid.Column="1"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentBottom}" />
+                                    x:Name="PART_DocumentPaneDropTargetBottom"
+                                    Grid.Row="2"
+                                    Grid.Column="1"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentBottom}" />
                                 <ContentControl
-									x:Name="PART_DocumentPaneDropTargetLeft"
-									Grid.Row="1"
-									Grid.Column="0"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentLeft}" />
+                                    x:Name="PART_DocumentPaneDropTargetLeft"
+                                    Grid.Row="1"
+                                    Grid.Column="0"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentLeft}" />
                                 <!--  Center button of star shapped control  -->
                                 <ContentControl
-									x:Name="PART_DocumentPaneDropTargetInto"
-									Grid.Row="1"
-									Grid.Column="1"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentInside}" />
+                                    x:Name="PART_DocumentPaneDropTargetInto"
+                                    Grid.Row="1"
+                                    Grid.Column="1"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentInside}" />
                             </Grid>
                         </Grid>
 
@@ -1128,12 +1137,12 @@
 
                             <!--  Gray Star Background  -->
                             <Path
-								Width="204"
-								Data="{DynamicResource DockPaneLargeEmpty}"
-								Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBackgroundBrushKey}}"
-								Stretch="Uniform"
-								Stroke="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBorderBrushKey}}"
-								StrokeThickness="1" />
+                                Width="204"
+                                Data="{DynamicResource DockPaneLargeEmpty}"
+                                Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBackgroundBrushKey}}"
+                                Stretch="Uniform"
+                                Stroke="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonStarBorderBrushKey}}"
+                                StrokeThickness="1" />
                             <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition />
@@ -1151,107 +1160,107 @@
                                 </Grid.RowDefinitions>
                                 <!--  Inner 5 buttons of star shapped control  -->
                                 <ContentControl
-									x:Name="PART_DocumentPaneFullDropTargetTop"
-									Grid.Row="1"
-									Grid.Column="2"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentTop}" />
+                                    x:Name="PART_DocumentPaneFullDropTargetTop"
+                                    Grid.Row="1"
+                                    Grid.Column="2"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentTop}" />
                                 <ContentControl
-									x:Name="PART_DocumentPaneFullDropTargetRight"
-									Grid.Row="2"
-									Grid.Column="3"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentRight}" />
+                                    x:Name="PART_DocumentPaneFullDropTargetRight"
+                                    Grid.Row="2"
+                                    Grid.Column="3"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentRight}" />
                                 <ContentControl
-									x:Name="PART_DocumentPaneFullDropTargetBottom"
-									Grid.Row="3"
-									Grid.Column="2"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentBottom}" />
+                                    x:Name="PART_DocumentPaneFullDropTargetBottom"
+                                    Grid.Row="3"
+                                    Grid.Column="2"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentBottom}" />
                                 <ContentControl
-									x:Name="PART_DocumentPaneFullDropTargetLeft"
-									Grid.Row="2"
-									Grid.Column="1"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentLeft}" />
+                                    x:Name="PART_DocumentPaneFullDropTargetLeft"
+                                    Grid.Row="2"
+                                    Grid.Column="1"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentLeft}" />
                                 <!--  Center button of star shapped control  -->
                                 <ContentControl
-									x:Name="PART_DocumentPaneFullDropTargetInto"
-									Grid.Row="2"
-									Grid.Column="2"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentInside}" />
+                                    x:Name="PART_DocumentPaneFullDropTargetInto"
+                                    Grid.Row="2"
+                                    Grid.Column="2"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentInside}" />
 
                                 <!--  Outer 4 buttons of star shapped control  -->
                                 <ContentControl
-									x:Name="PART_DocumentPaneDropTargetTopAsAnchorablePane"
-									Grid.Row="0"
-									Grid.Column="2"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentAsAnchorableTop}" />
+                                    x:Name="PART_DocumentPaneDropTargetTopAsAnchorablePane"
+                                    Grid.Row="0"
+                                    Grid.Column="2"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentAsAnchorableTop}" />
                                 <ContentControl
-									x:Name="PART_DocumentPaneDropTargetRightAsAnchorablePane"
-									Grid.Row="2"
-									Grid.Column="4"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentAsAnchorableRight}" />
+                                    x:Name="PART_DocumentPaneDropTargetRightAsAnchorablePane"
+                                    Grid.Row="2"
+                                    Grid.Column="4"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentAsAnchorableRight}" />
                                 <ContentControl
-									x:Name="PART_DocumentPaneDropTargetBottomAsAnchorablePane"
-									Grid.Row="4"
-									Grid.Column="2"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentAsAnchorableBottom}" />
+                                    x:Name="PART_DocumentPaneDropTargetBottomAsAnchorablePane"
+                                    Grid.Row="4"
+                                    Grid.Column="2"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentAsAnchorableBottom}" />
                                 <ContentControl
-									x:Name="PART_DocumentPaneDropTargetLeftAsAnchorablePane"
-									Grid.Row="2"
-									Grid.Column="0"
-									Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
-									Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
-									HorizontalContentAlignment="Stretch"
-									VerticalContentAlignment="Stretch"
-									Background="Transparent"
-									BorderBrush="Transparent"
-									Content="{StaticResource DockDocumentAsAnchorableLeft}" />
+                                    x:Name="PART_DocumentPaneDropTargetLeftAsAnchorablePane"
+                                    Grid.Row="2"
+                                    Grid.Column="0"
+                                    Width="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonWidthKey}}"
+                                    Height="{DynamicResource {x:Static reskeys:ResourceKeys.DockingButtonHeightKey}}"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Stretch"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Content="{StaticResource DockDocumentAsAnchorableLeft}" />
                             </Grid>
                         </Grid>
                     </Canvas>
@@ -1265,23 +1274,21 @@
     </DataTemplate>
 
     <DataTemplate x:Key="AvalonDockThemeVs2013AnchorableHeaderTemplate">
-        <TextBlock
-			Text="{Binding Title}"
-			TextTrimming="CharacterEllipsis" />
+        <TextBlock Text="{Binding Title}" TextTrimming="CharacterEllipsis" />
     </DataTemplate>
 
     <DataTemplate x:Key="AvalonDockThemeVs2013DocumentTitleTemplate">
         <TextBlock
-			VerticalAlignment="Center"
-			Text="{Binding Title}"
-			TextTrimming="CharacterEllipsis" />
+            VerticalAlignment="Center"
+            Text="{Binding Title}"
+            TextTrimming="CharacterEllipsis" />
     </DataTemplate>
 
     <DataTemplate x:Key="AvalonDockThemeVs2013AnchorableTitleTemplate">
         <TextBlock
-			VerticalAlignment="Center"
-			Text="{Binding Title}"
-			TextTrimming="CharacterEllipsis" />
+            VerticalAlignment="Center"
+            Text="{Binding Title}"
+            TextTrimming="CharacterEllipsis" />
     </DataTemplate>
 
     <DataTemplate x:Key="AvalonDockThemeVs2013IconContentTemplate">
@@ -1294,57 +1301,57 @@
         <MenuItem Command="{Binding Path=DockAsDocumentCommand}" Header="{x:Static avalonDockProperties:Resources.Anchorable_DockAsDocument}" />
         <MenuItem Command="{Binding Path=AutoHideCommand}" Header="{x:Static avalonDockProperties:Resources.Anchorable_AutoHide}" />
         <MenuItem
-			Command="{Binding Path=HideCommand}"
-			Header="{x:Static avalonDockProperties:Resources.Anchorable_Hide}"
-			Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}" />
+            Command="{Binding Path=HideCommand}"
+            Header="{x:Static avalonDockProperties:Resources.Anchorable_Hide}"
+            Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}" />
     </ContextMenu>
 
     <ContextMenu x:Key="AvalonDockThemeVs2013DocumentContextMenu">
         <MenuItem
-			Command="{Binding Path=CloseCommand}"
-			Header="{x:Static avalonDockProperties:Resources.Document_Close}"
-			Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}" />
+            Command="{Binding Path=CloseCommand}"
+            Header="{x:Static avalonDockProperties:Resources.Document_Close}"
+            Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}" />
         <MenuItem Command="{Binding Path=CloseAllButThisCommand}" Header="{x:Static avalonDockProperties:Resources.Document_CloseAllButThis}" />
         <MenuItem Command="{Binding Path=CloseAllCommand}" Header="{x:Static avalonDockProperties:Resources.Document_CloseAll}" />
         <MenuItem Command="{Binding Path=FloatCommand}" Header="{x:Static avalonDockProperties:Resources.Document_Float}" />
         <MenuItem Command="{Binding Path=DockAsDocumentCommand}" Header="{x:Static avalonDockProperties:Resources.Document_DockAsDocument}" />
         <MenuItem
-			Command="{Binding Path=NewHorizontalTabGroupCommand}"
-			Header="{x:Static avalonDockProperties:Resources.Document_NewHorizontalTabGroup}"
-			Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
+            Command="{Binding Path=NewHorizontalTabGroupCommand}"
+            Header="{x:Static avalonDockProperties:Resources.Document_NewHorizontalTabGroup}"
+            Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
             <MenuItem.Icon>
                 <Path
-					Width="14"
-					Height="14"
-					VerticalAlignment="Center"
-					Data="{DynamicResource HTabGroup}"
-					Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveGlyph}}"
-					Stretch="Uniform" />
+                    Width="14"
+                    Height="14"
+                    VerticalAlignment="Center"
+                    Data="{DynamicResource HTabGroup}"
+                    Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveGlyph}}"
+                    Stretch="Uniform" />
             </MenuItem.Icon>
         </MenuItem>
 
         <MenuItem
-			Command="{Binding Path=NewVerticalTabGroupCommand}"
-			Header="{x:Static avalonDockProperties:Resources.Document_NewVerticalTabGroup}"
-			Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
+            Command="{Binding Path=NewVerticalTabGroupCommand}"
+            Header="{x:Static avalonDockProperties:Resources.Document_NewVerticalTabGroup}"
+            Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
             <MenuItem.Icon>
                 <Path
-					Width="14"
-					Height="14"
-					VerticalAlignment="Center"
-					Data="{DynamicResource VTabGroup}"
-					Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveGlyph}}"
-					Stretch="Uniform" />
+                    Width="14"
+                    Height="14"
+                    VerticalAlignment="Center"
+                    Data="{DynamicResource VTabGroup}"
+                    Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionButtonInactiveGlyph}}"
+                    Stretch="Uniform" />
             </MenuItem.Icon>
         </MenuItem>
         <MenuItem
-			Command="{Binding Path=MoveToNextTabGroupCommand}"
-			Header="{x:Static avalonDockProperties:Resources.Document_MoveToNextTabGroup}"
-			Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}" />
+            Command="{Binding Path=MoveToNextTabGroupCommand}"
+            Header="{x:Static avalonDockProperties:Resources.Document_MoveToNextTabGroup}"
+            Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}" />
         <MenuItem
-			Command="{Binding Path=MoveToPreviousTabGroupCommand}"
-			Header="{x:Static avalonDockProperties:Resources.Document_MoveToPreviousTabGroup}"
-			Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}" />
+            Command="{Binding Path=MoveToPreviousTabGroupCommand}"
+            Header="{x:Static avalonDockProperties:Resources.Document_MoveToPreviousTabGroup}"
+            Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}" />
     </ContextMenu>
 
     <!--  DockingManager  -->
@@ -1364,14 +1371,14 @@
         <Setter Property="DocumentPaneMenuItemHeaderTemplate" Value="{StaticResource AvalonDockThemeVs2013DocumentHeaderTemplate}" />
         <Setter Property="IconContentTemplate" Value="{StaticResource AvalonDockThemeVs2013IconContentTemplate}" />
         <Setter Property="GridSplitterWidth" Value="6" />
-		<Setter Property="GridSplitterHeight" Value="6" />
-		<Setter Property="Template">
+        <Setter Property="GridSplitterHeight" Value="6" />
+        <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type avalonDock:DockingManager}">
                     <Border
-						Background="{TemplateBinding Background}"
-						BorderBrush="{TemplateBinding BorderBrush}"
-						BorderThickness="{TemplateBinding BorderThickness}">
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}">
                         <Grid FlowDirection="LeftToRight">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
@@ -1384,33 +1391,33 @@
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <ContentPresenter
-								Grid.Row="1"
-								Grid.Column="1"
-								Content="{TemplateBinding LayoutRootPanel}" />
+                                Grid.Row="1"
+                                Grid.Column="1"
+                                Content="{TemplateBinding LayoutRootPanel}" />
                             <ContentPresenter
-								Grid.Row="1"
-								Grid.Column="2"
-								Content="{TemplateBinding RightSidePanel}" />
+                                Grid.Row="1"
+                                Grid.Column="2"
+                                Content="{TemplateBinding RightSidePanel}" />
                             <ContentPresenter
-								Grid.Row="1"
-								Grid.Column="0"
-								Content="{TemplateBinding LeftSidePanel}" />
+                                Grid.Row="1"
+                                Grid.Column="0"
+                                Content="{TemplateBinding LeftSidePanel}" />
                             <ContentPresenter
-								Grid.Row="0"
-								Grid.Column="1"
-								Content="{TemplateBinding TopSidePanel}" />
+                                Grid.Row="0"
+                                Grid.Column="1"
+                                Content="{TemplateBinding TopSidePanel}" />
                             <ContentPresenter
-								Grid.Row="2"
-								Grid.Column="1"
-								Content="{TemplateBinding BottomSidePanel}" />
-							<ContentPresenter
-								x:Name="PART_AutoHideArea"
-								Grid.Row="1"
-								Grid.Column="1"
-								HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-								VerticalAlignment="{TemplateBinding VerticalAlignment}"
-								Content="{TemplateBinding AutoHideWindow}" />
-						</Grid>
+                                Grid.Row="2"
+                                Grid.Column="1"
+                                Content="{TemplateBinding BottomSidePanel}" />
+                            <ContentPresenter
+                                x:Name="PART_AutoHideArea"
+                                Grid.Row="1"
+                                Grid.Column="1"
+                                HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                                Content="{TemplateBinding AutoHideWindow}" />
+                        </Grid>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
@@ -1434,9 +1441,9 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutDocumentControl}">
                     <Border
-						Background="{TemplateBinding Background}"
-						BorderBrush="{TemplateBinding BorderBrush}"
-						BorderThickness="{TemplateBinding BorderThickness}">
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}">
                         <ContentPresenter Content="{Binding LayoutItem.View, RelativeSource={RelativeSource TemplatedParent}}" />
                     </Border>
                 </ControlTemplate>
@@ -1449,54 +1456,54 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutDocumentTabItem}">
                     <avalonDockControls:DropDownControlArea
-						DropDownContextMenu="{Binding Root.Manager.DocumentContextMenu}"
-						DropDownContextMenuDataContext="{Binding LayoutItem, RelativeSource={RelativeSource TemplatedParent}}"
-						Style="{DynamicResource DropDownControlArea}">
+                        DropDownContextMenu="{Binding Root.Manager.DocumentContextMenu}"
+                        DropDownContextMenuDataContext="{Binding LayoutItem, RelativeSource={RelativeSource TemplatedParent}}"
+                        Style="{DynamicResource DropDownControlArea}">
                         <Border
-							x:Name="Header"
-							Margin="0,0,0,2"
-							Padding="1,0"
-							Height="19"
-							Background="{TemplateBinding Background}"
-							BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.Background}}"
-							BorderThickness="0,0,0,1">
+                            x:Name="Header"
+                            Height="19"
+                            Margin="0,0,0,2"
+                            Padding="1,0"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.Background}}"
+                            BorderThickness="0,0,0,1">
                             <Grid>
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="*" />
-									<ColumnDefinition Width="Auto" />
-								</Grid.ColumnDefinitions>
-								<Border Grid.ColumnSpan="2" Background="Transparent" />
-								<ContentPresenter
-									Margin="4,0,4,1"
-									VerticalAlignment="Bottom"
-									Content="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}"
-									ContentTemplate="{Binding DocumentHeaderTemplate, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}"
-									ContentTemplateSelector="{Binding DocumentHeaderTemplateSelector, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}"
-									TextBlock.Foreground="{Binding Foreground, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=TabItem}}" />
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Border Grid.ColumnSpan="2" Background="Transparent" />
+                                <ContentPresenter
+                                    Margin="4,0,4,1"
+                                    VerticalAlignment="Bottom"
+                                    Content="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}"
+                                    ContentTemplate="{Binding DocumentHeaderTemplate, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}"
+                                    ContentTemplateSelector="{Binding DocumentHeaderTemplateSelector, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}"
+                                    TextBlock.Foreground="{Binding Foreground, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=TabItem}}" />
                                 <!--  Close button should be moved out to the container style  -->
-								<Button
-									x:Name="DocumentCloseButton"
-									Grid.Column="1"
-									Width="15"
+                                <Button
+                                    x:Name="DocumentCloseButton"
+                                    Grid.Column="1"
+                                    Width="15"
                                     Height="15"
-									Margin="3,0"
-									HorizontalAlignment="Center"
-									VerticalAlignment="Bottom"
-									Command="{Binding Path=LayoutItem.CloseCommand, RelativeSource={RelativeSource TemplatedParent}}"
-									Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
-									ToolTip="{x:Static avalonDockProperties:Resources.Document_Close}"
-									Visibility="Hidden">
-									<Path
-										x:Name="PART_ImgPinClose"
-										Width="10"
-										Height="10"
-										Margin="1,0,0,1"
-										VerticalAlignment="Center"
-										Data="{DynamicResource PinClose}"
-										Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveText}}"
-										Stretch="Uniform" />
-								</Button>
-							</Grid>
+                                    Margin="3,0"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Bottom"
+                                    Command="{Binding Path=LayoutItem.CloseCommand, RelativeSource={RelativeSource TemplatedParent}}"
+                                    Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
+                                    ToolTip="{x:Static avalonDockProperties:Resources.Document_Close}"
+                                    Visibility="Hidden">
+                                    <Path
+                                        x:Name="PART_ImgPinClose"
+                                        Width="10"
+                                        Height="10"
+                                        Margin="1,0,0,1"
+                                        VerticalAlignment="Center"
+                                        Data="{DynamicResource PinClose}"
+                                        Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveText}}"
+                                        Stretch="Uniform" />
+                                </Button>
+                            </Grid>
                         </Border>
                     </avalonDockControls:DropDownControlArea>
                     <ControlTemplate.Triggers>
@@ -1513,7 +1520,7 @@
                         <DataTrigger Binding="{Binding Path=IsActive}" Value="true">
                             <Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Visible" />
                         </DataTrigger>
-                        <!--BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true-->
+                        <!--  BD: 17.08.2020 use HideCommand if CanClose=false but CanHide=true  -->
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding Path=CanClose}" Value="false" />
@@ -1522,7 +1529,7 @@
                             <Setter TargetName="DocumentCloseButton" Property="Command" Value="{Binding Path=LayoutItem.HideCommand, RelativeSource={RelativeSource TemplatedParent}}" />
                             <Setter TargetName="DocumentCloseButton" Property="ToolTip" Value="{x:Static avalonDockProperties:Resources.Anchorable_Hide}" />
                         </MultiDataTrigger>
-                        <!--BD: 17.08.2020 hide button if both CanClose=false and CanHide=false-->
+                        <!--  BD: 17.08.2020 hide button if both CanClose=false and CanHide=false  -->
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding Path=CanClose}" Value="false" />
@@ -1531,25 +1538,25 @@
                             <Setter TargetName="DocumentCloseButton" Property="Visibility" Value="Collapsed" />
                         </MultiDataTrigger>
 
-						<!--  Document Well : Tab : Button / Selected, inactive  -->
+                        <!--  Document Well : Tab : Button / Selected, inactive  -->
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding IsLastFocusedDocument}" Value="true" />
                             </MultiDataTrigger.Conditions>
-							<Setter TargetName="Header" Property="BorderThickness" Value="0" />
-							<Setter TargetName="Header" Property="Padding" Value="0" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}" />
-						</MultiDataTrigger>
+                            <Setter TargetName="Header" Property="BorderThickness" Value="0" />
+                            <Setter TargetName="Header" Property="Padding" Value="0" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Document Well : Tab : Button / Selected, inactive, hovered  -->
+                        <!--  Document Well : Tab : Button / Selected, inactive, hovered  -->
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding IsLastFocusedDocument}" Value="true" />
                                 <Condition Binding="{Binding IsMouseOver, ElementName=DocumentCloseButton}" Value="True" />
                             </MultiDataTrigger.Conditions>
-							<Setter TargetName="Header" Property="BorderThickness" Value="0" />
-							<Setter TargetName="Header" Property="Padding" Value="0" />
-							<Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
+                            <Setter TargetName="Header" Property="BorderThickness" Value="0" />
+                            <Setter TargetName="Header" Property="Padding" Value="0" />
+                            <Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
                             <Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
                             <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
                         </MultiDataTrigger>
@@ -1560,18 +1567,18 @@
                                 <Condition Binding="{Binding IsLastFocusedDocument}" Value="true" />
                                 <Condition Binding="{Binding IsMouseCaptured, ElementName=DocumentCloseButton}" Value="True" />
                             </MultiDataTrigger.Conditions>
-							<Setter TargetName="Header" Property="BorderThickness" Value="0" />
-							<Setter TargetName="Header" Property="Padding" Value="0" />
-							<Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
+                            <Setter TargetName="Header" Property="BorderThickness" Value="0" />
+                            <Setter TargetName="Header" Property="Padding" Value="0" />
+                            <Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
                             <Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
                             <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
                         </MultiDataTrigger>
 
                         <!--  Document Well : Tab : Button / Selected, active  -->
                         <DataTrigger Binding="{Binding IsActive}" Value="true">
-							<Setter TargetName="Header" Property="BorderThickness" Value="0" />
-							<Setter TargetName="Header" Property="Padding" Value="0" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
+                            <Setter TargetName="Header" Property="BorderThickness" Value="0" />
+                            <Setter TargetName="Header" Property="Padding" Value="0" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
                         </DataTrigger>
 
                         <!--  Document Well : Tab : Button / Selected, active, hovered  -->
@@ -1580,9 +1587,9 @@
                                 <Condition Binding="{Binding IsActive}" Value="true" />
                                 <Condition Binding="{Binding IsMouseOver, ElementName=DocumentCloseButton}" Value="True" />
                             </MultiDataTrigger.Conditions>
-							<Setter TargetName="Header" Property="BorderThickness" Value="0" />
-							<Setter TargetName="Header" Property="Padding" Value="0" />
-							<Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
+                            <Setter TargetName="Header" Property="BorderThickness" Value="0" />
+                            <Setter TargetName="Header" Property="Padding" Value="0" />
+                            <Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBackground}}" />
                             <Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredBorder}}" />
                             <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveHoveredGlyph}}" />
                         </MultiDataTrigger>
@@ -1593,88 +1600,88 @@
                                 <Condition Binding="{Binding IsActive}" Value="true" />
                                 <Condition Binding="{Binding IsMouseCaptured, ElementName=DocumentCloseButton}" Value="True" />
                             </MultiDataTrigger.Conditions>
-							<Setter TargetName="Header" Property="BorderThickness" Value="0" />
-							<Setter TargetName="Header" Property="Padding" Value="0" />
-							<Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
+                            <Setter TargetName="Header" Property="BorderThickness" Value="0" />
+                            <Setter TargetName="Header" Property="Padding" Value="0" />
+                            <Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
                             <Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
                             <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
                         </MultiDataTrigger>
 
                         <!--  Document Well : Tab : Button / Unselected, tab hovered  -->
                         <MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsActive}" Value="False" />
-								<Condition Binding="{Binding IsLastFocusedDocument}" Value="False" />
-								<Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource TemplatedParent}}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredGlyph}}" />
-						</MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsActive}" Value="False" />
+                                <Condition Binding="{Binding IsLastFocusedDocument}" Value="False" />
+                                <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource TemplatedParent}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredGlyph}}" />
+                        </MultiDataTrigger>
 
                         <!--  Document Well : Tab : Button / Unselected, tab hovered, button hovered  -->
                         <MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsActive}" Value="False" />
-								<Condition Binding="{Binding IsLastFocusedDocument}" Value="False" />
-								<Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource TemplatedParent}}" Value="True" />
-								<Condition Binding="{Binding IsMouseOver, ElementName=DocumentCloseButton}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonHoveredBackground}}" />
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsActive}" Value="False" />
+                                <Condition Binding="{Binding IsLastFocusedDocument}" Value="False" />
+                                <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource TemplatedParent}}" Value="True" />
+                                <Condition Binding="{Binding IsMouseOver, ElementName=DocumentCloseButton}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonHoveredBackground}}" />
                             <Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonHoveredBorder}}" />
                             <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonHoveredGlyph}}" />
                         </MultiDataTrigger>
 
                         <!--  Document Well : Tab : Button / Unselected, tab hovered, button pressed  -->
                         <MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsActive}" Value="False" />
-								<Condition Binding="{Binding IsLastFocusedDocument}" Value="False" />
-								<Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource TemplatedParent}}" Value="True" />
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=DocumentCloseButton}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonPressedBackground}}" />
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsActive}" Value="False" />
+                                <Condition Binding="{Binding IsLastFocusedDocument}" Value="False" />
+                                <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource TemplatedParent}}" Value="True" />
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=DocumentCloseButton}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonPressedBackground}}" />
                             <Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonPressedBorder}}" />
                             <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonPressedGlyph}}" />
                         </MultiDataTrigger>
 
-						<!--  Mulitple Document Well : Tab : Button / Selected, tab hovered, button pressed  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding Path=IsActive}" Value="False" />
-								<Condition Binding="{Binding Path=IsSelected}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="Header" Property="BorderThickness" Value="0" />
-							<Setter TargetName="Header" Property="Padding" Value="0" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Mulitple Document Well : Tab : Button / Selected, tab hovered, button pressed  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsActive}" Value="False" />
+                                <Condition Binding="{Binding Path=IsSelected}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Header" Property="BorderThickness" Value="0" />
+                            <Setter TargetName="Header" Property="Padding" Value="0" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Mulitple Document Well : Tab : Button / Selected, inactive, hovered  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding Path=IsActive}" Value="False" />
-								<Condition Binding="{Binding Path=IsSelected}" Value="True" />
-								<Condition Binding="{Binding IsMouseOver, ElementName=DocumentCloseButton}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="Header" Property="BorderThickness" Value="0" />
-							<Setter TargetName="Header" Property="Padding" Value="0" />
-							<Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
-							<Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
-						</MultiDataTrigger>
+                        <!--  Mulitple Document Well : Tab : Button / Selected, inactive, hovered  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsActive}" Value="False" />
+                                <Condition Binding="{Binding Path=IsSelected}" Value="True" />
+                                <Condition Binding="{Binding IsMouseOver, ElementName=DocumentCloseButton}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Header" Property="BorderThickness" Value="0" />
+                            <Setter TargetName="Header" Property="Padding" Value="0" />
+                            <Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
+                            <Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
 
-						<!--  Mulitple Document Well : Tab : Button / Selected, inactive, pressed  -->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding Path=IsActive}" Value="False" />
-								<Condition Binding="{Binding Path=IsSelected}" Value="True" />
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=DocumentCloseButton}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="Header" Property="BorderThickness" Value="0" />
-							<Setter TargetName="Header" Property="Padding" Value="0" />
-							<Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
-							<Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
-						</MultiDataTrigger>
-					</ControlTemplate.Triggers>
+                        <!--  Mulitple Document Well : Tab : Button / Selected, inactive, pressed  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsActive}" Value="False" />
+                                <Condition Binding="{Binding Path=IsSelected}" Value="True" />
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=DocumentCloseButton}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Header" Property="BorderThickness" Value="0" />
+                            <Setter TargetName="Header" Property="Padding" Value="0" />
+                            <Setter TargetName="DocumentCloseButton" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
+                            <Setter TargetName="DocumentCloseButton" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
+                        </MultiDataTrigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -1685,22 +1692,22 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutAnchorableTabItem}">
                     <avalonDockControls:DropDownControlArea
-						DropDownContextMenu="{Binding Root.Manager.AnchorableContextMenu}"
-						DropDownContextMenuDataContext="{Binding LayoutItem, RelativeSource={RelativeSource TemplatedParent}}"
-						Style="{DynamicResource DropDownControlArea}">
+                        DropDownContextMenu="{Binding Root.Manager.AnchorableContextMenu}"
+                        DropDownContextMenuDataContext="{Binding LayoutItem, RelativeSource={RelativeSource TemplatedParent}}"
+                        Style="{DynamicResource DropDownControlArea}">
                         <Border
-							Background="{TemplateBinding Background}"
-							BorderBrush="{TemplateBinding BorderBrush}"
-							BorderThickness="{TemplateBinding BorderThickness}">
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
                             <Grid>
                                 <ContentPresenter
-									Content="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}"
-									ContentTemplate="{Binding AnchorableHeaderTemplate, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}"
-									ContentTemplateSelector="{Binding AnchorableHeaderTemplateSelector, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}" />
+                                    Content="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}"
+                                    ContentTemplate="{Binding AnchorableHeaderTemplate, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}"
+                                    ContentTemplateSelector="{Binding AnchorableHeaderTemplateSelector, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type avalonDock:DockingManager}, Mode=FindAncestor}}" />
                                 <avalonDockControls:DropDownControlArea
-									Grid.Column="0"
-									DropDownContextMenu="{Binding Model.Root.Manager.AnchorableContextMenu, RelativeSource={RelativeSource TemplatedParent}}"
-									DropDownContextMenuDataContext="{Binding Path=Model, RelativeSource={RelativeSource TemplatedParent}}" />
+                                    Grid.Column="0"
+                                    DropDownContextMenu="{Binding Model.Root.Manager.AnchorableContextMenu, RelativeSource={RelativeSource TemplatedParent}}"
+                                    DropDownContextMenuDataContext="{Binding Path=Model, RelativeSource={RelativeSource TemplatedParent}}" />
                             </Grid>
                         </Border>
                     </avalonDockControls:DropDownControlArea>
@@ -1713,12 +1720,12 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutAnchorableControl}">
-					<Border
-						x:Name="Bd"
+                    <Border
+                        x:Name="Bd"
                         Background="{TemplateBinding Background}"
-						BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}"
-						BorderThickness="1,0,1,1">
-						<Grid>
+                        BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}"
+                        BorderThickness="1,0,1,1">
+                        <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="*" />
@@ -1727,15 +1734,15 @@
                                 <avalonDockControls:AnchorablePaneTitle Model="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}" />
                             </Border>
                             <!--
-								Added ContentTemplate and ContentTemplateSelector
-								https://github.com/xceedsoftware/wpftoolkit/issues/1525
-							-->
+                                Added ContentTemplate and ContentTemplateSelector
+                                https://github.com/xceedsoftware/wpftoolkit/issues/1525
+                            -->
                             <ContentPresenter
-								Grid.Row="1"
-								Content="{Binding LayoutItem.View, RelativeSource={RelativeSource TemplatedParent}}"
-								ContentTemplate="{Binding LayoutItem.View.ContentTemplate, RelativeSource={RelativeSource TemplatedParent}}"
-								ContentTemplateSelector="{Binding LayoutItem.View.ContentTemplateSelector, RelativeSource={RelativeSource TemplatedParent}}"
-								FlowDirection="{TemplateBinding FlowDirection}" />
+                                Grid.Row="1"
+                                Content="{Binding LayoutItem.View, RelativeSource={RelativeSource TemplatedParent}}"
+                                ContentTemplate="{Binding LayoutItem.View.ContentTemplate, RelativeSource={RelativeSource TemplatedParent}}"
+                                ContentTemplateSelector="{Binding LayoutItem.View.ContentTemplateSelector, RelativeSource={RelativeSource TemplatedParent}}"
+                                FlowDirection="{TemplateBinding FlowDirection}" />
 
                             <!--
                                 <ContentPresenter
@@ -1748,69 +1755,69 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <!--
-							Hide the title if the control is directly hosted in floating window
-							The floating window control will show the title if there is only one control to host
-							without any other LayoutAnchorableControl
-						-->
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.IsFloating}" Value="True" />
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.Parent.IsDirectlyHostedInFloatingWindow}" Value="True" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="Header" Property="Visibility" Value="Collapsed" />
-						</MultiDataTrigger>
-						<MultiDataTrigger>
+                            Hide the title if the control is directly hosted in floating window
+                            The floating window control will show the title if there is only one control to host
+                            without any other LayoutAnchorableControl
+                        -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.IsFloating}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.Parent.IsDirectlyHostedInFloatingWindow}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Header" Property="Visibility" Value="Collapsed" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
                             <!--
-								Also hide the title, if model cannot be bound which can happen when using virtualization
-								See Issue #148 Drop Down Menu for LayoutAnchorables is not correct with Virtualization
-							-->
+                                Also hide the title, if model cannot be bound which can happen when using virtualization
+                                See Issue #148 Drop Down Menu for LayoutAnchorables is not correct with Virtualization
+                            -->
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model}" Value="{x:Null}" />
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="Header" Property="Visibility" Value="Collapsed" />
                         </MultiDataTrigger>
-					
-						<!-- Correct BorderThickness for all types of layouts LayoutAnchorableControls -->					
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.IsFloating}" Value="False" />		
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="Bd" Property="BorderThickness" Value="1"/>
-						</MultiDataTrigger>
 
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.Parent.IsDirectlyHostedInFloatingWindow}" Value="False" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="Bd" Property="BorderThickness" Value="1"/>
-						</MultiDataTrigger>
+                        <!--  Correct BorderThickness for all types of layouts LayoutAnchorableControls  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.IsFloating}" Value="False" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Bd" Property="BorderThickness" Value="1" />
+                        </MultiDataTrigger>
 
-						<MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.IsFloating}" Value="True" />
-								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.Parent.IsDirectlyHostedInFloatingWindow}" Value="True" />
-								<Condition Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TabControl}}, Path=Items.Count}" Value="1" />
-							</MultiDataTrigger.Conditions>
-							<Setter TargetName="Bd" Property="BorderThickness" Value="0"/>
-						</MultiDataTrigger>
-					</ControlTemplate.Triggers>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.Parent.IsDirectlyHostedInFloatingWindow}" Value="False" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Bd" Property="BorderThickness" Value="1" />
+                        </MultiDataTrigger>
+
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.IsFloating}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.Parent.IsDirectlyHostedInFloatingWindow}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TabControl}}, Path=Items.Count}" Value="1" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Bd" Property="BorderThickness" Value="0" />
+                        </MultiDataTrigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
     <Style x:Key="{x:Type avalonDockControls:LayoutDocumentFloatingWindowControl}" TargetType="{x:Type avalonDockControls:LayoutDocumentFloatingWindowControl}">
-		<Setter Property="UseLayoutRounding" Value="True" />
-		<Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.FloatingDocumentWindowBackground}}" />
+        <Setter Property="UseLayoutRounding" Value="True" />
+        <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.FloatingDocumentWindowBackground}}" />
         <Setter Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.FloatingDocumentWindowBorder}}" />
         <Setter Property="shell:WindowChrome.WindowChrome">
             <Setter.Value>
                 <shell:WindowChrome
-					CaptionHeight="32"
-					CornerRadius="0"
-					GlassFrameThickness="0"
-					ResizeBorderThickness="10"
-					ShowSystemMenu="False" />
+                    CaptionHeight="32"
+                    CornerRadius="0"
+                    GlassFrameThickness="0"
+                    ResizeBorderThickness="10"
+                    ShowSystemMenu="False" />
             </Setter.Value>
         </Setter>
         <Setter Property="Template">
@@ -1818,131 +1825,134 @@
                 <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutDocumentFloatingWindowControl}">
                     <Grid>
                         <Border
-							x:Name="WindowBorder"
-							Background="{TemplateBinding Background}"
-							BorderBrush="{TemplateBinding BorderBrush}"
-							BorderThickness="1">
+                            x:Name="WindowBorder"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="1">
                             <Grid>
                                 <Grid.RowDefinitions>
-									<RowDefinition Height="Auto" MinHeight="32" />
+                                    <RowDefinition Height="Auto" MinHeight="32" />
                                     <!--  https://github.com/xceedsoftware/wpftoolkit/issues/1203  -->
-									<RowDefinition x:Name="MaximizedAddBorder" Height="0" />
-									<RowDefinition Height="*" />
+                                    <RowDefinition x:Name="MaximizedAddBorder" Height="0" />
+                                    <RowDefinition Height="*" />
                                 </Grid.RowDefinitions>
 
                                 <Border
-									x:Name="Header"
-									Padding="0,0,0,0"
-									Background="Transparent"
-									TextElement.Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedInactiveText}}">
+                                    x:Name="Header"
+                                    Padding="0,0,0,0"
+                                    Background="Transparent"
+                                    TextElement.Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedInactiveText}}">
                                     <Grid UseLayoutRounding="True">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*" />
                                             <ColumnDefinition Width="Auto" />
-											<ColumnDefinition Width="Auto" />
-										</Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
                                         <ContentPresenter
-											TextElement.Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedInactiveText}}"
-											x:Name="HeaderContent"
+                                            x:Name="HeaderContent"
                                             Margin="12,4,12,0"
-											Content="{Binding Model.SinglePane.SelectedContent, RelativeSource={RelativeSource TemplatedParent}}"
-											ContentTemplate="{Binding Model.Root.Manager.DocumentTitleTemplate, RelativeSource={RelativeSource TemplatedParent}}"
-											ContentTemplateSelector="{Binding Model.Root.Manager.DocumentTitleTemplateSelector, RelativeSource={RelativeSource TemplatedParent}}" />
+                                            Content="{Binding Model.SinglePane.SelectedContent, RelativeSource={RelativeSource TemplatedParent}}"
+                                            ContentTemplate="{Binding Model.Root.Manager.DocumentTitleTemplate, RelativeSource={RelativeSource TemplatedParent}}"
+                                            ContentTemplateSelector="{Binding Model.Root.Manager.DocumentTitleTemplateSelector, RelativeSource={RelativeSource TemplatedParent}}"
+                                            TextElement.Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedInactiveText}}" />
 
                                         <Button
-											x:Name="PART_PinMaximize"
-											Grid.Column="1"
+                                            x:Name="PART_PinMaximize"
+                                            Grid.Column="1"
                                             Width="34"
-											Height="26"
-											VerticalAlignment="Top"
-											shell:WindowChrome.IsHitTestVisibleInChrome="True"
-											Command="{x:Static shell:SystemCommands.MaximizeWindowCommand}"
-											CommandParameter="{Binding RelativeSource={RelativeSource TemplatedParent}}"
-											Focusable="False"
-											Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
-											ToolTip="{x:Static avalonDockProperties:Resources.Window_Maximize}"
-											Visibility="{Binding IsMaximized, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:InverseBoolToVisibilityConverter}}">
-                                            <Path
-												x:Name="PART_ImgPinMaximize"
-												Width="9"
-												Height="9"
-												RenderOptions.EdgeMode="Aliased"
-												VerticalAlignment="Center"
-												Data="{DynamicResource PinMaximize}"
-												Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
-												Stretch="Uniform" />
-                                        </Button>
-
-                                        <Button
-											x:Name="PART_PinRestore"
-											Grid.Column="1"
-                                            Width="34"
-											Height="26"
+                                            Height="26"
                                             VerticalAlignment="Top"
-											shell:WindowChrome.IsHitTestVisibleInChrome="True"
-											Command="{x:Static shell:SystemCommands.RestoreWindowCommand}"
-											CommandParameter="{Binding RelativeSource={RelativeSource TemplatedParent}}"
-											Focusable="False"
-											Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
-											ToolTip="{x:Static avalonDockProperties:Resources.Window_Restore}"
-											Visibility="{Binding IsMaximized, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
+                                            shell:WindowChrome.IsHitTestVisibleInChrome="True"
+                                            Command="{x:Static shell:SystemCommands.MaximizeWindowCommand}"
+                                            CommandParameter="{Binding RelativeSource={RelativeSource TemplatedParent}}"
+                                            Focusable="False"
+                                            Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
+                                            ToolTip="{x:Static avalonDockProperties:Resources.Window_Maximize}"
+                                            Visibility="{Binding IsMaximized, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:InverseBoolToVisibilityConverter}}">
                                             <Path
-												x:Name="PART_ImgPinRestore"
-												Width="10"
-												Height="10"
-												VerticalAlignment="Center"
-												Data="{DynamicResource PinRestore}"
-												Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
-												Stretch="Uniform" />
+                                                x:Name="PART_ImgPinMaximize"
+                                                Width="9"
+                                                Height="9"
+                                                VerticalAlignment="Center"
+                                                Data="{DynamicResource PinMaximize}"
+                                                Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
+                                                RenderOptions.EdgeMode="Aliased"
+                                                Stretch="Uniform" />
                                         </Button>
 
                                         <Button
-											x:Name="PART_PinClose"
-											Grid.Column="2"
+                                            x:Name="PART_PinRestore"
+                                            Grid.Column="1"
                                             Width="34"
-											Height="26"
-											VerticalAlignment="Top"
-											shell:WindowChrome.IsHitTestVisibleInChrome="True"
-											Command="{Binding Path=CloseWindowCommand, RelativeSource={RelativeSource TemplatedParent}}"
-											Focusable="False"
-											Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
-											ToolTip="{x:Static avalonDockProperties:Resources.Document_Close}"
-											Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
+                                            Height="26"
+                                            VerticalAlignment="Top"
+                                            shell:WindowChrome.IsHitTestVisibleInChrome="True"
+                                            Command="{x:Static shell:SystemCommands.RestoreWindowCommand}"
+                                            CommandParameter="{Binding RelativeSource={RelativeSource TemplatedParent}}"
+                                            Focusable="False"
+                                            Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
+                                            ToolTip="{x:Static avalonDockProperties:Resources.Window_Restore}"
+                                            Visibility="{Binding IsMaximized, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
                                             <Path
-												x:Name="PART_ImgPinClose"
-												Width="10"
-												Height="10"
-												VerticalAlignment="Center"
-												Data="{DynamicResource PinClose}"
-												Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
-												Stretch="Uniform" />
+                                                x:Name="PART_ImgPinRestore"
+                                                Width="10"
+                                                Height="10"
+                                                VerticalAlignment="Center"
+                                                Data="{DynamicResource PinRestore}"
+                                                Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
+                                                Stretch="Uniform" />
+                                        </Button>
+
+                                        <Button
+                                            x:Name="PART_PinClose"
+                                            Grid.Column="2"
+                                            Width="34"
+                                            Height="26"
+                                            VerticalAlignment="Top"
+                                            shell:WindowChrome.IsHitTestVisibleInChrome="True"
+                                            Command="{Binding Path=CloseWindowCommand, RelativeSource={RelativeSource TemplatedParent}}"
+                                            Focusable="False"
+                                            Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
+                                            ToolTip="{x:Static avalonDockProperties:Resources.Document_Close}"
+                                            Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
+                                            <Path
+                                                x:Name="PART_ImgPinClose"
+                                                Width="10"
+                                                Height="10"
+                                                VerticalAlignment="Center"
+                                                Data="{DynamicResource PinClose}"
+                                                Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
+                                                Stretch="Uniform" />
                                         </Button>
                                     </Grid>
                                 </Border>
-                                <ContentPresenter Grid.Row="2" Margin="6" Content="{TemplateBinding Content}" />
+                                <ContentPresenter
+                                    Grid.Row="2"
+                                    Margin="6"
+                                    Content="{TemplateBinding Content}" />
                             </Grid>
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <!--  Show Header Bar (Window Title and Restore/Maximize/Minimize buttons with highlighting color if this IsActive)  -->
-						<Trigger Property="WindowState" Value="Maximized">
-							<Setter TargetName="WindowBorder" Property="Padding" Value="7" />
-							<Setter TargetName="MaximizedAddBorder" Property="Height" Value="4" />
-						</Trigger>
-						<DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="True">
+                        <Trigger Property="WindowState" Value="Maximized">
+                            <Setter TargetName="WindowBorder" Property="Padding" Value="7" />
+                            <Setter TargetName="MaximizedAddBorder" Property="Height" Value="4" />
+                        </Trigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="True">
                             <!--<Setter TargetName="Header" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedActiveBackground}}" />-->
-							<Setter TargetName="Header" Property="TextElement.Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedActiveText}}" />
-						</DataTrigger>
+                            <Setter TargetName="Header" Property="TextElement.Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabSelectedActiveText}}" />
+                        </DataTrigger>
 
-						<!--  In VS DocumentFloatingWindow colors change only for header text and icon if window is inactive  -->
+                        <!--  In VS DocumentFloatingWindow colors change only for header text and icon if window is inactive  -->
                         <!--  Document Well : Tab : Button / Selected, inactive, hovered  -->
                         <MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseOver, ElementName=PART_PinMaximize}" Value="True" />
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseOver, ElementName=PART_PinMaximize}" Value="True" />
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
-							<Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
+                            <Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
+                            <Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
                         </MultiDataTrigger>
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
@@ -1950,7 +1960,7 @@
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
                             <Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
+                            <Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
                         </MultiDataTrigger>
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
@@ -1963,13 +1973,13 @@
 
                         <!--  Document Well : Tab : Button / Selected, inactive, pressed  -->
                         <MultiDataTrigger>
-							<MultiDataTrigger.Conditions>
-								<Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinMaximize}" Value="True" />
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinMaximize}" Value="True" />
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
                             <Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
-						</MultiDataTrigger>
+                            <Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
+                        </MultiDataTrigger>
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinRestore}" Value="True" />
@@ -1987,7 +1997,8 @@
                             <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
                         </MultiDataTrigger>
 
-                        <!--  Mark Active Document on CLick in Document Well : Tab : Button / Selected, active  --><!--
+                        <!--  Mark Active Document on CLick in Document Well : Tab : Button / Selected, active  -->
+                        <!--
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="true">
 							<Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
 							<Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
@@ -1997,7 +2008,7 @@
 
                         <!--  Document Well : Tab : Button / Selected, active, hovered  -->
                         <!--  Highlight Maximize Button of Floating Window on MouseOver  -->
-						<!--<MultiDataTrigger>
+                        <!--<MultiDataTrigger>
 							<MultiDataTrigger.Conditions>
 								<Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsActive}" Value="true" />
 								<Condition Binding="{Binding IsMouseOver, ElementName=PART_PinMaximize}" Value="True" />
@@ -2038,8 +2049,8 @@
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
                             <Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
-						</MultiDataTrigger>
+                            <Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
+                        </MultiDataTrigger>
 
                         <!--  Highlight Restore Button of Floating Window on MouseClick and Holding Bottun (even when Mouse is moved away)  -->
                         <MultiDataTrigger>
@@ -2049,7 +2060,7 @@
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="PART_PinRestore" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBackground}}" />
                             <Setter TargetName="PART_PinRestore" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
+                            <Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActivePressedGlyph}}" />
                         </MultiDataTrigger>
 
                         <!--  Highlight Close Button of Floating Window on MouseClick and Holding Bottun (even when Mouse is moved away)  -->
@@ -2072,14 +2083,14 @@
     <Style x:Key="{x:Type avalonDockControls:LayoutAnchorableFloatingWindowControl}" TargetType="{x:Type avalonDockControls:LayoutAnchorableFloatingWindowControl}">
         <Setter Property="UseLayoutRounding" Value="True" />
         <Setter Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.FloatingToolWindowBackground}}" />
-		<Setter Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.FloatingToolWindowBorder}}" />
-		<Setter Property="shell:WindowChrome.WindowChrome">
+        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.FloatingToolWindowBorder}}" />
+        <Setter Property="shell:WindowChrome.WindowChrome">
             <Setter.Value>
                 <shell:WindowChrome
-					CaptionHeight="21"
-					CornerRadius="0"
-					GlassFrameThickness="0"
-					ResizeBorderThickness="10" />
+                    CaptionHeight="21"
+                    CornerRadius="0"
+                    GlassFrameThickness="0"
+                    ResizeBorderThickness="10" />
             </Setter.Value>
         </Setter>
         <Setter Property="Template">
@@ -2087,10 +2098,10 @@
                 <ControlTemplate TargetType="{x:Type avalonDockControls:LayoutAnchorableFloatingWindowControl}">
                     <Grid>
                         <Border
-							x:Name="WindowBorder"
-							Background="{TemplateBinding Background}"
-							BorderBrush="{TemplateBinding BorderBrush}"
-							BorderThickness="1">
+                            x:Name="WindowBorder"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="1">
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto" MinHeight="21" />
@@ -2098,52 +2109,61 @@
                                     <RowDefinition Height="*" />
                                 </Grid.RowDefinitions>
                                 <Border
-									x:Name="Header"
-									Padding="2,2,3,3"
-									Background="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveBackground}}"
-									TextElement.Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveText}}">
-									<Grid UseLayoutRounding="True">
+                                    x:Name="Header"
+                                    Padding="2,2,3,3"
+                                    Background="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveBackground}}"
+                                    TextElement.Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveText}}">
+                                    <Grid UseLayoutRounding="True">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*" />
                                             <ColumnDefinition Width="Auto" />
                                             <ColumnDefinition Width="Auto" />
-											<ColumnDefinition Width="Auto" />
-										</Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
 
-										<Rectangle
-											x:Name="DragHandleGeometryPlaceholder"
-											Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveGrip}}"
-											Visibility="Collapsed" />
+                                        <Rectangle
+                                            x:Name="DragHandleGeometryPlaceholder"
+                                            Fill="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveGrip}}"
+                                            Visibility="Collapsed" />
 
-										<DockPanel>
-                                            <Border Padding="2,0,4,0" HorizontalAlignment="Left" Visibility="{Binding Path=Model.IsSinglePane, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
+                                        <DockPanel>
+                                            <Border
+                                                Padding="2,0,4,0"
+                                                HorizontalAlignment="Left"
+                                                Visibility="{Binding Path=Model.IsSinglePane, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
                                                 <avalonDockControls:DropDownControlArea
-													DropDownContextMenu="{Binding Model.Root.Manager.AnchorableContextMenu, RelativeSource={RelativeSource TemplatedParent}}"
-													DropDownContextMenuDataContext="{Binding Path=SingleContentLayoutItem, RelativeSource={RelativeSource TemplatedParent}}"
-													Style="{DynamicResource DropDownControlArea}">
+                                                    DropDownContextMenu="{Binding Model.Root.Manager.AnchorableContextMenu, RelativeSource={RelativeSource TemplatedParent}}"
+                                                    DropDownContextMenuDataContext="{Binding Path=SingleContentLayoutItem, RelativeSource={RelativeSource TemplatedParent}}"
+                                                    Style="{DynamicResource DropDownControlArea}">
                                                     <ContentPresenter
-													Content="{Binding Model.SinglePane.SelectedContent, RelativeSource={RelativeSource TemplatedParent}}"
-													ContentTemplate="{Binding Model.Root.Manager.AnchorableTitleTemplate, RelativeSource={RelativeSource TemplatedParent}}"
-													ContentTemplateSelector="{Binding Model.Root.Manager.AnchorableTitleTemplateSelector, RelativeSource={RelativeSource TemplatedParent}}" />
+                                                        Content="{Binding Model.SinglePane.SelectedContent, RelativeSource={RelativeSource TemplatedParent}}"
+                                                        ContentTemplate="{Binding Model.Root.Manager.AnchorableTitleTemplate, RelativeSource={RelativeSource TemplatedParent}}"
+                                                        ContentTemplateSelector="{Binding Model.Root.Manager.AnchorableTitleTemplateSelector, RelativeSource={RelativeSource TemplatedParent}}" />
                                                 </avalonDockControls:DropDownControlArea>
                                             </Border>
 
                                             <Rectangle
-												x:Name="DragHandleTexture"
-												Height="5"
-												Margin="4,0,4,0"
-												VerticalAlignment="Center" 
-												UseLayoutRounding="True" 
-												RenderOptions.BitmapScalingMode="NearestNeighbor">
+                                                x:Name="DragHandleTexture"
+                                                Height="5"
+                                                Margin="4,0,4,0"
+                                                VerticalAlignment="Center"
+                                                RenderOptions.BitmapScalingMode="NearestNeighbor"
+                                                UseLayoutRounding="True">
                                                 <Rectangle.Fill>
                                                     <DrawingBrush
-														TileMode="Tile"
-														Viewbox="0,0,4,4"
-														ViewboxUnits="Absolute"
-														Viewport="0,0,4,4"
-														ViewportUnits="Absolute">
+                                                        TileMode="Tile"
+                                                        Viewbox="0,0,4,4"
+                                                        ViewboxUnits="Absolute"
+                                                        Viewport="0,0,4,4"
+                                                        ViewportUnits="Absolute">
                                                         <DrawingBrush.Drawing>
-                                                            <GeometryDrawing Brush="{Binding Fill, ElementName=DragHandleGeometryPlaceholder, Mode=OneWay, Converter={avalonDockConverters:NullToDoNothingConverter}}">
+
+                                                            <!--  FIX: Replace the binding with a direct resource reference  -->
+                                                            <GeometryDrawing Brush="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveGrip}}">
+
+                                                                <!--  ERROR HERE  -->
+                                                                <!--<GeometryDrawing Brush="{Binding Fill, ElementName=DragHandleGeometryPlaceholder, Mode=OneWay, Converter={avalonDockConverters:NullToDoNothingConverter}}">-->
+
                                                                 <GeometryDrawing.Geometry>
                                                                     <GeometryGroup>
                                                                         <GeometryGroup.Children>
@@ -2160,104 +2180,104 @@
                                         </DockPanel>
 
                                         <avalonDockControls:DropDownButton
-											x:Name="SinglePaneContextMenu"
-											Grid.Column="1"
-											Margin="1,1,1,0"
+                                            x:Name="SinglePaneContextMenu"
+                                            Grid.Column="1"
                                             Width="15"
-											Height="15"
-											HorizontalAlignment="Center"
-											VerticalAlignment="Center"
-											shell:WindowChrome.IsHitTestVisibleInChrome="True"
-											DropDownContextMenu="{Binding Model.Root.Manager.AnchorableContextMenu, RelativeSource={RelativeSource TemplatedParent}}"
-											DropDownContextMenuDataContext="{Binding Path=SingleContentLayoutItem, RelativeSource={RelativeSource TemplatedParent}}"
-											Focusable="False"
-											Style="{StaticResource AvalonDockThemeVs2013ToolButtonStyle}"
-											ToolTip="{x:Static avalonDockProperties:Resources.Anchorable_CxMenu_Hint}"
-											Visibility="{Binding Path=Model.IsSinglePane, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
+                                            Height="15"
+                                            Margin="1,1,1,0"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            shell:WindowChrome.IsHitTestVisibleInChrome="True"
+                                            DropDownContextMenu="{Binding Model.Root.Manager.AnchorableContextMenu, RelativeSource={RelativeSource TemplatedParent}}"
+                                            DropDownContextMenuDataContext="{Binding Path=SingleContentLayoutItem, RelativeSource={RelativeSource TemplatedParent}}"
+                                            Focusable="False"
+                                            Style="{StaticResource AvalonDockThemeVs2013ToolButtonStyle}"
+                                            ToolTip="{x:Static avalonDockProperties:Resources.Anchorable_CxMenu_Hint}"
+                                            Visibility="{Binding Path=Model.IsSinglePane, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
                                             <Path
-												x:Name="PART_ImgPinMenu"
-												Margin="0,0,0,1"
-												Width="8"
-												Height="8"
-												Data="{DynamicResource PinMenu}"
-												Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
-												Stretch="Uniform" />
+                                                x:Name="PART_ImgPinMenu"
+                                                Width="8"
+                                                Height="8"
+                                                Margin="0,0,0,1"
+                                                Data="{DynamicResource PinMenu}"
+                                                Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
+                                                Stretch="Uniform" />
                                         </avalonDockControls:DropDownButton>
 
                                         <Button
-											x:Name="PART_PinMaximize"
-											Grid.Column="2"
-											Margin="0,1,1,0"
+                                            x:Name="PART_PinMaximize"
+                                            Grid.Column="2"
                                             Width="15"
-											Height="15"
-											HorizontalAlignment="Center"
-											VerticalAlignment="Center"
-											shell:WindowChrome.IsHitTestVisibleInChrome="True"
-											Command="{x:Static shell:SystemCommands.MaximizeWindowCommand}"
-											CommandParameter="{Binding RelativeSource={RelativeSource TemplatedParent}}"
-											Focusable="False"
-											Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
-											ToolTip="{x:Static avalonDockProperties:Resources.Window_Maximize}"
-											Visibility="{Binding IsMaximized, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:InverseBoolToVisibilityConverter}}">
+                                            Height="15"
+                                            Margin="0,1,1,0"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            shell:WindowChrome.IsHitTestVisibleInChrome="True"
+                                            Command="{x:Static shell:SystemCommands.MaximizeWindowCommand}"
+                                            CommandParameter="{Binding RelativeSource={RelativeSource TemplatedParent}}"
+                                            Focusable="False"
+                                            Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
+                                            ToolTip="{x:Static avalonDockProperties:Resources.Window_Maximize}"
+                                            Visibility="{Binding IsMaximized, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:InverseBoolToVisibilityConverter}}">
                                             <Path
-												x:Name="PART_ImgPinMaximize"
-												Width="9"
-												Height="9"
-												VerticalAlignment="Center"
-												Data="{DynamicResource PinMaximize}"
-												Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
-												Stretch="Uniform" />
+                                                x:Name="PART_ImgPinMaximize"
+                                                Width="9"
+                                                Height="9"
+                                                VerticalAlignment="Center"
+                                                Data="{DynamicResource PinMaximize}"
+                                                Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
+                                                Stretch="Uniform" />
                                         </Button>
 
                                         <Button
-											x:Name="PART_PinRestore"
-											Grid.Column="2"
-											Margin="0,1,1,0"
+                                            x:Name="PART_PinRestore"
+                                            Grid.Column="2"
                                             Width="15"
-											Height="15"
-											HorizontalAlignment="Center"
-											VerticalAlignment="Center"
-											shell:WindowChrome.IsHitTestVisibleInChrome="True"
-											Command="{x:Static shell:SystemCommands.RestoreWindowCommand}"
-											CommandParameter="{Binding RelativeSource={RelativeSource TemplatedParent}}"
-											Focusable="False"
-											Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
-											ToolTip="{x:Static avalonDockProperties:Resources.Window_Restore}"
-											Visibility="{Binding IsMaximized, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
+                                            Height="15"
+                                            Margin="0,1,1,0"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            shell:WindowChrome.IsHitTestVisibleInChrome="True"
+                                            Command="{x:Static shell:SystemCommands.RestoreWindowCommand}"
+                                            CommandParameter="{Binding RelativeSource={RelativeSource TemplatedParent}}"
+                                            Focusable="False"
+                                            Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
+                                            ToolTip="{x:Static avalonDockProperties:Resources.Window_Restore}"
+                                            Visibility="{Binding IsMaximized, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
                                             <Path
-												x:Name="PART_ImgPinRestore"
-												Width="10"
-												Height="10"
-												Margin="1,1,0,0"
-												VerticalAlignment="Center"
-												Data="{DynamicResource PinRestore}"
-												Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
-												Stretch="Uniform" />
+                                                x:Name="PART_ImgPinRestore"
+                                                Width="10"
+                                                Height="10"
+                                                Margin="1,1,0,0"
+                                                VerticalAlignment="Center"
+                                                Data="{DynamicResource PinRestore}"
+                                                Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
+                                                Stretch="Uniform" />
                                         </Button>
 
                                         <Button
-											x:Name="PART_PinClose"
-											Grid.Column="3"
-											Margin="0,1,1,0"
+                                            x:Name="PART_PinClose"
+                                            Grid.Column="3"
                                             Width="15"
-											Height="15"
-											HorizontalAlignment="Center"
-											VerticalAlignment="Center"
-											shell:WindowChrome.IsHitTestVisibleInChrome="True"
-											Command="{Binding HideWindowCommand, RelativeSource={RelativeSource TemplatedParent}}"
-											Focusable="False"
-											Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
-											ToolTip="{x:Static avalonDockProperties:Resources.Anchorable_BtnClose_Hint}"
-											Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
+                                            Height="15"
+                                            Margin="0,1,1,0"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            shell:WindowChrome.IsHitTestVisibleInChrome="True"
+                                            Command="{Binding HideWindowCommand, RelativeSource={RelativeSource TemplatedParent}}"
+                                            Focusable="False"
+                                            Style="{StaticResource AvalonDockThemeVs2013ButtonStyle}"
+                                            ToolTip="{x:Static avalonDockProperties:Resources.Anchorable_BtnClose_Hint}"
+                                            Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={avalonDockConverters:BoolToVisibilityConverter}}">
                                             <Path
-												x:Name="PART_ImgPinClose"
-												Width="10"
-												Height="10"
-												Margin="1,0,0,1"
-												VerticalAlignment="Center"
-												Data="{DynamicResource PinClose}"
-												Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
-												Stretch="Uniform" />
+                                                x:Name="PART_ImgPinClose"
+                                                Width="10"
+                                                Height="10"
+                                                Margin="1,0,0,1"
+                                                VerticalAlignment="Center"
+                                                Data="{DynamicResource PinClose}"
+                                                Fill="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveGlyph}}"
+                                                Stretch="Uniform" />
                                         </Button>
                                     </Grid>
                                 </Border>
@@ -2266,15 +2286,15 @@
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
-						<Trigger Property="WindowState" Value="Maximized">
-							<Setter TargetName="WindowBorder" Property="Padding" Value="8" />
-							<Setter TargetName="WindowBorder" Property="BorderThickness" Value="0" />
-						</Trigger>
-						<DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="True">
-							<Setter TargetName="Header" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveBackground}}" />
-							<Setter TargetName="Header" Property="TextElement.Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveText}}" />
-							<Setter TargetName="DragHandleGeometryPlaceholder" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveGrip}}" />
-						</DataTrigger>
+                        <Trigger Property="WindowState" Value="Maximized">
+                            <Setter TargetName="WindowBorder" Property="Padding" Value="8" />
+                            <Setter TargetName="WindowBorder" Property="BorderThickness" Value="0" />
+                        </Trigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="True">
+                            <Setter TargetName="Header" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveBackground}}" />
+                            <Setter TargetName="Header" Property="TextElement.Foreground" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveText}}" />
+                            <Setter TargetName="DragHandleGeometryPlaceholder" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionActiveGrip}}" />
+                        </DataTrigger>
                         <DataTrigger Binding="{Binding Model.SinglePane.SelectedContent.CanClose, RelativeSource={RelativeSource Mode=Self}}" Value="True">
                             <Setter TargetName="PART_PinClose" Property="Command" Value="{Binding CloseWindowCommand, RelativeSource={RelativeSource TemplatedParent}}" />
                             <Setter TargetName="PART_PinClose" Property="ToolTip" Value="{x:Static avalonDockProperties:Resources.Document_Close}" />
@@ -2294,8 +2314,8 @@
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBackground}}" />
                             <Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredBorder}}" />
-							<Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
-						</MultiDataTrigger>
+                            <Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactiveHoveredGlyph}}" />
+                        </MultiDataTrigger>
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding IsMouseOver, ElementName=PART_PinRestore}" Value="True" />
@@ -2336,8 +2356,8 @@
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="PART_PinMaximize" Property="Background" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBackground}}" />
                             <Setter TargetName="PART_PinMaximize" Property="BorderBrush" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedBorder}}" />
-							<Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
-						</MultiDataTrigger>
+                            <Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedInactivePressedGlyph}}" />
+                        </MultiDataTrigger>
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding IsMouseCaptured, ElementName=PART_PinRestore}" Value="True" />
@@ -2359,8 +2379,8 @@
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Model.SinglePane.SelectedContent.IsActive}" Value="true">
                             <Setter TargetName="PART_ImgPinMenu" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
                             <Setter TargetName="PART_ImgPinMaximize" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
-							<Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
-							<Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
+                            <Setter TargetName="PART_ImgPinRestore" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
+                            <Setter TargetName="PART_ImgPinClose" Property="Fill" Value="{DynamicResource {x:Static reskeys:ResourceKeys.DocumentWellTabButtonSelectedActiveGlyph}}" />
                         </DataTrigger>
 
                         <!--  Document Well : Tab : Button / Selected, active, hovered  -->
@@ -2471,10 +2491,10 @@
             <Setter.Value>
                 <ControlTemplate>
                     <Rectangle
-						RadiusX="2"
-						RadiusY="2"
-						Stroke="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}"
-						StrokeThickness="1" />
+                        RadiusX="2"
+                        RadiusY="2"
+                        Stroke="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}"
+                        StrokeThickness="1" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -2494,10 +2514,10 @@
             <Setter.Value>
                 <ControlTemplate TargetType="ListBoxItem">
                     <Border
-						Background="{TemplateBinding Background}"
-						BorderBrush="{TemplateBinding BorderBrush}"
-						BorderThickness="{TemplateBinding BorderThickness}"
-						SnapsToDevicePixels="true">
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        SnapsToDevicePixels="true">
                         <Border x:Name="InnerBorder" BorderThickness="1">
                             <Grid>
                                 <Grid.RowDefinitions>
@@ -2505,13 +2525,13 @@
                                     <RowDefinition />
                                 </Grid.RowDefinitions>
                                 <Rectangle
-									x:Name="UpperHighlight"
-									Fill="#75FFFFFF"
-									Visibility="Collapsed" />
+                                    x:Name="UpperHighlight"
+                                    Fill="#75FFFFFF"
+                                    Visibility="Collapsed" />
                                 <ContentPresenter
-									Grid.RowSpan="2"
-									VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-									SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                    Grid.RowSpan="2"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             </Grid>
                         </Border>
                     </Border>
@@ -2566,10 +2586,10 @@
                 <ControlTemplate TargetType="{x:Type avalonDockControls:NavigatorWindow}">
                     <Grid>
                         <Border
-							x:Name="WindowBorder"
-							Background="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowBackground}}"
-							BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}"
-							BorderThickness="1">
+                            x:Name="WindowBorder"
+                            Background="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowBackground}}"
+                            BorderBrush="{DynamicResource {x:Static reskeys:ResourceKeys.PanelBorderBrush}}"
+                            BorderThickness="1">
                             <Grid>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="54" />
@@ -2588,32 +2608,32 @@
                                             <ColumnDefinition />
                                         </Grid.ColumnDefinitions>
                                         <Image
-											Source="{Binding SelectedDocument.LayoutElement.IconSource, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:NullToDoNothingConverter}}"
-											Stretch="None"
-											Visibility="{Binding SelectedDocument.LayoutElement.IconSource, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:BoolToVisibilityConverter}}" />
+                                            Source="{Binding SelectedDocument.LayoutElement.IconSource, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:NullToDoNothingConverter}}"
+                                            Stretch="None"
+                                            Visibility="{Binding SelectedDocument.LayoutElement.IconSource, RelativeSource={RelativeSource TemplatedParent}, Converter={avalonDockConverters:BoolToVisibilityConverter}}" />
                                         <TextBlock
-											x:Name="selectedElementTitle"
-											Grid.Column="1"
-											Margin="4,0,0,0"
-											VerticalAlignment="Center"
-											FontWeight="Bold"
-											Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}"
-											Text="{Binding SelectedDocument.LayoutElement.Title, RelativeSource={RelativeSource TemplatedParent}}"
-											TextTrimming="CharacterEllipsis" />
+                                            x:Name="selectedElementTitle"
+                                            Grid.Column="1"
+                                            Margin="4,0,0,0"
+                                            VerticalAlignment="Center"
+                                            FontWeight="Bold"
+                                            Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}"
+                                            Text="{Binding SelectedDocument.LayoutElement.Title, RelativeSource={RelativeSource TemplatedParent}}"
+                                            TextTrimming="CharacterEllipsis" />
                                     </Grid>
                                     <TextBlock
-										x:Name="selectedElementDescription"
-										VerticalAlignment="Center"
-										Text="{Binding SelectedDocument.LayoutElement.Description}"
-										TextTrimming="CharacterEllipsis" />
+                                        x:Name="selectedElementDescription"
+                                        VerticalAlignment="Center"
+                                        Text="{Binding SelectedDocument.LayoutElement.Description}"
+                                        TextTrimming="CharacterEllipsis" />
                                 </Grid>
 
                                 <Border
-									Grid.Row="1"
-									MinHeight="200"
-									Background="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowBackground}}"
-									BorderBrush="Transparent"
-									BorderThickness="0,1,0,0">
+                                    Grid.Row="1"
+                                    MinHeight="200"
+                                    Background="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowBackground}}"
+                                    BorderBrush="Transparent"
+                                    BorderThickness="0,1,0,0">
                                     <Grid Margin="5">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
@@ -2625,19 +2645,19 @@
                                                 <RowDefinition />
                                             </Grid.RowDefinitions>
                                             <TextBlock
-												Margin="0,3,0,4"
-												FontWeight="Bold"
-												Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}"
-												Text="{x:Static avalonDockProperties:Resources.Active_ToolWindows}" />
+                                                Margin="0,3,0,4"
+                                                FontWeight="Bold"
+                                                Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}"
+                                                Text="{x:Static avalonDockProperties:Resources.Active_ToolWindows}" />
                                             <ListBox
-												x:Name="PART_AnchorableListBox"
-												AutomationProperties.Name="{x:Static avalonDockProperties:Resources.Active_ToolWindows}"
-												Grid.Row="1"
-												MaxHeight="400"
-												Background="Transparent"
-												ItemContainerStyle="{StaticResource AvalonDockThemeVs2013NavigatorWindowListBoxItemStyle}"
-												ItemsSource="{Binding Anchorables}"
-												SelectedItem="{Binding SelectedAnchorable, Mode=TwoWay}">
+                                                x:Name="PART_AnchorableListBox"
+                                                Grid.Row="1"
+                                                MaxHeight="400"
+                                                AutomationProperties.Name="{x:Static avalonDockProperties:Resources.Active_ToolWindows}"
+                                                Background="Transparent"
+                                                ItemContainerStyle="{StaticResource AvalonDockThemeVs2013NavigatorWindowListBoxItemStyle}"
+                                                ItemsSource="{Binding Anchorables}"
+                                                SelectedItem="{Binding SelectedAnchorable, Mode=TwoWay}">
                                                 <ListBox.ItemTemplate>
                                                     <DataTemplate>
                                                         <Grid>
@@ -2647,10 +2667,10 @@
                                                             </Grid.ColumnDefinitions>
                                                             <Image Source="{Binding LayoutElement.IconSource, Converter={avalonDockConverters:NullToDoNothingConverter}}" Stretch="None" />
                                                             <TextBlock
-																Grid.Column="1"
-																Margin="4,0,0,0"
-																Text="{Binding LayoutElement.Title}"
-																TextTrimming="CharacterEllipsis" />
+                                                                Grid.Column="1"
+                                                                Margin="4,0,0,0"
+                                                                Text="{Binding LayoutElement.Title}"
+                                                                TextTrimming="CharacterEllipsis" />
                                                         </Grid>
                                                     </DataTemplate>
                                                 </ListBox.ItemTemplate>
@@ -2662,20 +2682,20 @@
                                                 <RowDefinition />
                                             </Grid.RowDefinitions>
                                             <TextBlock
-												Margin="0,3,0,4"
-												FontWeight="Bold"
-												Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}"
-												Text="{x:Static avalonDockProperties:Resources.Active_Files}" />
+                                                Margin="0,3,0,4"
+                                                FontWeight="Bold"
+                                                Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}"
+                                                Text="{x:Static avalonDockProperties:Resources.Active_Files}" />
 
                                             <ListBox
-												x:Name="PART_DocumentListBox"
-												AutomationProperties.Name="{x:Static avalonDockProperties:Resources.Active_Files}"
-												Grid.Row="1"
-												MaxHeight="400"
-												Background="Transparent"
-												ItemContainerStyle="{StaticResource AvalonDockThemeVs2013NavigatorWindowListBoxItemStyle}"
-												ItemsSource="{Binding Documents}"
-												SelectedItem="{Binding SelectedDocument, Mode=TwoWay}">
+                                                x:Name="PART_DocumentListBox"
+                                                Grid.Row="1"
+                                                MaxHeight="400"
+                                                AutomationProperties.Name="{x:Static avalonDockProperties:Resources.Active_Files}"
+                                                Background="Transparent"
+                                                ItemContainerStyle="{StaticResource AvalonDockThemeVs2013NavigatorWindowListBoxItemStyle}"
+                                                ItemsSource="{Binding Documents}"
+                                                SelectedItem="{Binding SelectedDocument, Mode=TwoWay}">
                                                 <ListBox.ItemTemplate>
                                                     <DataTemplate>
                                                         <Grid>
@@ -2685,10 +2705,10 @@
                                                             </Grid.ColumnDefinitions>
                                                             <Image Source="{Binding LayoutElement.IconSource, Converter={avalonDockConverters:NullToDoNothingConverter}}" Stretch="None" />
                                                             <TextBlock
-																Grid.Column="1"
-																Margin="4,0,0,0"
-																Text="{Binding LayoutElement.Title}"
-																TextTrimming="CharacterEllipsis" />
+                                                                Grid.Column="1"
+                                                                Margin="4,0,0,0"
+                                                                Text="{Binding LayoutElement.Title}"
+                                                                TextTrimming="CharacterEllipsis" />
                                                         </Grid>
                                                     </DataTemplate>
                                                 </ListBox.ItemTemplate>
@@ -2704,9 +2724,9 @@
 
                                 <Grid Grid.Row="2" Margin="5">
                                     <TextBlock
-										VerticalAlignment="Center"
-										Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}"
-										Text="{Binding SelectedDocument.LayoutElement.ToolTip, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        VerticalAlignment="Center"
+                                        Foreground="{DynamicResource {x:Static reskeys:ResourceKeys.NavigatorWindowForeground}}"
+                                        Text="{Binding SelectedDocument.LayoutElement.ToolTip, RelativeSource={RelativeSource TemplatedParent}}" />
                                 </Grid>
                             </Grid>
                         </Border>


### PR DESCRIPTION
## Fix: Resolve XAML binding errors in VS2013 theme

Fixed XAML binding errors in Generic.xaml that were causing "Cannot find governing FrameworkElement" errors. 
The issue occurred in the AnchorablePaneTitle and LayoutAnchorableFloatingWindowControl styles, where the GeometryDrawing 
was using an ElementName binding to reference DragHandleGeometryPlaceholder's Fill property.

Solution: Replaced the element bindings with direct DynamicResource references to the same resource keys.

---

The issue is caused in `./Themes/Generic.xaml` in two styles:
1. `<Style TargetType="avalonDockControls:AnchorablePaneTitle">`
2. `<Style x:Key="{x:Type avalonDockControls:LayoutAnchorableFloatingWindowControl}" TargetType="{x:Type avalonDockControls:LayoutAnchorableFloatingWindowControl}">`

Both styles contain a GeometryDrawing element that attempts to bind to the Fill property of another element named "DragHandleGeometryPlaceholder" using an ElementName binding, which fails due to element relationship issues in the visual tree.

## Solution
Fixed the problem by replacing the ElementName bindings with direct resource references:

```xml
Changed

<GeometryDrawing Brush="{Binding Fill, ElementName=DragHandleGeometryPlaceholder, Mode=OneWay, Converter={avalonDockConverters:NullToDoNothingConverter}}">

To:

<GeometryDrawing Brush="{DynamicResource {x:Static reskeys:ResourceKeys.ToolWindowCaptionInactiveGrip}}">
```

### Testing

Tested with .NET 6 and VS2022
Confirmed binding errors no longer appear
Verified that theme styling appears correctly