### PR TITLE
Add VS2026 JSON theme support to AvalonDock.Themes.VS (#4)

### DIFF
--- a/docs/themes/vs.md
+++ b/docs/themes/vs.md
@@ -20,6 +20,19 @@ dotnet add package Dirkster.AvalonDock.Themes.VS
 
 ## Built-in Variants
 
+### VS2026
+
+Visual Studio 2026 replaced the XML `.vstheme` format with a JSON-based override
+format (see [Make Visual Studio look the way you want](https://devblogs.microsoft.com/visualstudio/make-visual-studio-look-the-way-you-want/)).
+The built-in VS2026 variants apply the Fluent accent and the new tokens that color
+the window/tool headers and tab strips independently from the rest of the shell:
+
+```csharp
+dockManager.Theme = new VS2026DarkTheme();
+dockManager.Theme = new VS2026LightTheme();
+dockManager.Theme = new VS2026BlueTheme();
+```
+
 ### VS2022
 
 ```csharp
@@ -72,6 +85,39 @@ var palette = VsThemeParser.ParseFile("custom.vstheme");
 dockManager.Theme = new VsTheme(palette);
 ```
 
+## Loading Custom VS2026 JSON Files
+
+VS2026 stores theme customizations as JSON. The files are *override only* — they
+list only the color tokens that were changed — and are shared by dropping them into
+`%LOCALAPPDATA%\Microsoft\VisualStudio\18.0_xxxxxxxx\ColorThemes`, where the file
+name matches the theme being overridden (e.g. `dark.json` overrides Dark).
+
+A VS2026 JSON file is a flat array of `{ "Name", "Category", "Background" }` entries
+with 8-digit `AARRGGBB` color values:
+
+```json
+[
+  { "Name": "EnvironmentHeader", "Category": "5af241b7-...", "Background": "FFF5CC84" },
+  { "Name": "EnvironmentTab",    "Category": "5af241b7-...", "Background": "FFF5CC84" },
+  { "Name": "EnvironmentBackground", "Category": "5af241b7-...", "Background": "FFCCD5F0" }
+]
+```
+
+Use `VsTheme.FromJson` to load one. Because the file is override-only, pass a base
+palette to layer the overrides on top of a full theme:
+
+```csharp
+// Use a built-in VS theme palette as the base, then apply the JSON overrides.
+using var baseStream = File.OpenRead("vs2022dark.vstheme");
+var basePalette = VsThemeParser.Parse(baseStream);
+
+dockManager.Theme = VsTheme.FromJson("cool-breeze.json", basePalette);
+```
+
+If no base palette is supplied, only the tokens present in the JSON are used and all
+other colors fall back to the resource builder's defaults. The JSON can also be loaded
+from a stream via `VsTheme.FromJson(Stream, ...)`.
+
 ## XAML Markup Extension
 
 ```xml
@@ -89,6 +135,17 @@ The `Path` can be absolute or relative to the application directory.
 | `VsThemeParser.Parse(Stream)` | Parse from a stream (auto-detects gzip) |
 | `VsThemeParser.ParseFile(string)` | Parse from a file path |
 | `VsThemeParser.ParseGZip(byte[])` | Parse from gzip-compressed bytes |
+
+`VsJsonThemeParser` extracts the same `VsThemeColorPalette` from VS2026 JSON files:
+
+| Method | Description |
+|:-------|:------------|
+| `VsJsonThemeParser.Parse(string)` | Parse from a JSON string |
+| `VsJsonThemeParser.Parse(Stream)` | Parse from a stream |
+| `VsJsonThemeParser.ParseFile(string)` | Parse from a file path |
+
+Because VS2026 JSON files are override-only, combine them with a base palette using
+`basePalette.Merge(overridePalette)` before building a theme.
 
 The returned `VsThemeColorPalette` provides lookup methods:
 

--- a/source/AutomationTest/AvalonDockTest/VsJsonThemeParserTests.cs
+++ b/source/AutomationTest/AvalonDockTest/VsJsonThemeParserTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.Windows.Media;
+using AvalonDock.Themes.VS;
+using NUnit.Framework;
+
+namespace AvalonDockTest
+{
+	[TestFixture]
+	public class VsJsonThemeParserTests
+	{
+		// The override sample from the VS blog "Make Visual Studio look the way you want".
+		private const string CoolBreezeJson = @"[
+  { ""Name"": ""EnvironmentHeader"", ""Category"": ""5af241b7-5627-4d12-bfb1-2b67d11127d7"", ""Background"": ""FFF5CC84"" },
+  { ""Name"": ""EnvironmentTab"", ""Category"": ""5af241b7-5627-4d12-bfb1-2b67d11127d7"", ""Background"": ""FFF5CC84"" },
+  { ""Name"": ""EnvironmentBody"", ""Category"": ""5af241b7-5627-4d12-bfb1-2b67d11127d7"", ""Background"": ""FF5D6B99"" },
+  { ""Name"": ""EnvironmentBodyText"", ""Category"": ""5af241b7-5627-4d12-bfb1-2b67d11127d7"", ""Background"": ""E4FFFFFF"" },
+  { ""Name"": ""EnvironmentBackground"", ""Category"": ""5af241b7-5627-4d12-bfb1-2b67d11127d7"", ""Background"": ""FFCCD5F0"" },
+  { ""Name"": ""StatusBarBackgroundFillRest"", ""Category"": ""5af241b7-5627-4d12-bfb1-2b67d11127d7"", ""Background"": ""FF40508D"" }
+]";
+
+		[Test]
+		public void Parse_ReadsBackgroundColors()
+		{
+			var palette = VsJsonThemeParser.Parse(CoolBreezeJson);
+
+			Assert.That(palette.GetBackground("EnvironmentHeader"), Is.EqualTo(Color.FromArgb(0xFF, 0xF5, 0xCC, 0x84)));
+			Assert.That(palette.GetBackground("EnvironmentBackground"), Is.EqualTo(Color.FromArgb(0xFF, 0xCC, 0xD5, 0xF0)));
+		}
+
+		[Test]
+		public void Parse_HonorsAlphaChannel()
+		{
+			var palette = VsJsonThemeParser.Parse(CoolBreezeJson);
+
+			Assert.That(palette.GetBackground("EnvironmentBodyText"), Is.EqualTo(Color.FromArgb(0xE4, 0xFF, 0xFF, 0xFF)));
+		}
+
+		[Test]
+		public void Parse_MissingTokenReturnsNull()
+		{
+			var palette = VsJsonThemeParser.Parse(CoolBreezeJson);
+
+			Assert.That(palette.GetBackground("NonExistent"), Is.Null);
+		}
+
+		[Test]
+		public void Parse_EntryWithoutBackgroundHasNullBackground()
+		{
+			var palette = VsJsonThemeParser.Parse(@"[ { ""Name"": ""Foo"", ""Category"": ""x"" } ]");
+
+			Assert.That(palette.Contains("Foo"), Is.True);
+			Assert.That(palette.GetBackground("Foo"), Is.Null);
+		}
+
+		[Test]
+		public void Parse_IsCaseInsensitiveOnPropertyNames()
+		{
+			var palette = VsJsonThemeParser.Parse(@"[ { ""name"": ""Foo"", ""background"": ""FF112233"" } ]");
+
+			Assert.That(palette.GetBackground("Foo"), Is.EqualTo(Color.FromArgb(0xFF, 0x11, 0x22, 0x33)));
+		}
+
+		[Test]
+		public void Merge_OverridesReplaceBaseEntries()
+		{
+			var basePalette = MakePalette(
+				("EnvironmentBackground", Color.FromArgb(0xFF, 0x1E, 0x1E, 0x1E)),
+				("FileTabSelectedBorder", Color.FromArgb(0xFF, 0x00, 0x7A, 0xCC)));
+
+			var overrides = VsJsonThemeParser.Parse(CoolBreezeJson);
+			var merged = basePalette.Merge(overrides);
+
+			// Overridden token takes the new value.
+			Assert.That(merged.GetBackground("EnvironmentBackground"), Is.EqualTo(Color.FromArgb(0xFF, 0xCC, 0xD5, 0xF0)));
+			// Untouched base token is preserved.
+			Assert.That(merged.GetBackground("FileTabSelectedBorder"), Is.EqualTo(Color.FromArgb(0xFF, 0x00, 0x7A, 0xCC)));
+			// New token introduced by the override is added.
+			Assert.That(merged.GetBackground("EnvironmentHeader"), Is.EqualTo(Color.FromArgb(0xFF, 0xF5, 0xCC, 0x84)));
+		}
+
+		[Test]
+		public void Merge_PreservesBaseForegroundWhenOverrideOnlySetsBackground()
+		{
+			var baseColors = new Dictionary<string, VsThemeColorEntry>
+			{
+				["TitleBarActiveText"] = new VsThemeColorEntry(
+					Color.FromArgb(0xFF, 0x00, 0x00, 0x00),
+					Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF)),
+			};
+			var basePalette = new VsThemeColorPalette(baseColors);
+
+			var overrides = VsJsonThemeParser.Parse(@"[ { ""Name"": ""TitleBarActiveText"", ""Background"": ""FF112233"" } ]");
+			var merged = basePalette.Merge(overrides);
+
+			Assert.That(merged.GetBackground("TitleBarActiveText"), Is.EqualTo(Color.FromArgb(0xFF, 0x11, 0x22, 0x33)));
+			Assert.That(merged.GetForeground("TitleBarActiveText"), Is.EqualTo(Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF)));
+		}
+
+		[Test]
+		public void Merge_DoesNotModifyInputs()
+		{
+			var basePalette = MakePalette(("EnvironmentBackground", Color.FromArgb(0xFF, 0x1E, 0x1E, 0x1E)));
+			var overrides = MakePalette(("EnvironmentBackground", Color.FromArgb(0xFF, 0xCC, 0xD5, 0xF0)));
+
+			basePalette.Merge(overrides);
+
+			Assert.That(basePalette.GetBackground("EnvironmentBackground"), Is.EqualTo(Color.FromArgb(0xFF, 0x1E, 0x1E, 0x1E)));
+			Assert.That(basePalette.Count, Is.EqualTo(1));
+		}
+
+		private static VsThemeColorPalette MakePalette(params (string Name, Color Background)[] entries)
+		{
+			var colors = new Dictionary<string, VsThemeColorEntry>();
+			foreach (var (name, background) in entries)
+			{
+				colors[name] = new VsThemeColorEntry(background, null);
+			}
+
+			return new VsThemeColorPalette(colors);
+		}
+	}
+}

--- a/source/Components/AvalonDock.Themes.VS/AvalonDock.Themes.VS.csproj
+++ b/source/Components/AvalonDock.Themes.VS/AvalonDock.Themes.VS.csproj
@@ -15,6 +15,12 @@
 
 	<ItemGroup>
 		<EmbeddedResource Include="Resources\*.vstheme" />
+		<EmbeddedResource Include="Resources\*.json" />
+	</ItemGroup>
+
+	<!-- System.Text.Json ships in the shared framework on net9/net10; only net48 needs the package. -->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+		<PackageReference Include="System.Text.Json" Version="9.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/source/Components/AvalonDock.Themes.VS/Resources/vs2026blue.json
+++ b/source/Components/AvalonDock.Themes.VS/Resources/vs2026blue.json
@@ -1,0 +1,7 @@
+[
+  { "Name": "FileTabSelectedBorder", "Category": "5af241b7-5627-4d12-bfb1-2b67d11127d7", "Background": "FF007ACC" },
+  { "Name": "EnvironmentHeader", "Category": "5af241b7-5627-4d12-bfb1-2b67d11127d7", "Background": "FFCEDDF7" },
+  { "Name": "EnvironmentHeaderInactive", "Category": "5af241b7-5627-4d12-bfb1-2b67d11127d7", "Background": "FFE6EDF7" },
+  { "Name": "EnvironmentTab", "Category": "5af241b7-5627-4d12-bfb1-2b67d11127d7", "Background": "FFDCE6F7" },
+  { "Name": "EnvironmentTabInactive", "Category": "5af241b7-5627-4d12-bfb1-2b67d11127d7", "Background": "FFCEDDF7" }
+]

--- a/source/Components/AvalonDock.Themes.VS/Resources/vs2026dark.json
+++ b/source/Components/AvalonDock.Themes.VS/Resources/vs2026dark.json
@@ -1,0 +1,7 @@
+[
+  { "Name": "FileTabSelectedBorder", "Category": "5af241b7-5627-4d12-bfb1-2b67d11127d7", "Background": "FF0E639C" },
+  { "Name": "EnvironmentHeader", "Category": "5af241b7-5627-4d12-bfb1-2b67d11127d7", "Background": "FF2D2D30" },
+  { "Name": "EnvironmentHeaderInactive", "Category": "5af241b7-5627-4d12-bfb1-2b67d11127d7", "Background": "FF252526" },
+  { "Name": "EnvironmentTab", "Category": "5af241b7-5627-4d12-bfb1-2b67d11127d7", "Background": "FF252526" },
+  { "Name": "EnvironmentTabInactive", "Category": "5af241b7-5627-4d12-bfb1-2b67d11127d7", "Background": "FF2D2D30" }
+]

--- a/source/Components/AvalonDock.Themes.VS/Resources/vs2026light.json
+++ b/source/Components/AvalonDock.Themes.VS/Resources/vs2026light.json
@@ -1,0 +1,7 @@
+[
+  { "Name": "FileTabSelectedBorder", "Category": "5af241b7-5627-4d12-bfb1-2b67d11127d7", "Background": "FF0078D4" },
+  { "Name": "EnvironmentHeader", "Category": "5af241b7-5627-4d12-bfb1-2b67d11127d7", "Background": "FFEAEAEC" },
+  { "Name": "EnvironmentHeaderInactive", "Category": "5af241b7-5627-4d12-bfb1-2b67d11127d7", "Background": "FFF5F5F5" },
+  { "Name": "EnvironmentTab", "Category": "5af241b7-5627-4d12-bfb1-2b67d11127d7", "Background": "FFF0F0F0" },
+  { "Name": "EnvironmentTabInactive", "Category": "5af241b7-5627-4d12-bfb1-2b67d11127d7", "Background": "FFEAEAEC" }
+]

--- a/source/Components/AvalonDock.Themes.VS/VS2026BlueTheme.cs
+++ b/source/Components/AvalonDock.Themes.VS/VS2026BlueTheme.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace AvalonDock.Themes.VS
+{
+	/// <summary>
+	/// VS2026 Blue theme. Built from the VS2022 Blue base palette with a VS2026 JSON
+	/// override that applies the Fluent accent and the new independent header/tab colors.
+	/// </summary>
+	public class VS2026BlueTheme : VsTheme
+	{
+		private static readonly Uri VS2026GenericXamlUri =
+			new Uri("/AvalonDock.Themes.VS;component/Themes/VS2022/Generic.xaml", UriKind.Relative);
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="VS2026BlueTheme"/> class.
+		/// </summary>
+		public VS2026BlueTheme()
+			: base(Vs2026ThemeFactory.Build(
+				"AvalonDock.Themes.Resources.vs2022blue.vstheme",
+				"AvalonDock.Themes.Resources.vs2026blue.json",
+				VS2026GenericXamlUri))
+		{
+		}
+	}
+}

--- a/source/Components/AvalonDock.Themes.VS/VS2026DarkTheme.cs
+++ b/source/Components/AvalonDock.Themes.VS/VS2026DarkTheme.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace AvalonDock.Themes.VS
+{
+	/// <summary>
+	/// VS2026 Dark theme. Built from the VS2022 Dark base palette with a VS2026 JSON
+	/// override that applies the Fluent accent and the new independent header/tab colors.
+	/// </summary>
+	public class VS2026DarkTheme : VsTheme
+	{
+		private static readonly Uri VS2026GenericXamlUri =
+			new Uri("/AvalonDock.Themes.VS;component/Themes/VS2022/Generic.xaml", UriKind.Relative);
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="VS2026DarkTheme"/> class.
+		/// </summary>
+		public VS2026DarkTheme()
+			: base(Vs2026ThemeFactory.Build(
+				"AvalonDock.Themes.Resources.vs2022dark.vstheme",
+				"AvalonDock.Themes.Resources.vs2026dark.json",
+				VS2026GenericXamlUri))
+		{
+		}
+	}
+}

--- a/source/Components/AvalonDock.Themes.VS/VS2026LightTheme.cs
+++ b/source/Components/AvalonDock.Themes.VS/VS2026LightTheme.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace AvalonDock.Themes.VS
+{
+	/// <summary>
+	/// VS2026 Light theme. Built from the VS2022 Light base palette with a VS2026 JSON
+	/// override that applies the Fluent accent and the new independent header/tab colors.
+	/// </summary>
+	public class VS2026LightTheme : VsTheme
+	{
+		private static readonly Uri VS2026GenericXamlUri =
+			new Uri("/AvalonDock.Themes.VS;component/Themes/VS2022/Generic.xaml", UriKind.Relative);
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="VS2026LightTheme"/> class.
+		/// </summary>
+		public VS2026LightTheme()
+			: base(Vs2026ThemeFactory.Build(
+				"AvalonDock.Themes.Resources.vs2022light.vstheme",
+				"AvalonDock.Themes.Resources.vs2026light.json",
+				VS2026GenericXamlUri))
+		{
+		}
+	}
+}

--- a/source/Components/AvalonDock.Themes.VS/Vs2026ThemeFactory.cs
+++ b/source/Components/AvalonDock.Themes.VS/Vs2026ThemeFactory.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Windows;
+
+namespace AvalonDock.Themes.VS
+{
+	/// <summary>
+	/// Builds the resource dictionary for a bundled VS2026 theme by layering an embedded
+	/// VS2026 JSON override file on top of a full VS2022 base palette.
+	/// </summary>
+	/// <remarks>
+	/// VS2026 ships themes as JSON override files that only contain the tokens that differ
+	/// from a base theme. Until full VS2026 palette dumps are available, the bundled VS2026
+	/// themes reuse the existing VS2022 <c>.vstheme</c> palettes as their base and apply a
+	/// small VS2026 override (Fluent accent plus the new independent header/tab tokens).
+	/// </remarks>
+	internal static class Vs2026ThemeFactory
+	{
+		/// <summary>
+		/// Builds a resource dictionary by merging a base VS theme palette with a VS2026 JSON override.
+		/// </summary>
+		/// <param name="baseVsThemeResource">The embedded resource name of the base VS theme file (e.g., VS2022 .vstheme).</param>
+		/// <param name="jsonOverrideResource">The embedded resource name of the VS2026 JSON override file containing token overrides.</param>
+		/// <param name="genericXamlUri">The URI to the generic XAML resource dictionary for theme styling.</param>
+		/// <returns>A <see cref="ResourceDictionary"/> containing the merged theme colors and styles.</returns>
+		/// <exception cref="InvalidOperationException">Thrown if either the base or override resource cannot be found.</exception>
+		public static ResourceDictionary Build(string baseVsThemeResource, string jsonOverrideResource, Uri genericXamlUri)
+		{
+			VsThemeColorPalette basePalette;
+			using (var baseStream = OpenResource(baseVsThemeResource))
+			{
+				basePalette = VsThemeParser.Parse(baseStream);
+			}
+
+			VsThemeColorPalette overrides;
+			using (var jsonStream = OpenResource(jsonOverrideResource))
+			{
+				overrides = VsJsonThemeParser.Parse(jsonStream);
+			}
+
+			var merged = basePalette.Merge(overrides);
+			return VsThemeResourceBuilder.Build(merged, genericXamlUri);
+		}
+
+		/// <summary>
+		/// Opens an embedded manifest resource stream from the current assembly.
+		/// </summary>
+		/// <param name="name">The fully qualified name of the embedded resource.</param>
+		/// <returns>A <see cref="Stream"/> containing the resource data.</returns>
+		/// <exception cref="InvalidOperationException">Thrown if the resource with the specified name does not exist.</exception>
+		private static Stream OpenResource(string name)
+		{
+			var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(name);
+			if (stream == null)
+			{
+				throw new InvalidOperationException($"Embedded resource '{name}' was not found.");
+			}
+
+			return stream;
+		}
+	}
+}

--- a/source/Components/AvalonDock.Themes.VS/VsColorParser.cs
+++ b/source/Components/AvalonDock.Themes.VS/VsColorParser.cs
@@ -1,0 +1,37 @@
+using System.Globalization;
+using System.Windows.Media;
+
+namespace AvalonDock.Themes.VS
+{
+	/// <summary>
+	/// Helper for converting Visual Studio theme color strings into WPF colors.
+	/// Visual Studio stores colors as 8-digit AARRGGBB hexadecimal values in both
+	/// the XML <c>.vstheme</c> format (<c>Source</c> attribute) and the VS2026
+	/// JSON override format (<c>Background</c>/<c>Foreground</c> values).
+	/// </summary>
+	internal static class VsColorParser
+	{
+		/// <summary>
+		/// Parses an 8-digit AARRGGBB hexadecimal color string.
+		/// </summary>
+		/// <param name="argb">The color string (for example, <c>FF1E1E1E</c>).</param>
+		/// <returns>The parsed color, or <c>null</c> if the value is not a valid 8-digit AARRGGBB string.</returns>
+		public static Color? FromArgbHex(string argb)
+		{
+			if (string.IsNullOrEmpty(argb) || argb.Length != 8)
+			{
+				return null;
+			}
+
+			if (!byte.TryParse(argb.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var a) ||
+				!byte.TryParse(argb.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var r) ||
+				!byte.TryParse(argb.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var g) ||
+				!byte.TryParse(argb.Substring(6, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var b))
+			{
+				return null;
+			}
+
+			return Color.FromArgb(a, r, g, b);
+		}
+	}
+}

--- a/source/Components/AvalonDock.Themes.VS/VsJsonThemeParser.cs
+++ b/source/Components/AvalonDock.Themes.VS/VsJsonThemeParser.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AvalonDock.Themes.VS
+{
+	/// <summary>
+	/// Parses Visual Studio 2026 JSON theme files and extracts color definitions.
+	/// </summary>
+	/// <remarks>
+	/// Visual Studio 2026 replaced the XML <c>.vstheme</c> format with a JSON based
+	/// override format. A file is a flat array of color entries, for example:
+	/// <code>
+	/// [
+	///   { "Name": "EnvironmentBackground", "Category": "5af241b7-...", "Background": "FFCCD5F0" },
+	///   { "Name": "EnvironmentHeader",     "Category": "5af241b7-...", "Background": "FFF5CC84" }
+	/// ]
+	/// </code>
+	/// Each entry carries the classic VS color token name, an (ignored) category GUID,
+	/// and an 8-digit AARRGGBB color value. Such files are <em>override only</em>: they
+	/// list only the tokens that were changed, so they are normally layered on top of a
+	/// base palette via <see cref="VsThemeColorPalette.Merge"/>.
+	/// </remarks>
+	public static class VsJsonThemeParser
+	{
+		private static readonly JsonSerializerOptions Options = new JsonSerializerOptions
+		{
+			PropertyNameCaseInsensitive = true,
+			ReadCommentHandling = JsonCommentHandling.Skip,
+			AllowTrailingCommas = true,
+		};
+
+		/// <summary>
+		/// Parses a VS2026 JSON theme from a string and returns the color palette.
+		/// </summary>
+		/// <param name="json">The JSON content.</param>
+		/// <returns>A palette mapping color token names to their resolved colors.</returns>
+		public static VsThemeColorPalette Parse(string json)
+		{
+			if (json == null)
+			{
+				throw new ArgumentNullException(nameof(json));
+			}
+
+			var entries = JsonSerializer.Deserialize<List<JsonColorEntry>>(json, Options);
+			return Build(entries);
+		}
+
+		/// <summary>
+		/// Parses a VS2026 JSON theme from a stream and returns the color palette.
+		/// </summary>
+		/// <param name="stream">The stream containing the JSON content.</param>
+		/// <returns>A palette mapping color token names to their resolved colors.</returns>
+		public static VsThemeColorPalette Parse(Stream stream)
+		{
+			if (stream == null)
+			{
+				throw new ArgumentNullException(nameof(stream));
+			}
+
+			using (var reader = new StreamReader(stream))
+			{
+				return Parse(reader.ReadToEnd());
+			}
+		}
+
+		/// <summary>
+		/// Parses a VS2026 JSON theme from a file path and returns the color palette.
+		/// </summary>
+		/// <param name="filePath">The path to the JSON theme file.</param>
+		/// <returns>A palette mapping color token names to their resolved colors.</returns>
+		public static VsThemeColorPalette ParseFile(string filePath)
+		{
+			if (string.IsNullOrEmpty(filePath))
+			{
+				throw new ArgumentNullException(nameof(filePath));
+			}
+
+			return Parse(File.ReadAllText(filePath));
+		}
+
+		private static VsThemeColorPalette Build(List<JsonColorEntry> entries)
+		{
+			var colors = new Dictionary<string, VsThemeColorEntry>();
+			if (entries == null)
+			{
+				return new VsThemeColorPalette(colors);
+			}
+
+			foreach (var entry in entries)
+			{
+				if (entry == null || string.IsNullOrEmpty(entry.Name))
+				{
+					continue;
+				}
+
+				var bg = VsColorParser.FromArgbHex(entry.Background);
+				var fg = VsColorParser.FromArgbHex(entry.Foreground);
+
+				// Last entry wins for a duplicated token name.
+				colors[entry.Name] = new VsThemeColorEntry(bg, fg);
+			}
+
+			return new VsThemeColorPalette(colors);
+		}
+
+		private sealed class JsonColorEntry
+		{
+			[JsonPropertyName("Name")]
+			public string Name { get; set; }
+
+			[JsonPropertyName("Category")]
+			public string Category { get; set; }
+
+			[JsonPropertyName("Background")]
+			public string Background { get; set; }
+
+			[JsonPropertyName("Foreground")]
+			public string Foreground { get; set; }
+		}
+	}
+}

--- a/source/Components/AvalonDock.Themes.VS/VsTheme.cs
+++ b/source/Components/AvalonDock.Themes.VS/VsTheme.cs
@@ -72,6 +72,56 @@ namespace AvalonDock.Themes.VS
 		{
 		}
 
+		/// <summary>
+		/// Creates a <see cref="VsTheme"/> from a Visual Studio 2026 JSON theme file.
+		/// </summary>
+		/// <remarks>
+		/// VS2026 JSON theme files are override only: they list just the color tokens that
+		/// were changed. Pass <paramref name="basePalette"/> (for example, the palette of a
+		/// built-in VS theme) to layer the overrides on top of a full base; if omitted, only
+		/// the tokens defined in the file are used and all other colors fall back to the
+		/// resource builder's defaults.
+		/// </remarks>
+		/// <param name="filePath">The path to the VS2026 JSON theme file.</param>
+		/// <param name="basePalette">An optional base palette to merge the overrides onto.</param>
+		/// <param name="genericXamlUri">An optional pack URI for the Generic.xaml control templates to merge.</param>
+		/// <returns>A theme built from the merged palette.</returns>
+		public static VsTheme FromJson(string filePath, VsThemeColorPalette basePalette = null, Uri genericXamlUri = null)
+		{
+			if (string.IsNullOrEmpty(filePath))
+			{
+				throw new ArgumentNullException(nameof(filePath));
+			}
+
+			return FromPalette(VsJsonThemeParser.ParseFile(filePath), basePalette, genericXamlUri);
+		}
+
+		/// <summary>
+		/// Creates a <see cref="VsTheme"/> from a Visual Studio 2026 JSON theme stream.
+		/// </summary>
+		/// <param name="jsonStream">The stream containing the VS2026 JSON theme content.</param>
+		/// <param name="basePalette">An optional base palette to merge the overrides onto.</param>
+		/// <param name="genericXamlUri">An optional pack URI for the Generic.xaml control templates to merge.</param>
+		/// <returns>A theme built from the merged palette.</returns>
+		public static VsTheme FromJson(Stream jsonStream, VsThemeColorPalette basePalette = null, Uri genericXamlUri = null)
+		{
+			if (jsonStream == null)
+			{
+				throw new ArgumentNullException(nameof(jsonStream));
+			}
+
+			return FromPalette(VsJsonThemeParser.Parse(jsonStream), basePalette, genericXamlUri);
+		}
+
+		private static VsTheme FromPalette(VsThemeColorPalette overrides, VsThemeColorPalette basePalette, Uri genericXamlUri)
+		{
+			var palette = basePalette != null ? basePalette.Merge(overrides) : overrides;
+			var dict = genericXamlUri != null
+				? VsThemeResourceBuilder.Build(palette, genericXamlUri)
+				: VsThemeResourceBuilder.Build(palette);
+			return new VsTheme(dict);
+		}
+
 		private static ResourceDictionary BuildFromStream(Stream stream)
 		{
 			if (stream == null)

--- a/source/Components/AvalonDock.Themes.VS/VsThemeColorPalette.cs
+++ b/source/Components/AvalonDock.Themes.VS/VsThemeColorPalette.cs
@@ -64,6 +64,43 @@ namespace AvalonDock.Themes.VS
 		}
 
 		/// <summary>
+		/// Creates a new palette by layering the given override entries on top of this one.
+		/// </summary>
+		/// <remarks>
+		/// This is used to apply a VS2026 JSON override file (which only contains the
+		/// tokens that were changed) on top of a full base palette. The merge is performed
+		/// per field: an override that only specifies a background keeps the base
+		/// foreground for that token, and vice versa. Tokens present only in
+		/// <paramref name="overrides"/> are added.
+		/// </remarks>
+		/// <param name="overrides">The palette whose entries take precedence.</param>
+		/// <returns>A new merged palette. Neither input palette is modified.</returns>
+		public VsThemeColorPalette Merge(VsThemeColorPalette overrides)
+		{
+			if (overrides == null)
+			{
+				throw new ArgumentNullException(nameof(overrides));
+			}
+
+			var merged = new Dictionary<string, VsThemeColorEntry>(_colors);
+			foreach (var kvp in overrides._colors)
+			{
+				if (merged.TryGetValue(kvp.Key, out var baseEntry))
+				{
+					merged[kvp.Key] = new VsThemeColorEntry(
+						kvp.Value.Background ?? baseEntry.Background,
+						kvp.Value.Foreground ?? baseEntry.Foreground);
+				}
+				else
+				{
+					merged[kvp.Key] = kvp.Value;
+				}
+			}
+
+			return new VsThemeColorPalette(merged);
+		}
+
+		/// <summary>
 		/// Gets the total number of color entries in the palette.
 		/// </summary>
 		public int Count => _colors.Count;

--- a/source/Components/AvalonDock.Themes.VS/VsThemeParser.cs
+++ b/source/Components/AvalonDock.Themes.VS/VsThemeParser.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -147,20 +146,7 @@ namespace AvalonDock.Themes.VS
 			}
 
 			var source = element.Attribute("Source")?.Value;
-			if (string.IsNullOrEmpty(source) || source.Length != 8)
-			{
-				return null;
-			}
-
-			if (!byte.TryParse(source.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var a) ||
-				!byte.TryParse(source.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var r) ||
-				!byte.TryParse(source.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var g) ||
-				!byte.TryParse(source.Substring(6, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var b))
-			{
-				return null;
-			}
-
-			return Color.FromArgb(a, r, g, b);
+			return VsColorParser.FromArgbHex(source);
 		}
 	}
 }

--- a/source/Components/AvalonDock.Themes.VS/VsThemeResourceBuilder.cs
+++ b/source/Components/AvalonDock.Themes.VS/VsThemeResourceBuilder.cs
@@ -57,6 +57,15 @@ namespace AvalonDock.Themes.VS
 			var dimText = palette.GetForegroundOrDefault("ToolWindowTabText", Color.FromRgb(0x8C, 0x8C, 0x8C));
 			var brightText = Colors.White;
 
+			// VS2026 introduced tokens that color the tab strip and window/tool headers
+			// independently from the rest of the shell chrome. When present they take
+			// precedence over the classic per-element tokens; otherwise the original
+			// fallbacks below are used, so existing XML themes are unaffected.
+			var environmentTab = palette.GetBackground("EnvironmentTab");
+			var environmentTabInactive = palette.GetBackground("EnvironmentTabInactive");
+			var environmentHeader = palette.GetBackground("EnvironmentHeader");
+			var environmentHeaderInactive = palette.GetBackground("EnvironmentHeaderInactive");
+
 			// Accent
 			dict[ResourceKeys.ControlAccentColorKey] = accent;
 			SetBrush(dict, ResourceKeys.ControlAccentBrushKey, accent);
@@ -64,7 +73,7 @@ namespace AvalonDock.Themes.VS
 			// General
 			SetBrush(dict, ResourceKeys.Background, background);
 			SetBrush(dict, ResourceKeys.PanelBorderBrush, panelBorder);
-			SetBrush(dict, ResourceKeys.TabBackground, tabBg);
+			SetBrush(dict, ResourceKeys.TabBackground, environmentTab ?? tabBg);
 
 			// Auto Hide : Tab
 			SetBrush(dict, ResourceKeys.AutoHideTabDefaultBackground, palette.GetBackgroundOrDefault("AutoHideTabBackgroundBegin", background));
@@ -86,9 +95,9 @@ namespace AvalonDock.Themes.VS
 			// Document Well : Tab
 			SetBrush(dict, ResourceKeys.DocumentWellTabSelectedActiveBackground, palette.GetBackgroundOrDefault("FileTabSelectedBorder", accent));
 			SetBrush(dict, ResourceKeys.DocumentWellTabSelectedActiveText, palette.GetBackgroundOrDefault("FileTabSelectedText", brightText));
-			SetBrush(dict, ResourceKeys.DocumentWellTabSelectedInactiveBackground, palette.GetBackgroundOrDefault("FileTabInactiveBorder", background));
+			SetBrush(dict, ResourceKeys.DocumentWellTabSelectedInactiveBackground, environmentTabInactive ?? palette.GetBackgroundOrDefault("FileTabInactiveBorder", background));
 			SetBrush(dict, ResourceKeys.DocumentWellTabSelectedInactiveText, palette.GetBackgroundOrDefault("FileTabInactiveText", inactiveText));
-			SetBrush(dict, ResourceKeys.DocumentWellTabUnselectedBackground, palette.GetBackgroundOrDefault("FileTabBackground", tabBg));
+			SetBrush(dict, ResourceKeys.DocumentWellTabUnselectedBackground, environmentTab ?? palette.GetBackgroundOrDefault("FileTabBackground", tabBg));
 			SetBrush(dict, ResourceKeys.DocumentWellTabUnselectedText, palette.GetBackgroundOrDefault("FileTabText", dimText));
 			SetBrush(dict, ResourceKeys.DocumentWellTabUnselectedHoveredBackground, palette.GetBackgroundOrDefault("FileTabHotBorder", panelBorder));
 			SetBrush(dict, ResourceKeys.DocumentWellTabUnselectedHoveredText, palette.GetBackgroundOrDefault("FileTabHotText", brightText));
@@ -105,10 +114,10 @@ namespace AvalonDock.Themes.VS
 			MapCloseButton(dict, palette, "FileTabButtonDownInactive", ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonPressedBackground, ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonPressedBorder, ResourceKeys.DocumentWellTabButtonUnselectedTabHoveredButtonPressedGlyph, accent);
 
 			// Tool Window : Caption
-			SetBrush(dict, ResourceKeys.ToolWindowCaptionActiveBackground, palette.GetBackgroundOrDefault("TitleBarActiveBorder", accent));
+			SetBrush(dict, ResourceKeys.ToolWindowCaptionActiveBackground, environmentHeader ?? palette.GetBackgroundOrDefault("TitleBarActiveBorder", accent));
 			SetBrush(dict, ResourceKeys.ToolWindowCaptionActiveGrip, palette.GetBackgroundOrDefault("TitleBarDragHandleActive", panelBorder));
 			SetBrush(dict, ResourceKeys.ToolWindowCaptionActiveText, palette.GetBackgroundOrDefault("TitleBarActiveText", brightText));
-			SetBrush(dict, ResourceKeys.ToolWindowCaptionInactiveBackground, palette.GetBackgroundOrDefault("TitleBarInactive", background));
+			SetBrush(dict, ResourceKeys.ToolWindowCaptionInactiveBackground, environmentHeaderInactive ?? palette.GetBackgroundOrDefault("TitleBarInactive", background));
 			SetBrush(dict, ResourceKeys.ToolWindowCaptionInactiveGrip, palette.GetBackgroundOrDefault("TitleBarDragHandle", background));
 			SetBrush(dict, ResourceKeys.ToolWindowCaptionInactiveText, palette.GetBackgroundOrDefault("TitleBarInactiveText", dimText));
 
@@ -131,9 +140,9 @@ namespace AvalonDock.Themes.VS
 			// Tool Window : Tab
 			SetBrush(dict, ResourceKeys.ToolWindowTabSelectedActiveBackground, palette.GetBackgroundOrDefault("ToolWindowTabSelectedTab", accent));
 			SetBrush(dict, ResourceKeys.ToolWindowTabSelectedActiveText, palette.GetBackgroundOrDefault("ToolWindowTabSelectedActiveText", brightText));
-			SetBrush(dict, ResourceKeys.ToolWindowTabSelectedInactiveBackground, palette.GetBackgroundOrDefault("ToolWindowTabSelectedTab", panelBorder));
+			SetBrush(dict, ResourceKeys.ToolWindowTabSelectedInactiveBackground, environmentTabInactive ?? palette.GetBackgroundOrDefault("ToolWindowTabSelectedTab", panelBorder));
 			SetBrush(dict, ResourceKeys.ToolWindowTabSelectedInactiveText, palette.GetBackgroundOrDefault("ToolWindowTabSelectedText", inactiveText));
-			SetBrush(dict, ResourceKeys.ToolWindowTabUnselectedBackground, palette.GetBackgroundOrDefault("ToolWindowTabGradientBegin", tabBg));
+			SetBrush(dict, ResourceKeys.ToolWindowTabUnselectedBackground, environmentTab ?? palette.GetBackgroundOrDefault("ToolWindowTabGradientBegin", tabBg));
 			SetBrush(dict, ResourceKeys.ToolWindowTabUnselectedText, palette.GetBackgroundOrDefault("ToolWindowTabText", dimText));
 			SetBrush(dict, ResourceKeys.ToolWindowTabUnselectedHoveredBackground, palette.GetBackgroundOrDefault("ToolWindowTabMouseOverBackgroundBegin", panelBorder));
 			SetBrush(dict, ResourceKeys.ToolWindowTabUnselectedHoveredText, palette.GetBackgroundOrDefault("ToolWindowTabMouseOverText", brightText));

--- a/source/TestApp/MainWindow.xaml
+++ b/source/TestApp/MainWindow.xaml
@@ -80,6 +80,10 @@
                 <MenuItem Header="VS2013 Light" Click="OnSwitchTheme" Tag="VS2013Light" IsCheckable="True" />
                 <MenuItem Header="VS2013 Blue" Click="OnSwitchTheme" Tag="VS2013Blue" IsCheckable="True" />
                 <Separator />
+                <MenuItem Header="VS2026 Dark" Click="OnSwitchTheme" Tag="VS2026Dark" IsCheckable="True" />
+                <MenuItem Header="VS2026 Light" Click="OnSwitchTheme" Tag="VS2026Light" IsCheckable="True" />
+                <MenuItem Header="VS2026 Blue" Click="OnSwitchTheme" Tag="VS2026Blue" IsCheckable="True" />
+                <Separator />
                 <MenuItem Header="VS2022 Dark" Click="OnSwitchTheme" Tag="VS2022Dark" IsCheckable="True" />
                 <MenuItem Header="VS2022 Light" Click="OnSwitchTheme" Tag="VS2022Light" IsCheckable="True" />
                 <MenuItem Header="VS2022 Blue" Click="OnSwitchTheme" Tag="VS2022Blue" IsCheckable="True" />

--- a/source/TestApp/MainWindow.xaml.cs
+++ b/source/TestApp/MainWindow.xaml.cs
@@ -70,7 +70,7 @@ namespace TestApp
 		/// TestTimer Dependency Property
 		/// </summary>
 		public static readonly DependencyProperty TestTimerProperty =
-			DependencyProperty.Register("TestTimer", typeof(int), typeof(MainWindow),
+			DependencyProperty.Register(nameof(TestTimer), typeof(int), typeof(MainWindow),
 				new FrameworkPropertyMetadata((int)0));
 
 		/// <summary>
@@ -89,7 +89,7 @@ namespace TestApp
 		/// TestBackground Dependency Property
 		/// </summary>
 		public static readonly DependencyProperty TestBackgroundProperty =
-			DependencyProperty.Register("TestBackground", typeof(Brush), typeof(MainWindow),
+			DependencyProperty.Register(nameof(TestBackground), typeof(Brush), typeof(MainWindow),
 				new FrameworkPropertyMetadata((Brush)null));
 
 		/// <summary>
@@ -108,7 +108,7 @@ namespace TestApp
 		/// FocusedElement Dependency Property
 		/// </summary>
 		public static readonly DependencyProperty FocusedElementProperty =
-			DependencyProperty.Register("FocusedElement", typeof(string), typeof(MainWindow),
+			DependencyProperty.Register(nameof(FocusedElement), typeof(string), typeof(MainWindow),
 				new FrameworkPropertyMetadata((IInputElement)null));
 
 		/// <summary>
@@ -284,6 +284,9 @@ namespace TestApp
 				case "VS2013Dark": theme = new Vs2013DarkTheme(); break;
 				case "VS2013Light": theme = new Vs2013LightTheme(); break;
 				case "VS2013Blue": theme = new Vs2013BlueTheme(); break;
+				case "VS2026Dark": theme = new VS2026DarkTheme(); break;
+				case "VS2026Light": theme = new VS2026LightTheme(); break;
+				case "VS2026Blue": theme = new VS2026BlueTheme(); break;
 				case "VS2022Dark": theme = new VS2022DarkTheme(); break;
 				case "VS2022Light": theme = new VS2022LightTheme(); break;
 				case "VS2022Blue": theme = new VS2022BlueTheme(); break;


### PR DESCRIPTION
* Add VS2026 JSON theme support to AvalonDock.Themes.VS

Visual Studio 2026 replaced the XML .vstheme format with a JSON-based override format. This adds support for it while reusing the existing palette -> resource-builder pipeline:

- VsJsonThemeParser: parses the flat VS2026 JSON override array ({ Name, Category, Background[, Foreground] }, AARRGGBB hex) into the existing VsThemeColorPalette via System.Text.Json.
- VsColorParser: shared AARRGGBB hex -> Color helper, now used by both the XML and JSON parsers.
- VsThemeColorPalette.Merge: layers an override palette onto a base palette (field-level), since VS2026 JSON files are override-only.
- VsThemeResourceBuilder: honors the new EnvironmentHeader/EnvironmentTab (+Inactive) tokens so window headers and tab strips can be colored independently; additive with the existing fallbacks.
- VsTheme.FromJson: factory to load a custom VS2026 .json on top of a base palette.
- Bundled VS2026 Dark/Light/Blue themes built from the VS2022 base palettes plus embedded vs2026*.json overrides.
- TestApp menu entries, docs, and parser/merge unit tests.

Refs Dirkster99/AvalonDock#594
