### PR TITLE
[Fix] #615 - [FloatingWindow] Propagate inheritable properties to flo…

### DIFF
--- a/source/AutomationTest/AvalonDockTest/FloatingWindowInheritedPropertyTests.cs
+++ b/source/AutomationTest/AvalonDockTest/FloatingWindowInheritedPropertyTests.cs
@@ -1,0 +1,136 @@
+﻿namespace AvalonDockTest
+{
+	using System;
+	using System.Linq;
+	using System.Windows.Threading;
+
+	using NUnit.Framework;
+
+	using AvalonDock.Controls;
+	using AvalonDockTest.TestHelpers;
+	using AvalonDockTest.Views;
+
+	/// <summary>
+	/// Regression coverage for issue #615: an inheritable dependency property assigned to an ancestor of
+	/// the <see cref="AvalonDock.DockingManager"/> reached the content of a floating window but not the
+	/// floating window itself, so its title kept the default value.
+	/// </summary>
+	[TestFixture]
+	[Apartment(System.Threading.ApartmentState.STA)]
+	public class FloatingWindowInheritedPropertyTests : AutomationTestBase
+	{
+		/// <summary>A font size that differs from the WPF default of 12.</summary>
+		private const double ExpectedFontSize = 27d;
+
+		[Test]
+		public void FontSizeChangedAfterFloatingReachesTheFloatingWindow_Issue615()
+		{
+			var window = CreateTestWindow();
+			try
+			{
+				var floatingWindow = FloatFirstAnchorable(window);
+
+				window.FontSize = ExpectedFontSize;
+				window.UpdateLayout();
+
+				Assert.That(floatingWindow.FontSize, Is.EqualTo(ExpectedFontSize),
+					"A floating window has to pick up the FontSize of the window hosting the DockingManager (Issue #615).");
+			}
+			finally
+			{
+				window.Close();
+			}
+		}
+
+		[Test]
+		public void FontSizeSetBeforeFloatingReachesTheFloatingWindow_Issue615()
+		{
+			var window = CreateTestWindow();
+			try
+			{
+				window.FontSize = ExpectedFontSize;
+				window.UpdateLayout();
+
+				var floatingWindow = FloatFirstAnchorable(window);
+
+				Assert.That(floatingWindow.FontSize, Is.EqualTo(ExpectedFontSize),
+					"A floating window created after the FontSize was assigned has to pick it up as well (Issue #615).");
+			}
+			finally
+			{
+				window.Close();
+			}
+		}
+
+		[Test]
+		public void FontSizeAssignedToTheFloatingWindowItselfIsNotOverwritten_Issue615()
+		{
+			var window = CreateTestWindow();
+			try
+			{
+				var floatingWindow = FloatFirstAnchorable(window);
+				floatingWindow.FontSize = ExpectedFontSize + 5d;
+
+				window.FontSize = ExpectedFontSize;
+				window.UpdateLayout();
+
+				Assert.That(floatingWindow.FontSize, Is.EqualTo(ExpectedFontSize + 5d),
+					"A value assigned to the floating window itself has to win over the mirrored value.");
+			}
+			finally
+			{
+				window.Close();
+			}
+		}
+
+		/// <summary>Creates the test window and waits until it is loaded and its layout is up to date.</summary>
+		/// <returns>The fully loaded test window.</returns>
+		private static LayoutAnchorableFloatingWindowControlTestWindow CreateTestWindow()
+		{
+			var taskResult = WindowHelpers.CreateInvisibleWindowAsync<LayoutAnchorableFloatingWindowControlTestWindow>();
+			taskResult.Wait();
+
+			var window = taskResult.Result;
+
+			// The DockingManager builds its Layout*Controls when it is loaded, so the dispatcher queue has to
+			// be drained before the docking manager can be operated on.
+			DoEvents();
+			window.UpdateLayout();
+			DoEvents();
+			window.UpdateLayout();
+
+			return window;
+		}
+
+		/// <summary>Floats an anchorable of the test window and waits until its floating window is shown.</summary>
+		/// <param name="window">The test window to operate on.</param>
+		/// <returns>The floating window hosting the anchorable.</returns>
+		private static LayoutFloatingWindowControl FloatFirstAnchorable(LayoutAnchorableFloatingWindowControlTestWindow window)
+		{
+			window.Window1.Float();
+
+			// The floating window is shown through a dispatcher operation, so the queue has to be drained
+			// before the floating window is loaded.
+			DoEvents();
+			window.UpdateLayout();
+
+			var floatingWindow = window.dockingManager.FloatingWindows.FirstOrDefault();
+			Assert.That(floatingWindow, Is.Not.Null, "The anchorable should be hosted in a floating window.");
+
+			return floatingWindow;
+		}
+
+		/// <summary>
+		/// Drains the dispatcher queue down to <see cref="DispatcherPriority.Background"/>, which also
+		/// executes every pending <see cref="DispatcherPriority.Loaded"/> operation.
+		/// </summary>
+		private static void DoEvents()
+		{
+			var frame = new DispatcherFrame();
+			Dispatcher.CurrentDispatcher.BeginInvoke(
+				DispatcherPriority.Background,
+				new Action(() => frame.Continue = false));
+			Dispatcher.PushFrame(frame);
+		}
+	}
+}

