### PR TITLE
Update impact levels in breaking changes documentation

### DIFF
--- a/docs/migration/breaking-changes.md
+++ b/docs/migration/breaking-changes.md
@@ -126,11 +126,11 @@ A bug fix in v5.0.0 corrects the restacking behavior for bottom-docked panels. I
 
 | Category | Change | Impact | Action |
 |:---------|:-------|:-------|:-------|
-| Packages | Serializers separated | High | Install serializer package |
-| Namespaces | Serializer namespace moved | High | Update `using` statements |
+| Packages | Serializers separated | Low | Install serializer package |
+| Namespaces | Serializer namespace moved | Low | Update `using` statements |
 | Architecture | `ILayoutEngine` added | Low | No action for default behavior |
 | Frameworks | .NET < 4.8 dropped | High | Upgrade target framework |
 | Frameworks | .NET Core 3.x / 5 dropped | High | Upgrade target framework |
 | Themes | Arc theme added | None | Optional adoption |
 | Serialization | JSON serializer added | None | Optional adoption |
-| Behavior | Bottom restack fix | Low | Test and verify layouts |
+| Behavior | Bottom restack fix | High | Test and verify layouts |


### PR DESCRIPTION
## Summary of Changes & Impact Analysis

I have adjusted the impact level of this change because it introduces a major behavioral shift despite requiring minimal initial code modifications.

### 1. Code & Namespace Changes (Low Impact)
* **What:** Added an additional serialization package and updated namespaces.
* **Effort:** Minimal (~10–20 minutes). No real stability impact on the running application's core logic.

### 2. AvalonDock Behavior Change (High/Breaking Impact)
* **What:** The new "Bottom restack fix" forces runtime checks. If a current layout is affected, the entire layout must be recreated from scratch.
* **Internal Effort:** Significant (**5–10 hours**). We have 10 modules using AvalonDock, each with 2–5 XML-stored layouts, totaling **30–40 layouts** that must be manually rearranged and updated.

### 3. Customer Impact (Critical)
* **The Risk:** Customers who have saved their own custom layouts will likely experience broken UI states. 
* **Action Required:** Customers will be forced to recreate their custom layouts from scratch based on our new baseline layouts.