### PR TITLE
[Refactor] Refactor DI to builder pattern for AddDockLayoutService

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,8 @@ The `AvalonDock.DependencyInjection` package provides `IServiceCollection` exten
 
 | Method | Purpose |
 |:-------|:--------|
-| `AddToolbox<T>()` | Register a toolbox (anchorable) view model as a singleton |
-| `AddToolbox<T>(factory)` | Register a toolbox with a custom factory for constructor parameters |
-| `AddDockLayoutService()` | Register `IDockLayoutService` — auto-builds the layout tree from all `IToolbox` instances |
-| `AddToggleDockOptions(configure)` | Configure sidebar button size, default dock dimensions, and layout priority |
+| `AddDockLayoutService(configure)` | Register `IDockLayoutService` with a builder to configure toolboxes and toggle dock options in a single call |
+| `AddDockLayoutService()` | Register `IDockLayoutService` without builder configuration |
 | `AddAvalonDock<TFactory>()` | Register a custom `IFactory` implementation |
 | `AddAvalonDockSerializer<T>()` | Register an `ILayoutSerializer` (XML or JSON) |
 | `AddAvalonDockThemeManager<T>()` | Register a theme manager |
@@ -105,6 +103,14 @@ The `AvalonDock.DependencyInjection` package provides `IServiceCollection` exten
 | `AddAutoHideManager<T>()` | Register an auto-hide manager |
 | `AddFloatingWindowService<T>()` | Register a floating window service |
 | `AddDragDropHandler<T>()` | Register a custom drag-and-drop handler |
+
+#### DockLayoutBuilder Methods
+
+| Method | Purpose |
+|:-------|:--------|
+| `ConfigureToggleDock(configure)` | Configure sidebar button size, default dock dimensions, and layout priority |
+| `AddToolbox<T>()` | Register a toolbox (anchorable) view model as a singleton |
+| `AddToolbox<T>(factory)` | Register a toolbox with a custom factory for constructor parameters |
 
 ### Composition Root Example
 
@@ -123,22 +129,21 @@ public partial class App : Application
 
         var services = new ServiceCollection();
 
-        // Configure toggle dock options (sidebar behavior)
-        services.AddToggleDockOptions(opts =>
+        // Configure dock layout: toggle dock options + toolboxes in one call
+        services.AddDockLayoutService(dock =>
         {
-            opts.ButtonSize = 28;
-            opts.DefaultDockWidth = 280;
-            opts.DefaultDockHeight = 220;
-            opts.LayoutPriority = nameof(AvalonDock.DockLayoutPriority.BottomFullWidth);
+            dock.ConfigureToggleDock(opts =>
+            {
+                opts.ButtonSize = 28;
+                opts.DefaultDockWidth = 280;
+                opts.DefaultDockHeight = 220;
+                opts.LayoutPriority = nameof(AvalonDock.DockLayoutPriority.BottomFullWidth);
+            });
+
+            dock.AddToolbox<ExplorerToolbox>();
+            dock.AddToolbox<SearchToolbox>();
+            dock.AddToolbox<TerminalToolbox>();
         });
-
-        // Register toolbox view models
-        services.AddToolbox<ExplorerToolbox>();
-        services.AddToolbox<SearchToolbox>();
-        services.AddToolbox<TerminalToolbox>();
-
-        // Auto-build layout tree from registered toolboxes
-        services.AddDockLayoutService();
 
         services.AddSingleton<MainViewModel>();
         services.AddSingleton<MainWindow>();

--- a/docs/guides/dependency-injection.md
+++ b/docs/guides/dependency-injection.md
@@ -29,10 +29,18 @@ dotnet add package Dirkster.AvalonDock.DependencyInjection
 
 | Method | Purpose |
 |:-------|:--------|
+| `AddDockLayoutService(configure)` | Register `IDockLayoutService` with a builder to configure toolboxes and options |
+| `AddDockLayoutService()` | Register `IDockLayoutService` without builder configuration |
+
+#### DockLayoutBuilder Methods
+
+Used inside the `AddDockLayoutService(dock => { ... })` builder:
+
+| Method | Purpose |
+|:-------|:--------|
+| `ConfigureToggleDock(configure)` | Configure sidebar button size, dock dimensions, layout priority |
 | `AddToolbox<T>()` | Register a toolbox VM as singleton |
 | `AddToolbox<T>(factory)` | Register a toolbox VM with a custom factory |
-| `AddDockLayoutService()` | Register `IDockLayoutService` — auto-builds layout tree from `IToolbox` instances |
-| `AddToggleDockOptions(configure)` | Configure sidebar button size, dock dimensions, layout priority |
 
 ### Additional Services
 
@@ -60,29 +68,24 @@ using Microsoft.Extensions.DependencyInjection;
 
 var services = new ServiceCollection();
 
-// 1. Configure toggle dock options
-services.AddToggleDockOptions(opts =>
+// Configure dock layout: toggle dock options + toolboxes in one call
+services.AddDockLayoutService(dock =>
 {
-    opts.ButtonSize = 28;
-    opts.DefaultDockWidth = 280;
-    opts.DefaultDockHeight = 220;
-    opts.LayoutPriority = nameof(DockLayoutPriority.BottomFullWidth);
+    dock.ConfigureToggleDock(opts =>
+    {
+        opts.ButtonSize = 28;
+        opts.DefaultDockWidth = 280;
+        opts.DefaultDockHeight = 220;
+        opts.LayoutPriority = nameof(DockLayoutPriority.BottomFullWidth);
+    });
+
+    // Register toolboxes — order determines sidebar button order
+    dock.AddToolbox<ExplorerToolbox>();
+    dock.AddToolbox<SearchToolbox>();
+    dock.AddToolbox<OutputToolbox>();
 });
 
-// 2. Register toolboxes — order determines sidebar button order
-services.AddToolbox<ExplorerToolbox>();
-services.AddToolbox<SearchToolbox>();
-services.AddToolbox<OutputToolbox>();
-
-// 3. Register each as IToolbox for collection injection
-services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<ExplorerToolbox>());
-services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<SearchToolbox>());
-services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<OutputToolbox>());
-
-// 4. DockLayoutService auto-builds the MVVM layout tree
-services.AddDockLayoutService();
-
-// 5. Application view models and windows
+// Application view models and windows
 services.AddSingleton<MainViewModel>();
 services.AddSingleton<MainWindow>();
 
