### PR TITLE
Make XML layout deserialization tolerant of legacy formats (#7)

### DIFF
--- a/source/AutomationTest/AvalonDockTest/XmlLayoutSerializerTests.cs
+++ b/source/AutomationTest/AvalonDockTest/XmlLayoutSerializerTests.cs
@@ -716,6 +716,212 @@ namespace AvalonDockTest
 
 		#endregion
 
+		#region Legacy / cross-version compatibility
+
+		[Test]
+		public void Deserialize_LegacyCapitalizedBooleans_AreAccepted()
+		{
+			// Older AvalonDock layouts (and hand-edited files) may contain
+			// capitalized boolean values, which the XmlSerializer rejects out of
+			// the box. They must still deserialize.
+			var xml =
+				"<LayoutRoot>" +
+				"<RootPanel Orientation=\"Horizontal\">" +
+				"<LayoutAnchorablePane Id=\"anchorPane1\">" +
+				"<LayoutAnchorable Title=\"Properties\" ContentId=\"props\" " +
+				"CanHide=\"False\" CanAutoHide=\"False\" IsSelected=\"True\" CanClose=\"True\" />" +
+				"</LayoutAnchorablePane>" +
+				"</RootPanel>" +
+				"<TopSide /><RightSide /><LeftSide /><BottomSide />" +
+				"</LayoutRoot>";
+
+			var manager = new FakeDockingManager();
+			var result = DeserializeFromXml(xml, manager);
+
+			var anchor = result.RootPanel.Children
+				.OfType<LayoutAnchorablePaneDto>().First()
+				.Children.First();
+
+			Assert.That(anchor.CanHide, Is.False);
+			Assert.That(anchor.CanAutoHide, Is.False);
+			Assert.That(anchor.IsSelected, Is.True);
+			Assert.That(anchor.CanClose, Is.True);
+		}
+
+		[Test]
+		public void Deserialize_CapitalizedBooleanInStringAttribute_IsNotAltered()
+		{
+			// Only real boolean attributes are normalized; a string attribute whose
+			// value happens to be "True" must be preserved verbatim.
+			var xml =
+				"<LayoutRoot>" +
+				"<RootPanel Orientation=\"Horizontal\">" +
+				"<LayoutDocumentPane Id=\"docPane1\">" +
+				"<LayoutDocument Title=\"True\" ContentId=\"False\" IsSelected=\"True\" />" +
+				"</LayoutDocumentPane>" +
+				"</RootPanel>" +
+				"<TopSide /><RightSide /><LeftSide /><BottomSide />" +
+				"</LayoutRoot>";
+
+			var manager = new FakeDockingManager();
+			var result = DeserializeFromXml(xml, manager);
+
+			var doc = result.RootPanel.Children
+				.OfType<LayoutDocumentPaneDto>().First()
+				.Children.OfType<LayoutDocumentDto>().First();
+
+			Assert.That(doc.Title, Is.EqualTo("True"));
+			Assert.That(doc.ContentId, Is.EqualTo("False"));
+			Assert.That(doc.IsSelected, Is.True);
+		}
+
+		[Test]
+		public void Deserialize_MismatchedUtf16EncodingDeclaration_IsTolerated()
+		{
+			// A layout persisted as a UTF-16 string (declaration says utf-16) but
+			// handed to us as UTF-8 bytes must still load rather than failing with
+			// "There is no Unicode byte order mark".
+			var xml =
+				"<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+				"<LayoutRoot>" +
+				"<RootPanel Orientation=\"Horizontal\">" +
+				"<LayoutDocumentPane Id=\"docPane1\" />" +
+				"</RootPanel>" +
+				"<TopSide /><RightSide /><LeftSide /><BottomSide />" +
+				"</LayoutRoot>";
+
+			var manager = new FakeDockingManager();
+			var serializer = new XmlLayoutSerializer(manager);
+			using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+			Assert.DoesNotThrow(() => serializer.Deserialize(stream));
+
+			var result = ((FakeDtoMapper)manager.DtoMapper).LastFromDtoInput;
+			Assert.That(result.RootPanel.Children.Count, Is.EqualTo(1));
+			Assert.That(((LayoutDocumentPaneDto)result.RootPanel.Children[0]).Id, Is.EqualTo("docPane1"));
+		}
+
+		[Test]
+		public void Deserialize_Utf16BomEncodedStream_IsTolerated()
+		{
+			// Bytes that are genuinely UTF-16 (with BOM) must be decoded correctly.
+			var xml =
+				"<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+				"<LayoutRoot>" +
+				"<RootPanel Orientation=\"Horizontal\">" +
+				"<LayoutDocumentPane Id=\"docPane1\" />" +
+				"</RootPanel>" +
+				"<TopSide /><RightSide /><LeftSide /><BottomSide />" +
+				"</LayoutRoot>";
+
+			var manager = new FakeDockingManager();
+			var serializer = new XmlLayoutSerializer(manager);
+			var bytes = Encoding.Unicode.GetPreamble()
+				.Concat(Encoding.Unicode.GetBytes(xml)).ToArray();
+			using var stream = new MemoryStream(bytes);
+
+			Assert.DoesNotThrow(() => serializer.Deserialize(stream));
+
+			var result = ((FakeDtoMapper)manager.DtoMapper).LastFromDtoInput;
+			Assert.That(((LayoutDocumentPaneDto)result.RootPanel.Children[0]).Id, Is.EqualTo("docPane1"));
+		}
+
+		[Test]
+		public void Deserialize_GoldenV4Layout_LoadsCompletely()
+		{
+			// A layout exactly as AvalonDock v4 wrote it: utf-16 declaration (while the
+			// bytes are UTF-8), capitalised booleans (v4 used bool.ToString()),
+			// xmlns:xsi/xsd declarations on nested elements (v4 serialized children with
+			// per-type XmlSerializers), floating-window children named by their type,
+			// anchor groups on the sides and a Hidden section.
+			var xml =
+				"<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n" +
+				"<LayoutRoot xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\r\n" +
+				"  <RootPanel Orientation=\"Horizontal\">\r\n" +
+				"    <LayoutAnchorablePane xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" Id=\"toolsPane\" Name=\"ToolsPane\" DockWidth=\"200\">\r\n" +
+				"      <LayoutAnchorable Title=\"Solution Explorer\" IsSelected=\"True\" ContentId=\"explorer\" CanHide=\"False\" CanClose=\"True\" LastActivationTimeStamp=\"06/25/2026 14:16:56\" />\r\n" +
+				"    </LayoutAnchorablePane>\r\n" +
+				"    <LayoutDocumentPane xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" Id=\"docPane\" ShowHeader=\"False\">\r\n" +
+				"      <LayoutDocument Title=\"Readme\" IsSelected=\"True\" IsLastFocusedDocument=\"True\" ContentId=\"readme\" CanMove=\"False\" Description=\"Docs\" />\r\n" +
+				"    </LayoutDocumentPane>\r\n" +
+				"  </RootPanel>\r\n" +
+				"  <TopSide />\r\n" +
+				"  <RightSide />\r\n" +
+				"  <LeftSide>\r\n" +
+				"    <LayoutAnchorGroup xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" Id=\"group1\" PreviousContainerId=\"toolsPane\">\r\n" +
+				"      <LayoutAnchorable Title=\"Output\" ContentId=\"output\" CanAutoHide=\"True\" />\r\n" +
+				"    </LayoutAnchorGroup>\r\n" +
+				"  </LeftSide>\r\n" +
+				"  <BottomSide />\r\n" +
+				"  <FloatingWindows>\r\n" +
+				"    <LayoutAnchorableFloatingWindow>\r\n" +
+				"      <LayoutAnchorablePaneGroup xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" Orientation=\"Horizontal\" FloatingWidth=\"400\" FloatingHeight=\"300\" FloatingLeft=\"10.5\" FloatingTop=\"20.5\">\r\n" +
+				"        <LayoutAnchorablePane Id=\"floatPane\" DockWidth=\"1*\">\r\n" +
+				"          <LayoutAnchorable Title=\"Watch\" ContentId=\"watch\" />\r\n" +
+				"        </LayoutAnchorablePane>\r\n" +
+				"      </LayoutAnchorablePaneGroup>\r\n" +
+				"    </LayoutAnchorableFloatingWindow>\r\n" +
+				"  </FloatingWindows>\r\n" +
+				"  <Hidden>\r\n" +
+				"    <LayoutAnchorable Title=\"Hidden Tool\" ContentId=\"hiddenTool\" PreviousContainerId=\"toolsPane\" PreviousContainerIndex=\"0\" CanShowOnHover=\"False\" />\r\n" +
+				"  </Hidden>\r\n" +
+				"</LayoutRoot>";
+
+			var manager = new FakeDockingManager();
+			var serializer = new XmlLayoutSerializer(manager);
+			using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+			serializer.Deserialize(stream);
+			var root = ((FakeDtoMapper)manager.DtoMapper).LastFromDtoInput;
+
+			// Root panel with anchorable pane and document pane
+			Assert.That(root.RootPanel.Orientation, Is.EqualTo("Horizontal"));
+			Assert.That(root.RootPanel.Children.Count, Is.EqualTo(2));
+
+			var toolsPane = (LayoutAnchorablePaneDto)root.RootPanel.Children[0];
+			Assert.That(toolsPane.Id, Is.EqualTo("toolsPane"));
+			Assert.That(toolsPane.Name, Is.EqualTo("ToolsPane"));
+			Assert.That(toolsPane.DockWidth, Is.EqualTo("200"));
+
+			var explorer = toolsPane.Children.Single();
+			Assert.That(explorer.Title, Is.EqualTo("Solution Explorer"));
+			Assert.That(explorer.IsSelected, Is.True);
+			Assert.That(explorer.CanHide, Is.False);
+			Assert.That(explorer.CanClose, Is.True);
+			Assert.That(explorer.LastActivationTimeStamp, Is.EqualTo("06/25/2026 14:16:56"));
+
+			var docPane = (LayoutDocumentPaneDto)root.RootPanel.Children[1];
+			Assert.That(docPane.ShowHeader, Is.False);
+
+			var readme = (LayoutDocumentDto)docPane.Children.Single();
+			Assert.That(readme.IsLastFocusedDocument, Is.True);
+			Assert.That(readme.CanMove, Is.False);
+			Assert.That(readme.Description, Is.EqualTo("Docs"));
+
+			// Auto-hidden anchor group on the left side
+			var group = root.LeftSide.Children.Single();
+			Assert.That(group.Id, Is.EqualTo("group1"));
+			Assert.That(group.PreviousContainerId, Is.EqualTo("toolsPane"));
+			Assert.That(group.Children.Single().ContentId, Is.EqualTo("output"));
+
+			// Floating window with its type-named pane group child
+			var floating = (LayoutAnchorableFloatingWindowDto)root.FloatingWindows.Single();
+			Assert.That(floating.RootPanel.FloatingWidth, Is.EqualTo(400.0));
+			Assert.That(floating.RootPanel.FloatingLeft, Is.EqualTo(10.5));
+
+			var floatPane = (LayoutAnchorablePaneDto)floating.RootPanel.Children.Single();
+			Assert.That(floatPane.DockWidth, Is.EqualTo("1*"));
+			Assert.That(floatPane.Children.Single().ContentId, Is.EqualTo("watch"));
+
+			// Hidden section
+			var hidden = root.Hidden.Single();
+			Assert.That(hidden.ContentId, Is.EqualTo("hiddenTool"));
+			Assert.That(hidden.PreviousContainerId, Is.EqualTo("toolsPane"));
+			Assert.That(hidden.PreviousContainerIndex, Is.EqualTo(0));
+			Assert.That(hidden.CanShowOnHover, Is.False);
+		}
+
+		#endregion
+
 		#region Extension method tests (TextWriter/TextReader)
 
 		[Test]

--- a/source/Components/AvalonDock.Serializer.Xml/XmlLayoutSerializer.cs
+++ b/source/Components/AvalonDock.Serializer.Xml/XmlLayoutSerializer.cs
@@ -1,4 +1,6 @@
 using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Xml.Serialization;
 using AvalonDock.Core;
 using AvalonDock.Core.Serialization.Dto;
@@ -13,6 +15,21 @@ namespace AvalonDock.Serializer.Xml
 	public class XmlLayoutSerializer : LayoutSerializerBase
 	{
 		private static readonly XmlSerializer DtoSerializer = new XmlSerializer(typeof(LayoutRootDto));
+
+		/// <summary>
+		/// Matches capitalised <c>True</c>/<c>False</c> values of the boolean layout
+		/// attributes as written by AvalonDock v4 and earlier, which
+		/// <see cref="XmlSerializer"/> rejects (xsd:boolean is lower-case). Only these
+		/// named attributes are matched so string values such as <c>Title</c> or
+		/// <c>ContentId</c> are never altered. The list is frozen together with the
+		/// legacy format: attributes added in v5 or later can never occur in legacy
+		/// files, so it does not need updating when DTO properties are added.
+		/// </summary>
+		private static readonly Regex LegacyBooleanRegex = new Regex(
+			"\\b(IsSelected|IsLastFocusedDocument|IsMaximized|CanClose|CanFloat|CanShowOnHover"
+			+ "|CanHide|CanAutoHide|CanDockAsTabbedDocument|CanDock|CanMove|ShowHeader)"
+			+ "=\"(True|False)\"",
+			RegexOptions.Compiled);
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="XmlLayoutSerializer"/> class.
@@ -34,7 +51,21 @@ namespace AvalonDock.Serializer.Xml
 		/// <inheritdoc/>
 		protected override LayoutRootDto DeserializeCore(Stream stream)
 		{
-			return (LayoutRootDto)DtoSerializer.Deserialize(stream);
+			// Decode the stream ourselves (honouring a BOM when present) and deserialize
+			// from the resulting string. Reading from already-decoded text makes the XML
+			// prolog's encoding declaration irrelevant, so legacy layouts persisted with a
+			// mismatched declaration (e.g. encoding="utf-16" on UTF-8 bytes) load instead
+			// of failing with "There is no Unicode byte order mark".
+			string xml;
+			using (var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true))
+				xml = reader.ReadToEnd();
+
+			// Legacy layouts store booleans as "True"/"False"; normalise to xsd:boolean.
+			xml = LegacyBooleanRegex.Replace(xml,
+				m => m.Groups[1].Value + "=\"" + m.Groups[2].Value.ToLowerInvariant() + "\"");
+
+			using var textReader = new StringReader(xml);
+			return (LayoutRootDto)DtoSerializer.Deserialize(textReader);
 		}
 	}
 }


