### PR TITLE
Add keyboard shortcut support for toggling toolboxes

### DIFF
--- a/source/AutomationTest/AvalonDockTest/FlaUI/ToggleDockShortcutTests.cs
+++ b/source/AutomationTest/AvalonDockTest/FlaUI/ToggleDockShortcutTests.cs
@@ -1,0 +1,107 @@
+using System;
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Definitions;
+using FlaUI.Core.Input;
+using FlaUI.Core.Tools;
+using FlaUI.Core.WindowsAPI;
+using NUnit.Framework;
+
+namespace AvalonDockTest.FlaUITests
+{
+	/// <summary>
+	/// UI automation tests verifying that the keyboard shortcuts declared via
+	/// <see cref="AvalonDock.Core.IToolbox.Shortcut"/> toggle their toolbox, exactly
+	/// like clicking the corresponding sidebar button.
+	/// </summary>
+	[TestFixture]
+	[Category("FlaUI")]
+	[Category("ToggleDock")]
+	public class ToggleDockShortcutTests : ToggleDockFlaUITestBase
+	{
+		/// <summary>
+		/// Pressing the Explorer shortcut (Ctrl+Shift+E) docks it; pressing it again hides it.
+		/// </summary>
+		[Test]
+		public void Shortcut_TogglesExplorer_OnAndOff()
+		{
+			// Explorer starts auto-hidden (only Terminal is open by default).
+			Assert.That(
+				WaitForToggleState("Explorer", ToggleState.Off),
+				Is.True,
+				"Explorer should start unchecked.");
+
+			SendChord(VirtualKeyShort.KEY_E, VirtualKeyShort.CONTROL, VirtualKeyShort.SHIFT);
+			Assert.That(
+				WaitForToggleState("Explorer", ToggleState.On),
+				Is.True,
+				"Explorer should be docked after pressing Ctrl+Shift+E.");
+
+			SendChord(VirtualKeyShort.KEY_E, VirtualKeyShort.CONTROL, VirtualKeyShort.SHIFT);
+			Assert.That(
+				WaitForToggleState("Explorer", ToggleState.Off),
+				Is.True,
+				"Explorer should be hidden after pressing Ctrl+Shift+E a second time.");
+		}
+
+		/// <summary>
+		/// A shortcut only affects its own toolbox: toggling Search (Ctrl+Shift+F) does not
+		/// dock Explorer.
+		/// </summary>
+		[Test]
+		public void Shortcut_TogglesOnlyTargetToolbox()
+		{
+			Assert.That(WaitForToggleState("Search", ToggleState.Off), Is.True,
+				"Search should start unchecked.");
+
+			SendChord(VirtualKeyShort.KEY_F, VirtualKeyShort.CONTROL, VirtualKeyShort.SHIFT);
+
+			Assert.That(WaitForToggleState("Search", ToggleState.On), Is.True,
+				"Search should be docked after pressing Ctrl+Shift+F.");
+			Assert.That(GetToggleState(FindToggleButton("Explorer")), Is.EqualTo(ToggleState.Off),
+				"Explorer should remain hidden when only the Search shortcut is pressed.");
+
+			// Clean up: hide Search again.
+			SendChord(VirtualKeyShort.KEY_F, VirtualKeyShort.CONTROL, VirtualKeyShort.SHIFT);
+			WaitForToggleState("Search", ToggleState.Off);
+		}
+
+		/// <summary>
+		/// Sends a keyboard chord (modifiers held while the main key is typed).
+		/// </summary>
+		/// <param name="key">The main key.</param>
+		/// <param name="modifiers">The modifier keys held down.</param>
+		private void SendChord(VirtualKeyShort key, params VirtualKeyShort[] modifiers)
+		{
+			MainWindow.SetForeground();
+			Wait.UntilInputIsProcessed();
+
+			foreach (var modifier in modifiers)
+			{
+				Keyboard.Press(modifier);
+			}
+
+			Keyboard.Type(key);
+
+			for (int i = modifiers.Length - 1; i >= 0; i--)
+			{
+				Keyboard.Release(modifiers[i]);
+			}
+
+			Wait.UntilInputIsProcessed();
+		}
+
+		/// <summary>
+		/// Polls the toggle state of a sidebar button until it reaches the expected state.
+		/// </summary>
+		/// <param name="name">The toolbox/button name.</param>
+		/// <param name="expected">The expected toggle state.</param>
+		/// <returns><c>true</c> if the state was reached within the timeout.</returns>
+		private bool WaitForToggleState(string name, ToggleState expected)
+		{
+			return Retry.WhileFalse(
+				() => GetToggleState(FindToggleButton(name)) == expected,
+				timeout: TimeSpan.FromSeconds(5),
+				interval: TimeSpan.FromMilliseconds(250)).Result;
+		}
+	}
+}