@@ -93,19 +96,24 @@ var provider = services.BuildServiceProvider();
 
 ## ToggleDockOptions
 
-Configure the sidebar and docking behavior:
+Configure the sidebar and docking behavior via `ConfigureToggleDock` inside the builder:
 
 ```csharp
-services.AddToggleDockOptions(opts =>
+services.AddDockLayoutService(dock =>
 {
-    opts.ButtonSize = 28;                // Sidebar button size (px)
-    opts.DefaultDockWidth = 280;         // Default width for side panes
-    opts.DefaultDockHeight = 220;        // Default height for bottom panes
-    opts.LayoutPriority = "BottomFullWidth";  // Layout restructuring mode
-    opts.ShowHeaderMinimizeButton = true; // Show minimize in pane headers
-    opts.ShowHeaderOptionsButton = true;  // Show options (⋯) in pane headers
+    dock.ConfigureToggleDock(opts =>
+    {
+        opts.ButtonSize = 28;                // Sidebar button size (px)
+        opts.DefaultDockWidth = 280;         // Default width for side panes
+        opts.DefaultDockHeight = 220;        // Default height for bottom panes
+        opts.LayoutPriority = "BottomFullWidth";  // Layout restructuring mode
+        opts.ShowHeaderMinimizeButton = true; // Show minimize in pane headers
+        opts.ShowHeaderOptionsButton = true;  // Show options (⋯) in pane headers
+    });
 });
 ```
+
+If `ConfigureToggleDock` is not called, default `ToggleDockOptions` are registered automatically.
 
 ### Layout Priority Modes
 
