### PR TITLE
Fix of the XmlSerializer "file not found" in Dot.Net > 6.

### DIFF
--- a/source/Components/AvalonDock.Serializer.Xml/XmlLayoutSerializer.cs
+++ b/source/Components/AvalonDock.Serializer.Xml/XmlLayoutSerializer.cs
@@ -12,7 +12,7 @@ namespace AvalonDock.Serializer.Xml
 	/// </summary>
 	public class XmlLayoutSerializer : LayoutSerializerBase
 	{
-		private static readonly XmlSerializer DtoSerializer = new XmlSerializer(typeof(LayoutRootDto));
+		private static readonly XmlSerializer DtoSerializer = new XmlSerializer(typeof(LayoutRootDto), new XmlAttributeOverrides());
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="XmlLayoutSerializer"/> class.


### PR DESCRIPTION
Fix of the XmlSerializer file not found in Dot.Net > 6.
Otherwise the XMLSerializer looks for the assembly AvalonDock.Core.Serializer.Xml which doesnt exist.