--- a/source/AutomationTest/AvalonDockTest/ShortcutTests.cs
+++ b/source/AutomationTest/AvalonDockTest/ShortcutTests.cs
@@ -1,0 +1,97 @@
+using System.ComponentModel;
+using AvalonDock.Core;
+using AvalonDock.Mvvm;
+using AvalonDock.Mvvm.CommunityToolkit;
+using NUnit.Framework;
+
+namespace AvalonDockTest
+{
+	/// <summary>
+	/// Unit tests for the <see cref="IToolbox.Shortcut"/> MVVM contract and its
+	/// implementations on the supplied toolbox base classes.
+	/// </summary>
+	[TestFixture]
+	public class ShortcutTests
+	{
+		private sealed class TestToolbox : ToolboxBase
+		{
+			public TestToolbox()
+			{
+				Id = "test";
+				Title = "Test";
+			}
+		}
+
+		private sealed class TestObservableToolbox : ObservableToolboxBase
+		{
+			public TestObservableToolbox()
+			{
+				Id = "test-observable";
+				Title = "Test Observable";
+			}
+		}
+
+		[Test]
+		public void IToolbox_HasShortcutProperty()
+		{
+			var prop = typeof(IToolbox).GetProperty(nameof(IToolbox.Shortcut));
+			Assert.That(prop, Is.Not.Null);
+			Assert.That(prop!.PropertyType, Is.EqualTo(typeof(string)));
+			Assert.That(prop.GetMethod, Is.Not.Null);
+			Assert.That(prop.SetMethod, Is.Not.Null);
+		}
+
+		[Test]
+		public void Shortcut_DefaultsToNull()
+		{
+			Assert.That(new TestToolbox().Shortcut, Is.Null);
+			Assert.That(new TestObservableToolbox().Shortcut, Is.Null);
+		}
+
+		[Test]
+		public void ToolboxBase_Shortcut_RoundTrips()
+		{
+			var toolbox = new TestToolbox { Shortcut = "Ctrl+Shift+E" };
+			Assert.That(toolbox.Shortcut, Is.EqualTo("Ctrl+Shift+E"));
+		}
+
+		[Test]
+		public void ObservableToolboxBase_Shortcut_RoundTrips()
+		{
+			var toolbox = new TestObservableToolbox { Shortcut = "Ctrl+OemTilde" };
+			Assert.That(toolbox.Shortcut, Is.EqualTo("Ctrl+OemTilde"));
+		}
+
+		[Test]
+		public void ToolboxBase_Shortcut_RaisesPropertyChanged()
+		{
+			var toolbox = new TestToolbox();
+			string changed = null;
+			((INotifyPropertyChanged)toolbox).PropertyChanged += (_, e) => changed = e.PropertyName;
+
+			toolbox.Shortcut = "Ctrl+Shift+F";
+
+			Assert.That(changed, Is.EqualTo(nameof(IToolbox.Shortcut)));
+		}
+
+		[Test]
+		public void ObservableToolboxBase_Shortcut_RaisesPropertyChanged()
+		{
+			var toolbox = new TestObservableToolbox();
+			string changed = null;
+			((INotifyPropertyChanged)toolbox).PropertyChanged += (_, e) => changed = e.PropertyName;
+
+			toolbox.Shortcut = "Ctrl+Shift+F";
+
+			Assert.That(changed, Is.EqualTo(nameof(IToolbox.Shortcut)));
+		}
+
+		[Test]
+		public void Shortcut_AssignableThroughInterface()
+		{
+			IToolbox toolbox = new TestToolbox();
+			toolbox.Shortcut = "Ctrl+Shift+G";
+			Assert.That(toolbox.Shortcut, Is.EqualTo("Ctrl+Shift+G"));
+		}
+	}
+}