@@ -119,11 +127,14 @@ services.AddToggleDockOptions(opts =>
 
 ## Factory Registration
 
-For toolboxes that need constructor parameters:
+For toolboxes that need constructor parameters, use the factory overload inside the builder:
 
 ```csharp
-services.AddToolbox<FolderExplorerToolbox>(sp =>
-    new FolderExplorerToolbox(filePath => { /* callback */ }));
+services.AddDockLayoutService(dock =>
+{
+    dock.AddToolbox<FolderExplorerToolbox>(sp =>
+        new FolderExplorerToolbox(filePath => { /* callback */ }));
+});
 ```
 
 ---

--- a/docs/guides/toggle-docking-manager.md
+++ b/docs/guides/toggle-docking-manager.md
@@ -133,10 +133,12 @@ public class ExplorerToolbox : ToolboxBase
 Register toolboxes with DI:
 
 ```csharp
-services.AddToolbox<ExplorerToolbox>();
-services.AddToolbox<OutputToolbox>();
-services.AddToolbox<SearchToolbox>();
-services.AddDockLayoutService();
+services.AddDockLayoutService(dock =>
+{
+    dock.AddToolbox<ExplorerToolbox>();
+    dock.AddToolbox<OutputToolbox>();
+    dock.AddToolbox<SearchToolbox>();
+});
 ```
 
 See [MVVM Integration]({% link guides/mvvm.md %}) for the full pattern.

--- a/docs/tutorials/dependency-injection-app.md
+++ b/docs/tutorials/dependency-injection-app.md
@@ -3,7 +3,7 @@ title: "Tutorial: Dependency Injection App"
 layout: default
 parent: Tutorials
 nav_order: 2
-description: "Build a modern AvalonDock application using the v5 DI architecture with AddToolbox, AddDockLayoutService, and ToggleDockingManager."
+description: "Build a modern AvalonDock application using the v5 DI architecture with AddDockLayoutService builder pattern and ToggleDockingManager."
 ---
 
 # Tutorial: Dependency Injection Deep Dive
@@ -17,9 +17,9 @@ This tutorial covers the same DI patterns used in the `AvalonDockCodeApp` sample
 
 ## What You'll Learn
 
-- Every `IServiceCollection` extension method and when to use it
-- How `AddDockLayoutService()` auto-builds the layout tree from registered `IToolbox` instances
-- How `AddToggleDockOptions()` configures the sidebar and docking behavior
+- The `AddDockLayoutService(configure)` builder pattern and when to use it
+- How the `DockLayoutBuilder` auto-builds the layout tree from registered `IToolbox` instances
+- How `ConfigureToggleDock()` configures the sidebar and docking behavior
 - How to use factory overloads (`AddToolbox<T>(factory)`) for toolboxes that need constructor parameters
 - How to register additional AvalonDock services (theme manager, serializer, auto-hide)
 - Testing patterns with DI
@@ -44,10 +44,8 @@ The `AvalonDock.DependencyInjection` package provides these extension methods on
 
 | Method | Purpose |
 |:-------|:--------|
-| `AddToolbox<T>()` | Register a toolbox VM as singleton |
-| `AddToolbox<T>(factory)` | Register a toolbox VM with a custom factory |
-| `AddDockLayoutService()` | Register `IDockLayoutService` — auto-builds layout tree from all `IToolbox` instances |
-| `AddToggleDockOptions(configure)` | Register `ToggleDockOptions` for sidebar/dock configuration |
+| `AddDockLayoutService(configure)` | Register `IDockLayoutService` with a builder to configure toolboxes and options |
+| `AddDockLayoutService()` | Register `IDockLayoutService` without builder configuration |
 | `AddAvalonDock<TFactory>()` | Register a custom `IFactory` implementation |
 | `AddAvalonDockSerializer<T>()` | Register a layout serializer |
 | `AddAvalonDockThemeManager<T>()` | Register a theme manager |
@@ -56,29 +54,41 @@ The `AvalonDock.DependencyInjection` package provides these extension methods on
 | `AddFloatingWindowService<T>()` | Register a floating window service |
 | `AddDragDropHandler<T>()` | Register a drag-and-drop handler |
 
+#### DockLayoutBuilder Methods
+
+| Method | Purpose |
+|:-------|:--------|
+| `ConfigureToggleDock(configure)` | Register `ToggleDockOptions` for sidebar/dock configuration |
+| `AddToolbox<T>()` | Register a toolbox VM as singleton |
+| `AddToolbox<T>(factory)` | Register a toolbox VM with a custom factory |
+
 ---
 
 ## Registration Patterns
 
 ### Basic Toolbox Registration
 
-For toolboxes with parameterless constructors:
+For toolboxes with parameterless constructors, use `AddToolbox<T>()` inside the builder:
 
 ```csharp
-services.AddToolbox<SearchToolbox>();
-services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<SearchToolbox>());
+services.AddDockLayoutService(dock =>
+{
+    dock.AddToolbox<SearchToolbox>();
+});
 ```
 
-The first line registers `SearchToolbox` as a singleton. The second line registers it as `IToolbox` so that `DockLayoutService` can discover it.
+This registers `SearchToolbox` as a singleton and also as `IToolbox` so that `DockLayoutService` can discover it.
 
 ### Factory-Based Registration
 
 For toolboxes that need constructor parameters (like callbacks):
 
 ```csharp
-services.AddToolbox<FolderExplorerToolbox>(sp =>
-    new FolderExplorerToolbox(filePath => { /* open file callback */ }));
-services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<FolderExplorerToolbox>());
+services.AddDockLayoutService(dock =>
+{
+    dock.AddToolbox<FolderExplorerToolbox>(sp =>
+        new FolderExplorerToolbox(filePath => { /* open file callback */ }));
+});
 ```
 
 This is used in `AvalonDockCodeApp` for the `FolderExplorerViewModel` which needs a file-open callback.
@@ -86,7 +96,11 @@ This is used in `AvalonDockCodeApp` for the `FolderExplorerViewModel` which need
 ### DockLayoutService
 
 ```csharp
-services.AddDockLayoutService();
+services.AddDockLayoutService(dock =>
+{
+    dock.AddToolbox<ExplorerToolbox>();
+    dock.AddToolbox<SearchToolbox>();
+});
 ```
 
 This registers `IDockLayoutService` as a singleton. On creation, it:
@@ -95,17 +109,24 @@ This registers `IDockLayoutService` as a singleton. On creation, it:
 2. Builds an `IRootDock` layout tree with toolboxes placed by their `DockZone`
 3. Exposes the tree via `Layout` for XAML binding
 
+If `ConfigureToggleDock` is not called, default `ToggleDockOptions` are registered automatically.
+
 ### ToggleDockOptions
 
+Configure via `ConfigureToggleDock` inside the builder:
+
 ```csharp
-services.AddToggleDockOptions(opts =>
+services.AddDockLayoutService(dock =>
 {
-    opts.ButtonSize = 28;           // Sidebar toggle button size in pixels
-    opts.DefaultDockWidth = 280;    // Default width for side-docked panes
-    opts.DefaultDockHeight = 220;   // Default height for bottom-docked panes
-    opts.LayoutPriority = nameof(DockLayoutPriority.BottomFullWidth);
-    opts.ShowHeaderMinimizeButton = true;
-    opts.ShowHeaderOptionsButton = true;
+    dock.ConfigureToggleDock(opts =>
+    {
+        opts.ButtonSize = 28;           // Sidebar toggle button size in pixels
+        opts.DefaultDockWidth = 280;    // Default width for side-docked panes
+        opts.DefaultDockHeight = 220;   // Default height for bottom-docked panes
+        opts.LayoutPriority = nameof(DockLayoutPriority.BottomFullWidth);
+        opts.ShowHeaderMinimizeButton = true;
+        opts.ShowHeaderOptionsButton = true;
+    });
 });
 ```
 
@@ -151,36 +172,29 @@ public partial class App : Application
 
     private static void ConfigureServices(IServiceCollection services)
     {
-        // 1. Configure toggle dock options
-        services.AddToggleDockOptions(opts =>
+        // Configure dock layout: toggle dock options + toolboxes in one call
+        services.AddDockLayoutService(dock =>
         {
-            opts.ButtonSize = 28;
-            opts.DefaultDockWidth = 280;
-            opts.DefaultDockHeight = 220;
-            opts.LayoutPriority = nameof(DockLayoutPriority.BottomFullWidth);
+            dock.ConfigureToggleDock(opts =>
+            {
+                opts.ButtonSize = 28;
+                opts.DefaultDockWidth = 280;
+                opts.DefaultDockHeight = 220;
+                opts.LayoutPriority = nameof(DockLayoutPriority.BottomFullWidth);
+            });
+
+            // Register toolbox VMs — order determines sidebar button order
+            dock.AddToolbox<ExplorerToolbox>();
+            dock.AddToolbox<SearchToolbox>();
+            dock.AddToolbox<SourceControlToolbox>();
+            dock.AddToolbox<ProblemsToolbox>();
+            dock.AddToolbox<TerminalToolbox>();
         });
 
-        // 2. Register toolbox VMs — order determines sidebar button order
-        services.AddToolbox<ExplorerToolbox>();
-        services.AddToolbox<SearchToolbox>();
-        services.AddToolbox<SourceControlToolbox>();
-        services.AddToolbox<ProblemsToolbox>();
-        services.AddToolbox<TerminalToolbox>();
-
-        // 3. Register each as IToolbox for collection injection
-        services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<ExplorerToolbox>());
-        services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<SearchToolbox>());
-        services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<SourceControlToolbox>());
-        services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<ProblemsToolbox>());
-        services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<TerminalToolbox>());
-
-        // 4. DockLayoutService auto-builds the layout tree
-        services.AddDockLayoutService();
-
-        // 5. MainViewModel receives IDockLayoutService
+        // MainViewModel receives IDockLayoutService
         services.AddSingleton<MainViewModel>();
 
