### PR TITLE
Set floating window owner in DockingManager in Loaded.

### DIFF
--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -2486,6 +2486,7 @@ namespace AvalonDock
 				fwc.EnableBindings();
 				if (fwc.KeepContentVisibleOnClose)
 				{
+					fwc.UpdateOwnership();
 					fwc.Show();
 					fwc.KeepContentVisibleOnClose = false;
 				}


### PR DESCRIPTION
When unloading/loading occurs the owner of the window may have changed.
This change assures that the owner is correct, before displaying the window.