--- a/source/AvalonDockCodeApp/ViewModels/FolderExplorerViewModel.cs
+++ b/source/AvalonDockCodeApp/ViewModels/FolderExplorerViewModel.cs
@@ -75,6 +75,7 @@ public partial class FolderExplorerViewModel : ObservableToolboxBase
 		Id = "Explorer";
 		Title = "Explorer";
 		ToolTipText = "Explorer (Ctrl+Shift+E)";
+		Shortcut = "Ctrl+Shift+E";
 		Zone = DockZone.LeftTop;
 		Icon = ToolboxIcons.Explorer;
 	}

--- a/source/AvalonDockCodeApp/ViewModels/ProblemsViewModel.cs
+++ b/source/AvalonDockCodeApp/ViewModels/ProblemsViewModel.cs
@@ -11,6 +11,7 @@ public partial class ProblemsViewModel : ObservableToolboxBase
 		Id = "Problems";
 		Title = "Problems";
 		ToolTipText = "Problems (Ctrl+Shift+M)";
+		Shortcut = "Ctrl+Shift+M";
 		Zone = DockZone.BottomLeft;
 		Icon = ToolboxIcons.Problems;
 	}

--- a/source/AvalonDockCodeApp/ViewModels/SearchViewModel.cs
+++ b/source/AvalonDockCodeApp/ViewModels/SearchViewModel.cs
@@ -44,6 +44,7 @@ public partial class SearchViewModel : ObservableToolboxBase
 		Id = "Search";
 		Title = "Search";
 		ToolTipText = "Search (Ctrl+Shift+F)";
+		Shortcut = "Ctrl+Shift+F";
 		Zone = DockZone.LeftTop;
 		Icon = ToolboxIcons.Search;
 		_dispatcher = Dispatcher.CurrentDispatcher;

--- a/source/AvalonDockCodeApp/ViewModels/SourceControlViewModel.cs
+++ b/source/AvalonDockCodeApp/ViewModels/SourceControlViewModel.cs
@@ -50,6 +50,7 @@ public partial class SourceControlViewModel : ObservableToolboxBase
 		Id = "Git";
 		Title = "Source Control";
 		ToolTipText = "Source Control (Ctrl+Shift+G)";
+		Shortcut = "Ctrl+Shift+G";
 		Zone = DockZone.LeftBottom;
 		Icon = ToolboxIcons.Git;
 		_dispatcher = Dispatcher.CurrentDispatcher;

--- a/source/AvalonDockCodeApp/ViewModels/TerminalViewModel.cs
+++ b/source/AvalonDockCodeApp/ViewModels/TerminalViewModel.cs
@@ -23,6 +23,7 @@ public partial class TerminalViewModel : ObservableToolboxBase, IDisposable
 		Id = "Terminal";
 		Title = "Terminal";
 		ToolTipText = "Terminal (Ctrl+`)";
+		Shortcut = "Ctrl+OemTilde";
 		Zone = DockZone.BottomRight;
 		IsOpenByDefault = true;
 		Icon = ToolboxIcons.Terminal;

--- a/source/Components/AvalonDock.Core/Interfaces/IToolbox.cs
+++ b/source/Components/AvalonDock.Core/Interfaces/IToolbox.cs
@@ -66,6 +66,14 @@ namespace AvalonDock.Core
 		/// <summary>Gets or sets the dock zone where this toolbox is placed.</summary>
 		DockZone Zone { get; set; }
 
