### PR TITLE
fix: Ensure stable pane insertion order for DocumentPaneDockRight/Bottom

### DIFF
--- a/source/Components/AvalonDock/Controls/DocumentPaneDropTarget.cs
+++ b/source/Components/AvalonDock/Controls/DocumentPaneDropTarget.cs
@@ -111,8 +111,9 @@ namespace AvalonDock.Controls
 							paneGroup.Orientation = System.Windows.Controls.Orientation.Vertical;
 						}
 
-						var insertToIndex = paneGroup.IndexOfChild(targetModel);
-						if (insertToIndex == (paneGroup.Children.Count - 1))
+						var targetIndex = paneGroup.IndexOfChild(targetModel);
+						var insertToIndex = targetIndex < 0 ? paneGroup.Children.Count : targetIndex + 1;
+						if (insertToIndex > paneGroup.Children.Count)
 						{
 							insertToIndex = paneGroup.Children.Count;
 						}
@@ -180,8 +181,9 @@ namespace AvalonDock.Controls
 							paneGroup.Orientation = System.Windows.Controls.Orientation.Horizontal;
 						}
 
-						var insertToIndex = paneGroup.IndexOfChild(targetModel);
-						if (insertToIndex == (paneGroup.Children.Count - 1))
+						var targetIndex = paneGroup.IndexOfChild(targetModel);
+						var insertToIndex = targetIndex < 0 ? paneGroup.Children.Count : targetIndex + 1;
+						if (insertToIndex > paneGroup.Children.Count)
 						{
 							insertToIndex = paneGroup.Children.Count;
 						}


### PR DESCRIPTION
The old logic only inserted the target pane to the back when it was the last one; if the target pane was in the middle, it would be inserted in front of the target. After repeated dragging and dropping, the order would become unstable. Now, both DocumentPaneDockRight and DocumentPaneDockBottom will be stably inserted after the target pane.