--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -32,6 +33,18 @@ namespace AvalonDock.Controls
 		private DragService _dragService = null;
 		private bool _internalCloseFlag = false;
 		private bool _isClosing = false;
+
+		/// <summary>
+		/// Caches the inheritable dependency properties that are mirrored from the <see cref="DockingManager"/>
+		/// onto every floating window.
+		/// </summary>
+		private static readonly Lazy<DependencyProperty[]> InheritableProperties = new Lazy<DependencyProperty[]>(GetInheritableProperties);
+
+		/// <summary>
+		/// Stores the inheritable dependency properties whose value is currently mirrored from the
+		/// <see cref="DockingManager"/> onto this floating window.
+		/// </summary>
+		private readonly HashSet<DependencyProperty> _mirroredInheritedProperties = new HashSet<DependencyProperty>();
 
 		/// <summary>
 		/// Is false until the margins have been found once.
@@ -655,6 +668,7 @@ namespace AvalonDock.Controls
 			Loaded -= OnLoaded;
 
 			this.UpdateOwnership();
+			SyncInheritedProperties();
 			ApplyResizeBorderThickness();
 
 			_hwndSrc = PresentationSource.FromDependencyObject(this) as HwndSource;
@@ -663,6 +677,92 @@ namespace AvalonDock.Controls
 			// Restore maximize state
 			var maximized = Model.Descendents().OfType<ILayoutElementForFloatingWindow>().Any(l => l.IsMaximized);
 			UpdateMaximizedState(maximized);