+		/// <summary>
+		/// Gets or sets the keyboard shortcut that toggles this toolbox open/closed,
+		/// expressed as a WPF gesture string (e.g. <c>"Ctrl+Shift+E"</c>, <c>"Ctrl+OemTilde"</c>).
+		/// When <c>null</c> or empty no shortcut is registered. Pressing the shortcut has the
+		/// same effect as clicking the toolbox's sidebar toggle button.
+		/// </summary>
+		string? Shortcut { get; set; }
+
 		/// <summary>Gets or sets a value indicating whether this toolbox should be toggled open on startup.</summary>
 		bool IsOpenByDefault { get; set; }
 

--- a/source/Components/AvalonDock.Mvvm.CommunityToolkit/ObservableToolboxBase.cs
+++ b/source/Components/AvalonDock.Mvvm.CommunityToolkit/ObservableToolboxBase.cs
@@ -20,6 +20,7 @@ namespace AvalonDock.Mvvm.CommunityToolkit
 	{
 		private string? _toolTipText;
 		private DockZone _zone = DockZone.LeftTop;
+		private string? _shortcut;
 		private bool _isOpenByDefault;
 		private bool _isOpen;
 		private object? _icon;
@@ -38,6 +39,14 @@ namespace AvalonDock.Mvvm.CommunityToolkit
 		{
 			get => _zone;
 			set => SetProperty(ref _zone, value);
+		}
+
+		/// <inheritdoc/>
+		[DataMember(IsRequired = false, EmitDefaultValue = false)]
+		public string? Shortcut
+		{
+			get => _shortcut;
+			set => SetProperty(ref _shortcut, value);
 		}
 
 		/// <inheritdoc/>

--- a/source/Components/AvalonDock.Mvvm/ToolboxBase.cs
+++ b/source/Components/AvalonDock.Mvvm/ToolboxBase.cs
@@ -20,6 +20,7 @@ namespace AvalonDock.Mvvm
 	{
 		private string? _toolTipText;
 		private DockZone _zone = DockZone.LeftTop;
+		private string? _shortcut;
 		private bool _isOpenByDefault;
 		private bool _isOpen;
 		private object? _icon;
@@ -38,6 +39,14 @@ namespace AvalonDock.Mvvm
 		{
 			get => _zone;
 			set => SetProperty(ref _zone, value);
+		}
+
+		/// <inheritdoc/>
+		[DataMember(IsRequired = false, EmitDefaultValue = false)]
+		public string? Shortcut
+		{
+			get => _shortcut;
+			set => SetProperty(ref _shortcut, value);
 		}
 
 		/// <inheritdoc/>

--- a/source/Components/AvalonDock/ToggleDockingManager.cs
+++ b/source/Components/AvalonDock/ToggleDockingManager.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 using AvalonDock.Controls;
 using AvalonDock.Core;
@@ -93,6 +94,14 @@ public class ToggleDockingManager : DockingManager
 
 	private readonly Dictionary<IToolbox, LayoutAnchorable> _toolboxToAnchorable =
 		new Dictionary<IToolbox, LayoutAnchorable>();
+
+	/// <summary>
+	/// Key bindings registered on the host window for toolbox shortcuts.
+	/// Tracked so they can be removed and rebuilt when toolboxes change.
+	/// </summary>
+	private readonly List<KeyBinding> _shortcutBindings = new List<KeyBinding>();
+
+	private static readonly KeyGestureConverter _gestureConverter = new KeyGestureConverter();
 
 	private int _syncDepth;
 
@@ -476,6 +485,7 @@ public class ToggleDockingManager : DockingManager
 		ApplyToggleAnchorableStyle();
 		SetupToggleDockButtonBars();
 		OpenDefaultToolboxes();
+		RefreshShortcuts();
 		Dispatcher.BeginInvoke(
 			System.Windows.Threading.DispatcherPriority.Loaded,
 			new System.Action(UpdatePinButtonsToMinimize));
@@ -1603,6 +1613,8 @@ public class ToggleDockingManager : DockingManager
 		{
 			npc.PropertyChanged += OnToolboxPropertyChanged;
 		}
+
+		RefreshShortcuts();
 	}
 
 	/// <summary>
@@ -1617,6 +1629,8 @@ public class ToggleDockingManager : DockingManager
 		{
 			npc.PropertyChanged -= OnToolboxPropertyChanged;
 		}
+
+		RefreshShortcuts();
 	}
 
 	private void OnToolboxPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -1680,6 +1694,103 @@ public class ToggleDockingManager : DockingManager
 		finally
 		{
 			_syncDepth--;
+		}
+	}
+
+	/// <summary>
+	/// Rebuilds the keyboard shortcut <see cref="KeyBinding"/>s on the host window from the
+	/// <see cref="IToolbox.Shortcut"/> of every registered toolbox. Existing bindings created by
+	/// this manager are removed first so the method is safe to call repeatedly. A no-op until the
+	/// manager is hosted in a <see cref="Window"/>.
+	/// </summary>
+	private void RefreshShortcuts()
+	{
+		var window = Window.GetWindow(this);
+		if (window == null)
+		{
+			return;
+		}
+
+		foreach (var binding in _shortcutBindings)
+		{
+			window.InputBindings.Remove(binding);
+		}
+
+		_shortcutBindings.Clear();
+
+		foreach (var pair in _toolboxToAnchorable)
+		{
+			var gesture = TryParseGesture(pair.Key.Shortcut);
+			if (gesture == null)
+			{
+				continue;
+			}
+
+			var binding = new KeyBinding(new ToggleToolboxCommand(this, pair.Key), gesture);
+			window.InputBindings.Add(binding);
+			_shortcutBindings.Add(binding);
+		}
+	}
+
+	/// <summary>
+	/// Parses a WPF gesture string (e.g. <c>"Ctrl+Shift+E"</c>) into a <see cref="KeyGesture"/>.
+	/// Returns <c>null</c> for null/empty/invalid input rather than throwing.
+	/// </summary>
+	/// <param name="text">The gesture string.</param>
+	/// <returns>The parsed gesture, or <c>null</c>.</returns>
+	private static KeyGesture TryParseGesture(string text)
+	{
+		if (string.IsNullOrWhiteSpace(text))
+		{
+			return null;
+		}
+
+		try
+		{
+			return _gestureConverter.ConvertFromInvariantString(text) as KeyGesture;
+		}
+		catch (NotSupportedException)
+		{
+			return null;
+		}
+		catch (FormatException)
+		{
+			return null;
+		}
+	}
+
+	/// <summary>
+	/// Toggles the docked/auto-hidden state of a toolbox's anchorable, mirroring a click on its
+	/// sidebar button. Used as the command target for keyboard shortcut <see cref="KeyBinding"/>s.
+	/// </summary>
+	private sealed class ToggleToolboxCommand : ICommand
+	{
+		private readonly ToggleDockingManager _manager;
+		private readonly IToolbox _toolbox;
+
+		public ToggleToolboxCommand(ToggleDockingManager manager, IToolbox toolbox)
+		{
+			_manager = manager;
+			_toolbox = toolbox;
+		}
+
+		event EventHandler ICommand.CanExecuteChanged
+		{
+			add { }
+			remove { }
+		}
+
+		public bool CanExecute(object parameter) => true;
+
+		public void Execute(object parameter)
+		{
+			if (!_manager._toolboxToAnchorable.TryGetValue(_toolbox, out var anchorable))
+			{
+				return;
+			}
+
+			var zone = _manager.GetAnchorableZone(anchorable);
+			_manager.ToggleAnchorable(anchorable, zone);
 		}
 	}
 


### PR DESCRIPTION
Toolboxes can now declare a keyboard shortcut via the new IToolbox.Shortcut MVVM property (a WPF gesture string, e.g. "Ctrl+Shift+E"). ToggleDockingManager registers these as KeyBindings on the host window and toggles the matching anchorable when pressed, mirroring a click on the sidebar button.

- IToolbox: add Shortcut property; implement on ToolboxBase and ObservableToolboxBase
- ToggleDockingManager: parse gestures and (de)register KeyBindings on register/unregister and load
- AvalonDockCodeApp: wire shortcuts on the demo toolboxes
- Tests: unit tests for the Shortcut contract/MVVM behavior and FlaUI end-to-end tests that press the shortcuts