-        // 6. MainWindow receives MainViewModel + ToggleDockOptions
+        // MainWindow receives MainViewModel + ToggleDockOptions
         services.AddSingleton<MainWindow>();
     }
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -21,7 +21,7 @@ These tutorials assume you have already completed the [Quick Start]({% link gett
 | Tutorial | What You'll Build | Key Topics |
 |:---------|:------------------|:-----------|
 | [MVVM IDE Application]({% link tutorials/mvvm-ide.md %}) | A VS Code-style IDE with sidebar toggles | ToolboxBase, Document, IDockLayoutService, ToggleDockingManager, DockZone, DI |
-| [Dependency Injection Deep Dive]({% link tutorials/dependency-injection-app.md %}) | DI patterns and APIs in depth | AddToolbox, AddDockLayoutService, ToggleDockOptions, factory registration, testing |
+| [Dependency Injection Deep Dive]({% link tutorials/dependency-injection-app.md %}) | DI patterns and APIs in depth | AddDockLayoutService builder, DockLayoutBuilder, ConfigureToggleDock, factory registration, testing |
 | [Styling & Theming]({% link tutorials/styling-and-theming.md %}) | A theme-switchable app with custom branding | Runtime theme switching, brush overrides, custom theme classes, application-wide theming |
 | [Layout Persistence]({% link tutorials/layout-persistence.md %}) | An app that remembers its window layout | XML/JSON serialization, MVVM serialization callbacks, auto-save, layout reset |
 

--- a/docs/tutorials/mvvm-ide.md
+++ b/docs/tutorials/mvvm-ide.md
@@ -52,11 +52,12 @@ Before diving in, here is how the pieces fit together:
 
 ```
 App.xaml.cs  (Composition Root)
-├── AddToolbox<ExplorerToolbox>()       ← registers tool VMs
-├── AddToolbox<SearchToolbox>()
-├── AddToolbox<OutputToolbox>()
-├── AddDockLayoutService()              ← auto-builds layout tree from toolboxes
-├── AddToggleDockOptions(...)           ← configures sidebar button size, dock sizes
+├── AddDockLayoutService(dock => {      ← single entry point for dock configuration
+│       dock.ConfigureToggleDock(...)   ← configures sidebar button size, dock sizes
+│       dock.AddToolbox<ExplorerToolbox>()  ← registers tool VMs
+│       dock.AddToolbox<SearchToolbox>()
+│       dock.AddToolbox<OutputToolbox>()
+│   })
 └── AddSingleton<MainViewModel>()       ← receives IDockLayoutService via DI
 
 MainViewModel
@@ -350,26 +351,21 @@ public partial class App : Application
 
     private static void ConfigureServices(IServiceCollection services)
     {
-        // Configure sidebar and docking options
-        services.AddToggleDockOptions(opts =>
+        // Configure dock layout: toggle dock options + toolboxes in one call
+        services.AddDockLayoutService(dock =>
         {
-            opts.ButtonSize = 28;
-            opts.DefaultDockWidth = 280;
-            opts.DefaultDockHeight = 220;
+            dock.ConfigureToggleDock(opts =>
+            {
+                opts.ButtonSize = 28;
+                opts.DefaultDockWidth = 280;
+                opts.DefaultDockHeight = 220;
+            });
+
+            // Register toolbox VMs — order determines sidebar button order
+            dock.AddToolbox<ExplorerToolbox>();
+            dock.AddToolbox<SearchToolbox>();
+            dock.AddToolbox<OutputToolbox>();
         });
-
-        // Register toolbox VMs — order determines sidebar button order
-        services.AddToolbox<ExplorerToolbox>();
-        services.AddToolbox<SearchToolbox>();
-        services.AddToolbox<OutputToolbox>();
-
-        // Register each as IToolbox so DockLayoutService can discover them
-        services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<ExplorerToolbox>());
-        services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<SearchToolbox>());
-        services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<OutputToolbox>());
-
-        // DockLayoutService auto-builds the MVVM layout tree from registered IToolbox instances
-        services.AddDockLayoutService();
 
         // Main view model — receives IDockLayoutService
         services.AddSingleton<MainViewModel>();
@@ -655,10 +651,9 @@ To add a new tool panel in the v5 architecture:
    }
    ```
 
-2. **Register in DI** — add two lines to `ConfigureServices`:
+2. **Register in DI** — add one line inside the `AddDockLayoutService` builder:
    ```csharp
-   services.AddToolbox<ProblemsToolbox>();
-   services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<ProblemsToolbox>());
+   dock.AddToolbox<ProblemsToolbox>();
    ```
 
 3. **Add a DataTemplate** in XAML:

--- a/source/AutomationTest/AvalonDockTest/DependencyInjectionTests.cs
+++ b/source/AutomationTest/AvalonDockTest/DependencyInjectionTests.cs
@@ -39,10 +39,13 @@ namespace AvalonDockTest
 	public class ServiceCollectionExtensionsTests
 	{
 		[Test]
-		public void AddToolbox_RegistersSingleton()
+		public void AddDockLayoutService_Builder_AddToolbox_RegistersSingleton()
 		{
 			var services = new ServiceCollection();
-			services.AddToolbox<DiTestToolbox>();
+			services.AddDockLayoutService(dock =>
+			{
+				dock.AddToolbox<DiTestToolbox>();
+			});
 
 			var provider = services.BuildServiceProvider();
 			var instance1 = provider.GetRequiredService<DiTestToolbox>();
@@ -53,11 +56,14 @@ namespace AvalonDockTest
 		}
 
 		[Test]
-		public void AddToolbox_WithFactory_RegistersSingleton()
+		public void AddDockLayoutService_Builder_AddToolbox_WithFactory_RegistersSingleton()
 		{
 			var services = new ServiceCollection();
-			services.AddToolbox<DiTestToolboxWithDeps>(sp =>
-				new DiTestToolboxWithDeps("injected-value"));
+			services.AddDockLayoutService(dock =>
+			{
+				dock.AddToolbox<DiTestToolboxWithDeps>(sp =>
+					new DiTestToolboxWithDeps("injected-value"));
+			});
 
 			var provider = services.BuildServiceProvider();
 			var instance = provider.GetRequiredService<DiTestToolboxWithDeps>();
@@ -67,11 +73,14 @@ namespace AvalonDockTest
 		}
 
 		[Test]
-		public void AddToolbox_WithFactory_IsSingleton()
+		public void AddDockLayoutService_Builder_AddToolbox_WithFactory_IsSingleton()
 		{
 			var services = new ServiceCollection();
-			services.AddToolbox<DiTestToolboxWithDeps>(sp =>
-				new DiTestToolboxWithDeps("test"));
+			services.AddDockLayoutService(dock =>
+			{
+				dock.AddToolbox<DiTestToolboxWithDeps>(sp =>
+					new DiTestToolboxWithDeps("test"));
+			});
 
 			var provider = services.BuildServiceProvider();
 			var instance1 = provider.GetRequiredService<DiTestToolboxWithDeps>();
@@ -81,10 +90,13 @@ namespace AvalonDockTest
 		}
 
 		[Test]
-		public void AddToolbox_CanBeResolvedAsIToolbox()
+		public void AddDockLayoutService_Builder_AddToolbox_CanBeResolvedAsIToolbox()
 		{
 			var services = new ServiceCollection();
-			services.AddToolbox<DiTestToolbox>();
+			services.AddDockLayoutService(dock =>
+			{
+				dock.AddToolbox<DiTestToolbox>();
+			});
 
 			var provider = services.BuildServiceProvider();
 			var toolboxes = provider.GetServices<IToolbox>().ToList();
@@ -94,12 +106,15 @@ namespace AvalonDockTest
 		}
 
 		[Test]
-		public void AddToolbox_MultipleToolboxes_AllResolvable()
+		public void AddDockLayoutService_Builder_MultipleToolboxes_AllResolvable()
 		{
 			var services = new ServiceCollection();
-			services.AddToolbox<DiTestToolbox>();
-			services.AddToolbox<DiTestToolboxWithDeps>(sp => new DiTestToolboxWithDeps("v"));
-			
+			services.AddDockLayoutService(dock =>
+			{
+				dock.AddToolbox<DiTestToolbox>();
+				dock.AddToolbox<DiTestToolboxWithDeps>(sp => new DiTestToolboxWithDeps("v"));
+			});
+
 			var provider = services.BuildServiceProvider();
 			var toolboxes = provider.GetServices<IToolbox>().ToList();
 
@@ -107,14 +122,17 @@ namespace AvalonDockTest
 		}
 
 		[Test]
-		public void AddToggleDockOptions_RegistersOptions()
+		public void AddDockLayoutService_Builder_ConfigureToggleDock_RegistersOptions()
 		{
 			var services = new ServiceCollection();
-			services.AddToggleDockOptions(opts =>
+			services.AddDockLayoutService(dock =>
 			{
-				opts.ButtonSize = 32;
-				opts.DefaultDockWidth = 300;
-				opts.DefaultDockHeight = 200;
+				dock.ConfigureToggleDock(opts =>
+				{
+					opts.ButtonSize = 32;
+					opts.DefaultDockWidth = 300;
+					opts.DefaultDockHeight = 200;
+				});
 			});
 
 			var provider = services.BuildServiceProvider();
@@ -126,31 +144,65 @@ namespace AvalonDockTest
 		}
 
 		[Test]
-		public void AddToggleDockOptions_WithoutConfigure_UsesDefaults()
+		public void AddDockLayoutService_Builder_WithoutConfigureToggleDock_RegistersDefaults()
 		{
 			var services = new ServiceCollection();
-			services.AddToggleDockOptions();
+			services.AddDockLayoutService(dock =>
+			{
+				dock.AddToolbox<DiTestToolbox>();
+			});
 
 			var provider = services.BuildServiceProvider();
 			var options = provider.GetRequiredService<ToggleDockOptions>();
 
 			Assert.That(options, Is.Not.Null);
+			Assert.That(options.ButtonSize, Is.EqualTo(25));
+			Assert.That(options.DefaultDockWidth, Is.EqualTo(250));
+			Assert.That(options.DefaultDockHeight, Is.EqualTo(200));
 		}
 
 		[Test]
-		public void AddToolbox_ReturnsSameServiceCollection_ForChaining()
+		public void AddDockLayoutService_Builder_ReturnsSameServiceCollection_ForChaining()
 		{
 			var services = new ServiceCollection();
-			var result = services.AddToolbox<DiTestToolbox>();
+			var result = services.AddDockLayoutService(dock =>
+			{
+				dock.AddToolbox<DiTestToolbox>();
+			});
 			Assert.That(result, Is.SameAs(services));
 		}
 
 		[Test]
-		public void AddToggleDockOptions_ReturnsSameServiceCollection_ForChaining()
+		public void AddDockLayoutService_Builder_RegistersLayoutServiceAndSideToggleManager()
 		{
 			var services = new ServiceCollection();
-			var result = services.AddToggleDockOptions();
-			Assert.That(result, Is.SameAs(services));
+			services.AddDockLayoutService(dock =>
+			{
+				dock.AddToolbox<DiTestToolbox>();
+			});
+
+			var provider = services.BuildServiceProvider();
+			var layoutSvc = provider.GetRequiredService<IDockLayoutService>();
+			var sideToggle = provider.GetRequiredService<SideToggleManager>();
+
+			Assert.That(layoutSvc, Is.Not.Null);
+			Assert.That(sideToggle, Is.Not.Null);
+		}
+
+		[Test]
+		public void AddDockLayoutService_Builder_CollectsToolboxes()
+		{
+			var services = new ServiceCollection();
+			services.AddDockLayoutService(dock =>
+			{
+				dock.AddToolbox<DiTestToolbox>();
+				dock.AddToolbox<DiTestToolboxWithDeps>(sp => new DiTestToolboxWithDeps("val"));
+			});
+
+			var provider = services.BuildServiceProvider();
+			var svc = provider.GetRequiredService<IDockLayoutService>();
+
+			Assert.That(svc.Anchorables.Count(), Is.EqualTo(2));
 		}
 
 		[Test]
@@ -458,9 +510,10 @@ namespace AvalonDockTest
 		public void AddDockLayoutService_RegistersSingleton()
 		{
 			var services = new ServiceCollection();
-			services.AddToolbox<DiTestToolbox>();
-			services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<DiTestToolbox>());
-			services.AddDockLayoutService();
+			services.AddDockLayoutService(dock =>
+			{
+				dock.AddToolbox<DiTestToolbox>();
+			});
 
 			var provider = services.BuildServiceProvider();
 			var svc1 = provider.GetRequiredService<IDockLayoutService>();
@@ -475,8 +528,10 @@ namespace AvalonDockTest
 		public void DockLayoutService_CollectsToolboxes()
 		{
 			var services = new ServiceCollection();
-			services.AddToolbox<DiTestToolbox>();
-			services.AddDockLayoutService();
+			services.AddDockLayoutService(dock =>
+			{
+				dock.AddToolbox<DiTestToolbox>();
+			});
 
 			var provider = services.BuildServiceProvider();
 			var svc = provider.GetRequiredService<IDockLayoutService>();

--- a/source/AvalonDockCodeApp/App.xaml.cs
+++ b/source/AvalonDockCodeApp/App.xaml.cs
@@ -26,25 +26,25 @@ public partial class App : Application
 
 	private static void ConfigureServices(IServiceCollection services)
 	{
-		// AvalonDock toggle options via DI
-		services.AddToggleDockOptions(opts =>
+		// Dock layout service — configure toggle dock options and toolboxes in one call
+		services.AddDockLayoutService(dock =>
 		{
-			opts.ButtonSize = 28;
-			opts.DefaultDockWidth = 280;
-			opts.DefaultDockHeight = 220;
-			opts.LayoutPriority = nameof(DockLayoutPriority.BottomFullWidth);
+			dock.ConfigureToggleDock(opts =>
+			{
+				opts.ButtonSize = 28;
+				opts.DefaultDockWidth = 280;
+				opts.DefaultDockHeight = 220;
+				opts.LayoutPriority = nameof(DockLayoutPriority.BottomFullWidth);
+			});
+
+			// Register toolboxes — order determines sidebar button order
+			dock.AddToolbox<FolderExplorerViewModel>(sp =>
+				new FolderExplorerViewModel(_ => { }));
+			dock.AddToolbox<SearchViewModel>();
+			dock.AddToolbox<SourceControlViewModel>();
+			dock.AddToolbox<ProblemsViewModel>();
+			dock.AddToolbox<TerminalViewModel>();
 		});
-
-		// Register toolboxes — order determines sidebar button order
-		services.AddToolbox<FolderExplorerViewModel>(sp =>
-			new FolderExplorerViewModel(_ => { }));
-		services.AddToolbox<SearchViewModel>();
-		services.AddToolbox<SourceControlViewModel>();
-		services.AddToolbox<ProblemsViewModel>();
-		services.AddToolbox<TerminalViewModel>();
-
-		// Dock layout service — auto-builds the MVVM dock tree from toolboxes
-		services.AddDockLayoutService();
 
 		// MainViewModel uses only the layout service — all anchorables accessible via GetAnchorable<T>()
 		services.AddSingleton<MainViewModel>();

--- a/source/Components/AvalonDock.DependencyInjection/DockLayoutBuilder.cs
+++ b/source/Components/AvalonDock.DependencyInjection/DockLayoutBuilder.cs
@@ -1,0 +1,68 @@
+using System;
+using AvalonDock.Core;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AvalonDock.DependencyInjection
+{
+	/// <summary>
+	/// Builder for configuring dock layout services, toolboxes, and toggle dock options
+	/// through a single <see cref="ServiceCollectionExtensions.AddDockLayoutService(IServiceCollection, Action{DockLayoutBuilder})"/> call.
+	/// </summary>
+	public class DockLayoutBuilder
+	{
+		private readonly IServiceCollection _services;
+
+		/// <summary>Gets a value indicating whether <see cref="ConfigureToggleDock"/> was called.</summary>
+		internal bool ToggleDockConfigured { get; private set; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DockLayoutBuilder"/> class.
+		/// </summary>
+		/// <param name="services">The service collection to register services into.</param>
+		public DockLayoutBuilder(IServiceCollection services)
+		{
+			_services = services ?? throw new ArgumentNullException(nameof(services));
+		}
+
+		/// <summary>
+		/// Configures <see cref="ToggleDockOptions"/> for the toggle docking manager.
+		/// </summary>
+		/// <param name="configure">Optional delegate to configure the options.</param>
+		/// <returns>This builder for chaining.</returns>
+		public DockLayoutBuilder ConfigureToggleDock(Action<ToggleDockOptions>? configure = null)
+		{
+			var options = new ToggleDockOptions();
+			configure?.Invoke(options);
+			_services.AddSingleton(options);
+			ToggleDockConfigured = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Registers a toolbox ViewModel for use with the ToggleDockingManager.
+		/// </summary>
+		/// <typeparam name="T">The concrete ViewModel type implementing <see cref="IToolbox"/>.</typeparam>
+		/// <returns>This builder for chaining.</returns>
+		public DockLayoutBuilder AddToolbox<T>()
+			where T : class, IToolbox
+		{
+			_services.AddSingleton<T>();
+			_services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<T>());
+			return this;
+		}
+
+		/// <summary>
+		/// Registers a toolbox ViewModel with a factory for use with the ToggleDockingManager.
+		/// </summary>
+		/// <typeparam name="T">The concrete ViewModel type implementing <see cref="IToolbox"/>.</typeparam>
+		/// <param name="factory">Factory to create the ViewModel instance.</param>
+		/// <returns>This builder for chaining.</returns>
+		public DockLayoutBuilder AddToolbox<T>(Func<IServiceProvider, T> factory)
+			where T : class, IToolbox
+		{
+			_services.AddSingleton<T>(factory);
+			_services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<T>());
+			return this;
+		}
+	}
+}

--- a/source/Components/AvalonDock.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/source/Components/AvalonDock.DependencyInjection/ServiceCollectionExtensions.cs
@@ -59,55 +59,6 @@ namespace AvalonDock.DependencyInjection
 		}
 
 		/// <summary>
-		/// Registers <see cref="ToggleDockOptions"/> with an optional configuration delegate.
-		/// </summary>
-		/// <param name="services">The service collection.</param>
-		/// <param name="configure">Optional delegate to configure the options.</param>
-		/// <returns>The service collection for chaining.</returns>
-		public static IServiceCollection AddToggleDockOptions(
-			this IServiceCollection services,
-			Action<ToggleDockOptions>? configure = null)
-		{
-			var options = new ToggleDockOptions();
-			configure?.Invoke(options);
-			services.AddSingleton(options);
-			return services;
-		}
-
-		/// <summary>
-		/// Registers a toolbox ViewModel for use with the ToggleDockingManager.
-		/// The ViewModel should implement <c>AvalonDock.Core.IToolbox</c>.
-		/// All registered toolboxes are collected via <c>IEnumerable&lt;IToolboxRegistration&gt;</c>.
-		/// </summary>
-		/// <typeparam name="T">The concrete ViewModel type.</typeparam>
-		/// <param name="services">The service collection.</param>
-		/// <returns>The service collection for chaining.</returns>
-		public static IServiceCollection AddToolbox<T>(this IServiceCollection services)
-			where T : class, IToolbox
-		{
-			services.AddSingleton<T>();
-			services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<T>());
-			return services;
-		}
-
-		/// <summary>
-		/// Registers a toolbox ViewModel with a factory for use with the ToggleDockingManager.
-		/// </summary>
-		/// <typeparam name="T">The concrete ViewModel type.</typeparam>
-		/// <param name="services">The service collection.</param>
-		/// <param name="factory">Factory to create the ViewModel instance.</param>
-		/// <returns>The service collection for chaining.</returns>
-		public static IServiceCollection AddToolbox<T>(
-			this IServiceCollection services,
-			Func<IServiceProvider, T> factory)
-			where T : class, IToolbox
-		{
-			services.AddSingleton<T>(factory);
-			services.AddSingleton<IToolbox>(sp => sp.GetRequiredService<T>());
-			return services;
-		}
-
-		/// <summary>
 		/// Registers a theme manager implementation.
 		/// </summary>
 		/// <typeparam name="TThemeManager">The concrete type implementing <see cref="IThemeManager"/>.</typeparam>
@@ -176,6 +127,36 @@ namespace AvalonDock.DependencyInjection
 			where TDragDrop : class, IDragDropHandler
 		{
 			services.AddSingleton<IDragDropHandler, TDragDrop>();
+			return services;
+		}
+
+		/// <summary>
+		/// Registers the <see cref="IDockLayoutService"/> which auto-builds the MVVM layout tree
+		/// from all registered <see cref="IToolbox"/> instances, using a builder to configure
+		/// toolboxes and toggle dock options in a single call.
+		/// </summary>
+		/// <param name="services">The service collection.</param>
+		/// <param name="configure">Delegate to configure the dock layout via <see cref="DockLayoutBuilder"/>.</param>
+		/// <returns>The service collection for chaining.</returns>
+		public static IServiceCollection AddDockLayoutService(
+			this IServiceCollection services,
+			Action<DockLayoutBuilder> configure)
+		{
+			var builder = new DockLayoutBuilder(services);
+			configure(builder);
+
+			if (!builder.ToggleDockConfigured)
+			{
+				services.AddSingleton(new ToggleDockOptions());
+			}
+
+			services.AddSingleton<IDockLayoutService>(sp =>
+			{
+				var toolboxes = sp.GetService<IEnumerable<IToolbox>>()
+					?? System.Array.Empty<IToolbox>();
+				return new Mvvm.DockLayoutService(toolboxes);
+			});
+			services.AddSingleton<Mvvm.SideToggleManager>();
 			return services;
 		}
 

--- a/source/Components/AvalonDock.DependencyInjection/ToggleDockOptions.cs
+++ b/source/Components/AvalonDock.DependencyInjection/ToggleDockOptions.cs
@@ -2,7 +2,7 @@ namespace AvalonDock.DependencyInjection
 {
 	/// <summary>
 	/// Configuration options for the Toggle Docking Manager.
-	/// Register via <see cref="ServiceCollectionExtensions.AddToggleDockOptions"/>
+	/// Register via <see cref="DockLayoutBuilder.ConfigureToggleDock"/>
 	/// and resolve in your window to apply settings.
 	/// </summary>
 	public class ToggleDockOptions

--- a/source/Components/AvalonDock.Mvvm.CommunityToolkit/ObservableToolboxBase.cs
+++ b/source/Components/AvalonDock.Mvvm.CommunityToolkit/ObservableToolboxBase.cs
@@ -12,7 +12,8 @@ namespace AvalonDock.Mvvm.CommunityToolkit
 	/// <para>Inherit from this class for your toolbox ViewModels when using
 	/// CommunityToolkit.Mvvm source generators. Set <see cref="Zone"/> in the
 	/// constructor to control placement.</para>
-	/// <para>Register with DI using <c>services.AddToolbox&lt;T&gt;()</c>.</para>
+	/// <para>Register with DI using <c>dock.AddToolbox&lt;T&gt;()</c> inside the
+	/// <c>AddDockLayoutService</c> builder.</para>
 	/// </remarks>
 	[DataContract]
 	public abstract class ObservableToolboxBase : ObservableDockableBase, IToolbox

--- a/source/Components/AvalonDock.Mvvm/ToolboxBase.cs
+++ b/source/Components/AvalonDock.Mvvm/ToolboxBase.cs
@@ -11,8 +11,9 @@ namespace AvalonDock.Mvvm
 	/// <para>Inherit from this class for your toolbox ViewModels. Set <see cref="Zone"/>
 	/// in the constructor to control placement. Override <see cref="DockableBase.Title"/>
 	/// and <see cref="DockableBase.Id"/> for display and serialization.</para>
-	/// <para>Register with DI using <c>services.AddToolbox&lt;T&gt;()</c> and they will
-	/// be automatically placed into the ToggleDockingManager layout.</para>
+	/// <para>Register with DI using <c>dock.AddToolbox&lt;T&gt;()</c> inside the
+	/// <c>AddDockLayoutService</c> builder and they will be automatically placed
+	/// into the ToggleDockingManager layout.</para>
 	/// </remarks>
 	[DataContract]
 	public abstract class ToolboxBase : DockableBase, IToolbox


### PR DESCRIPTION
Replace separate AddToolbox, AddToggleDockOptions, and AddDockLayoutService calls with a single AddDockLayoutService(Action<DockLayoutBuilder>) entry point. The DockLayoutBuilder exposes ConfigureToggleDock and AddToolbox methods, making the API self-documenting and grouping related registrations.