### PR DESCRIPTION
Loading layouts saved by AvalonDock v4 (or hand-edited files) into v5 could fail during XML deserialization for two format reasons unrelated to the layout structure itself:

1. A mismatched XML encoding declaration (e.g. encoding="utf-16" on bytes that are actually UTF-8), which aborts the read with "There is no Unicode byte order mark".
2. Capitalised boolean values ("True"/"False") as written by v4's XmlWriter-based serialization, which XmlSerializer rejects because it only accepts the lower-case xsd:boolean form.

These were the only two incompatibilities: the DTO schema already mirrors the v4 wire format 1:1 (element/attribute names, element order, type-named floating-window children, conditional attribute emission), verified against the pre-refactor IXmlSerializable code (159e607^). The reverse direction needs no change either, since v4 reads booleans case-insensitively via bool.Parse and so accepts v5 output as-is.

XmlLayoutSerializer.DeserializeCore now decodes the stream itself (honouring a BOM when present) and deserializes from the resulting string, so the encoding declaration no longer aborts the read. Legacy boolean casing is normalised beforehand for the fixed set of boolean attributes of the legacy format; string attributes such as Title/ContentId are never altered. The attribute list is frozen together with the v4 format, so it needs no maintenance as DTOs evolve.

Adds unit tests covering capitalised booleans, string attributes whose value happens to be "True"/"False", a mismatched utf-16 declaration on UTF-8 bytes, a genuine UTF-16 (BOM) stream, and a golden-file test of a complete v4-written layout (xmlns noise on nested elements, floating windows, anchor groups, hidden section).

This should also solve #604 