+		}
+
+		/// <summary>
+		/// Mirrors the current value of every inheritable dependency property of the owning
+		/// <see cref="DockingManager"/> onto this floating window.
+		/// </summary>
+		/// <remarks>
+		/// A <see cref="Window"/> is always the root of its own tree - WPF throws
+		/// <see cref="InvalidOperationException"/> ("Window must be the root of the tree") as soon as a
+		/// <see cref="Window"/> is given a logical parent. A floating window can therefore never be part of the
+		/// logical tree of its <see cref="DockingManager"/> and inheritable dependency properties such as
+		/// <see cref="Control.FontSize"/> never reach the window chrome, even though the hosted content does
+		/// receive them (the content root is a logical child of the <see cref="DockingManager"/>).
+		/// The values are mirrored explicitly instead.
+		/// </remarks>
+		internal void SyncInheritedProperties()
+		{
+			foreach (var property in InheritableProperties.Value)
+				SyncInheritedProperty(property);
+		}
+
+		/// <summary>
+		/// Mirrors the current value of a single inheritable dependency property of the owning
+		/// <see cref="DockingManager"/> onto this floating window.
+		/// </summary>
+		/// <param name="property">The inheritable dependency property to mirror.</param>
+		/// <remarks>
+		/// A value that has been assigned to the floating window itself - by a style, a trigger, a binding or by
+		/// application code - always wins over the mirrored value and is never overwritten.
+		/// </remarks>
+		internal void SyncInheritedProperty(DependencyProperty property)
+		{
+			if (property == null || _isClosing)
+				return;
+
+			var manager = Model?.Root?.Manager;
+			if (manager == null)
+				return;
+
+			if (DependencyPropertyHelper.GetValueSource(manager, property).BaseValueSource == BaseValueSource.Default)
+			{
+				// The docking manager fell back to the default value, so there is nothing left to mirror.
+				if (_mirroredInheritedProperties.Remove(property))
+					ClearValue(property);
+				return;
+			}
+
+			if (!_mirroredInheritedProperties.Contains(property) &&
+				DependencyPropertyHelper.GetValueSource(this, property).BaseValueSource > BaseValueSource.Inherited)
+			{
+				return;
+			}
+
+			_mirroredInheritedProperties.Add(property);
+			SetValue(property, manager.GetValue(property));
+		}
+
+		/// <summary>
+		/// Determines the inheritable dependency properties that are mirrored from the
+		/// <see cref="DockingManager"/> onto a floating window.
+		/// </summary>
+		/// <returns>The inheritable dependency properties of a <see cref="LayoutFloatingWindowControl"/>.</returns>
+		private static DependencyProperty[] GetInheritableProperties()
+		{
+			// Attached inheritable properties are not exposed as CLR properties and have to be listed explicitly.
+			var properties = new List<DependencyProperty>
+			{
+				TextOptions.TextFormattingModeProperty,
+				TextOptions.TextRenderingModeProperty,
+				TextOptions.TextHintingModeProperty,
+			};
+
+			foreach (PropertyDescriptor descriptor in TypeDescriptor.GetProperties(typeof(LayoutFloatingWindowControl)))
+			{
+				if (descriptor.IsReadOnly)
+					continue;
+
+				var dependencyProperty = DependencyPropertyDescriptor.FromProperty(descriptor)?.DependencyProperty;
+				if (dependencyProperty == null || properties.Contains(dependencyProperty))
+					continue;
+
+				if (dependencyProperty.GetMetadata(typeof(LayoutFloatingWindowControl)) is FrameworkPropertyMetadata metadata && metadata.Inherits)
+					properties.Add(dependencyProperty);
+			}
+
+			return properties.ToArray();
 		}
 
 		/// <summary>

--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -2410,6 +2410,25 @@ namespace AvalonDock
 		}
 
 		/// <inheritdoc/>
+		protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
+		{
+			base.OnPropertyChanged(e);
+
+			// Floating windows are top level windows and can never become part of the logical tree of this
+			// DockingManager, because WPF requires a Window to be the root of its own tree. Inheritable
+			// dependency properties therefore never flow into a floating window and its chrome (its title in
+			// particular) and have to be mirrored onto the floating windows explicitly.
+			if (_fwList.Count == 0 && _fwHiddenList.Count == 0)
+				return;
+
+			if (!(e.Property.GetMetadata(this) is FrameworkPropertyMetadata metadata) || !metadata.Inherits)
+				return;
+
+			foreach (var floatingWindow in _fwList.Concat(_fwHiddenList).ToArray())
+				floatingWindow.SyncInheritedProperty(e.Property);
+		}
+
+		/// <inheritdoc/>
 		protected override void OnPreviewKeyDown(KeyEventArgs e)
 		{
 			if (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl))


### PR DESCRIPTION
…ating windows

An inheritable dependency property assigned to an ancestor of the DockingManager (for example the FontSize of the hosting window) reached the content of a floating window but not the floating window itself, so its title kept the default value.

The content root of a floating window is a logical child of the DockingManager and therefore inherits, while the LayoutFloatingWindowControl is not - and can never be: WPF requires a Window to be the root of its own tree and Window.OnAncestorChanged throws "Window must be the root of the tree" as soon as a Window is given a logical parent.

The values are now mirrored explicitly instead: the DockingManager pushes every inheritable property change onto its floating windows, and a floating window pulls the current values when it is loaded. A value that has been assigned to the floating window itself - by a style, a trigger, a binding or by application code - always wins and is never overwritten, and the mirrored value is cleared again when the DockingManager falls back to the default value.

fixes #615