### PR TITLE
[Fix] #618 - [FloatingWindow] Defer ownership until the hosting window is shown

### DIFF
--- a/source/AutomationTest/AvalonDockTest/FloatingWindowOwnershipTests.cs
+++ b/source/AutomationTest/AvalonDockTest/FloatingWindowOwnershipTests.cs
@@ -1,0 +1,128 @@
+namespace AvalonDockTest
+{
+	using System;
+	using System.Linq;
+	using System.Windows;
+	using System.Windows.Threading;
+
+	using NUnit.Framework;
+
+	using AvalonDock;
+	using AvalonDock.Layout;
+	using AvalonDockTest.TestHelpers;
+
+	/// <summary>
+	/// Regression coverage for issue #618: floating a <see cref="LayoutAnchorable"/> before the window
+	/// hosting the <see cref="DockingManager"/> has been shown crashed with
+	/// InvalidOperationException("Cannot set Owner property to a Window that has not been shown previously."),
+	/// because WPF refuses to own a window by a window that has never been shown.
+	/// </summary>
+	[TestFixture]
+	[Apartment(System.Threading.ApartmentState.STA)]
+	public class FloatingWindowOwnershipTests : AutomationTestBase
+	{
+		[Test]
+		public void FloatBeforeTheHostingWindowIsShownDoesNotThrow_Issue618()
+		{
+			var window = CreateHostingWindow(out var dockingManager, out var anchorable);
+			Exception dispatcherException = null;
+			void OnUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
+			{
+				dispatcherException = e.Exception;
+				e.Handled = true;
+			}
+
+			Dispatcher.CurrentDispatcher.UnhandledException += OnUnhandledException;
+			try
+			{
+				// The floating window is shown through a dispatcher operation, so the crash of issue #618
+				// surfaces while the dispatcher queue is drained and not in the call to Float() itself.
+				Assert.DoesNotThrow(
+					() =>
+					{
+						anchorable.Float();
+						DoEvents();
+					},
+					"Floating an anchorable before the window hosting the DockingManager is shown must not throw (Issue #618).");
+
+				Assert.That(dispatcherException, Is.Null,
+					"Floating an anchorable before the window hosting the DockingManager is shown must not throw (Issue #618).");
+
+				var floatingWindow = dockingManager.FloatingWindows.FirstOrDefault();
+				Assert.That(floatingWindow, Is.Not.Null, "The anchorable should be hosted in a floating window.");
+				Assert.That(floatingWindow.Owner, Is.Null,
+					"As long as the hosting window has not been shown it cannot own the floating window.");
+			}
+			finally
+			{
+				Dispatcher.CurrentDispatcher.UnhandledException -= OnUnhandledException;
+				window.Close();
+			}
+		}
+
+		[Test]
+		public void OwnershipIsEstablishedOnceTheHostingWindowIsShown_Issue618()
+		{
+			var window = CreateHostingWindow(out var dockingManager, out var anchorable);
+			try
+			{
+				anchorable.Float();
+				DoEvents();
+
+				var floatingWindow = dockingManager.FloatingWindows.FirstOrDefault();
+				Assert.That(floatingWindow, Is.Not.Null, "The anchorable should be hosted in a floating window.");
+				Assert.That(floatingWindow.Owner, Is.Null,
+					"As long as the hosting window has not been shown it cannot own the floating window.");
+
+				window.Show();
+				DoEvents();
+
+				Assert.That(floatingWindow.Owner, Is.SameAs(window),
+					"The deferred ownership has to be established as soon as the hosting window is shown (Issue #618).");
+			}
+			finally
+			{
+				window.Close();
+			}
+		}
+
+		/// <summary>
+		/// Creates a window hosting a <see cref="DockingManager"/> with a single floatable anchorable
+		/// without showing the window.
+		/// </summary>
+		/// <param name="dockingManager">The docking manager hosted by the window.</param>
+		/// <param name="anchorable">The anchorable that can be floated.</param>
+		/// <returns>The window that has not been shown yet.</returns>
+		private static Window CreateHostingWindow(out DockingManager dockingManager, out LayoutAnchorable anchorable)
+		{
+			dockingManager = new DockingManager();
+			anchorable = new LayoutAnchorable { Title = "Anchorable" };
+			dockingManager.Layout.RootPanel.Children.Add(new LayoutAnchorablePane(anchorable));
+
+			return new Window
+			{
+				Width = 400,
+				Height = 300,
+				ShowInTaskbar = false,
+				ShowActivated = false,
+				WindowStartupLocation = WindowStartupLocation.Manual,
+				Left = -10000,
+				Top = -10000,
+				Content = dockingManager,
+			};
+		}
+
+		/// <summary>
+		/// Drains the dispatcher queue down to <see cref="DispatcherPriority.Background"/>, which also
+		/// executes every pending <see cref="DispatcherPriority.Loaded"/> operation.
+		/// </summary>
+		private static void DoEvents()
+		{
+			var frame = new DispatcherFrame();
+			Dispatcher.CurrentDispatcher.BeginInvoke(
+				DispatcherPriority.Background,
+				new Action(() => frame.Continue = false));
+			Dispatcher.PushFrame(frame);
+		}
+	}
+}

--- a/source/AutomationTest/AvalonDockTest/FloatingWindowOwnershipTests.cs
+++ b/source/AutomationTest/AvalonDockTest/FloatingWindowOwnershipTests.cs
@@ -61,6 +61,26 @@ namespace AvalonDockTest
 		}
 
 		[Test]
+		public void FloatBeforeTheHostingWindowIsShownDoesNotShowTheFloatingWindow_Issue618()
+		{
+			var window = CreateHostingWindow(out var dockingManager, out var anchorable);
+			try
+			{
+				anchorable.Float();
+				DoEvents();
+
+				var floatingWindow = dockingManager.FloatingWindows.FirstOrDefault();
+				Assert.That(floatingWindow, Is.Not.Null, "The anchorable should be hosted in a floating window.");
+				Assert.That(floatingWindow.IsVisible, Is.False,
+					"A floating window must not be put on screen while the window hosting the DockingManager is still invisible (Issue #618).");
+			}
+			finally
+			{
+				window.Close();
+			}
+		}
+
+		[Test]
 		public void OwnershipIsEstablishedOnceTheHostingWindowIsShown_Issue618()
 		{
 			var window = CreateHostingWindow(out var dockingManager, out var anchorable);
@@ -79,6 +99,33 @@ namespace AvalonDockTest
 
 				Assert.That(floatingWindow.Owner, Is.SameAs(window),
 					"The deferred ownership has to be established as soon as the hosting window is shown (Issue #618).");
+				Assert.That(floatingWindow.IsVisible, Is.True,
+					"The deferred floating window has to be shown as soon as the hosting window is shown (Issue #618).");
+			}
+			finally
+			{
+				window.Close();
+			}
+		}
+
+		[Test]
+		public void FloatAfterTheHostingWindowIsShownShowsTheFloatingWindowImmediately_Issue618()
+		{
+			var window = CreateHostingWindow(out var dockingManager, out var anchorable);
+			try
+			{
+				window.Show();
+				DoEvents();
+
+				anchorable.Float();
+				DoEvents();
+
+				var floatingWindow = dockingManager.FloatingWindows.FirstOrDefault();
+				Assert.That(floatingWindow, Is.Not.Null, "The anchorable should be hosted in a floating window.");
+				Assert.That(floatingWindow.IsVisible, Is.True,
+					"Floating an anchorable of a window that is already shown has to show the floating window right away.");
+				Assert.That(floatingWindow.Owner, Is.SameAs(window),
+					"A floating window created while the hosting window is shown is owned by it.");
 			}
 			finally
 			{

--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -35,6 +35,12 @@ namespace AvalonDock.Controls
 		private bool _isClosing = false;
 
 		/// <summary>
+		/// The window hosting the <see cref="DockingManager"/> that has not been shown yet and whose
+		/// <see cref="Window.SourceInitialized"/> event is awaited to establish the ownership (issue #618).
+		/// </summary>
+		private Window _deferredOwnerWindow;
+
+		/// <summary>
 		/// Caches the inheritable dependency properties that are mirrored from the <see cref="DockingManager"/>
 		/// onto every floating window.
 		/// </summary>
@@ -602,6 +608,7 @@ namespace AvalonDock.Controls
 		protected override void OnClosed(EventArgs e)
 		{
 			SizeChanged -= OnSizeChanged;
+			DetachDeferredOwnershipUpdate();
 			if (Content != null)
 			{
 				(Content as FloatingWindowContentHost)?.Dispose();
@@ -775,12 +782,58 @@ namespace AvalonDock.Controls
 			var manager = Model?.Root?.Manager;
 			if (OwnedByDockingManagerWindow && manager != null)
 			{
-				this.SetParentToMainWindowOf(manager);
+				if (this.SetParentToMainWindowOf(manager))
+				{
+					DetachDeferredOwnershipUpdate();
+				}
+				else
+				{
+					// The window hosting the DockingManager has not been shown yet, so it cannot own this
+					// floating window before it has created its native window handle (issue #618).
+					DeferOwnershipUpdate(Window.GetWindow(manager));
+				}
 			}
 			else
 			{
+				DetachDeferredOwnershipUpdate();
 				this.SetParentWindowToNull();
 			}
+		}
+
+		/// <summary>
+		/// Retries <see cref="UpdateOwnership"/> as soon as <paramref name="ownerWindow"/> has created its
+		/// native window handle, because WPF cannot own a window by a window that has never been shown.
+		/// </summary>
+		/// <param name="ownerWindow">The window hosting the <see cref="DockingManager"/> of this floating window.</param>
+		private void DeferOwnershipUpdate(Window ownerWindow)
+		{
+			if (ownerWindow == null || ReferenceEquals(ownerWindow, _deferredOwnerWindow))
+				return;
+
+			DetachDeferredOwnershipUpdate();
+			_deferredOwnerWindow = ownerWindow;
+			ownerWindow.SourceInitialized += OnDeferredOwnerWindowSourceInitialized;
+		}
+
+		/// <summary>
+		/// Stops waiting for the window hosting the <see cref="DockingManager"/> to be shown.
+		/// </summary>
+		private void DetachDeferredOwnershipUpdate()
+		{
+			if (_deferredOwnerWindow == null)
+				return;
+
+			_deferredOwnerWindow.SourceInitialized -= OnDeferredOwnerWindowSourceInitialized;
+			_deferredOwnerWindow = null;
+		}
+
+		private void OnDeferredOwnerWindowSourceInitialized(object sender, EventArgs e)
+		{
+			DetachDeferredOwnershipUpdate();
+			if (_isClosing)
+				return;
+
+			UpdateOwnership();
 		}
 
 		private const double KeyboardMoveStep = 10.0;

--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -41,6 +41,12 @@ namespace AvalonDock.Controls
 		private Window _deferredOwnerWindow;
 
 		/// <summary>
+		/// The <see cref="DockingManager"/> whose <see cref="FrameworkElement.Loaded"/> event is awaited
+		/// before this floating window is shown (issue #618).
+		/// </summary>
+		private DockingManager _deferredShowManager;
+
+		/// <summary>
 		/// Caches the inheritable dependency properties that are mirrored from the <see cref="DockingManager"/>
 		/// onto every floating window.
 		/// </summary>
@@ -609,6 +615,7 @@ namespace AvalonDock.Controls
 		{
 			SizeChanged -= OnSizeChanged;
 			DetachDeferredOwnershipUpdate();
+			CancelDeferredShow();
 			if (Content != null)
 			{
 				(Content as FloatingWindowContentHost)?.Dispose();
@@ -834,6 +841,76 @@ namespace AvalonDock.Controls
 				return;
 
 			UpdateOwnership();
+		}
+
+		/// <summary>
+		/// Shows this floating window, or postpones the operation until the <see cref="DockingManager"/> is
+		/// loaded when the window hosting it has not been shown yet.
+		/// </summary>
+		/// <remarks>
+		/// Showing a floating window while the window hosting the <see cref="DockingManager"/> is still
+		/// invisible puts a window on screen that has no visible owner, so the operation is postponed until
+		/// the <see cref="DockingManager"/> is loaded - the same point in time at which
+		/// <see cref="DockingManager"/> creates the floating windows of a layout that was assigned before the
+		/// hosting window was shown (issue #618).
+		/// </remarks>
+		internal void ShowWhenHostWindowIsShown()
+		{
+			var manager = Model?.Root?.Manager;
+			if (manager == null)
+			{
+				Show();
+				return;
+			}
+
+			// A DockingManager that is not hosted in a WPF Window - inside a WindowsFormsHost, for example -
+			// never gets a hosting window to wait for, so the floating window is shown right away.
+			var hostWindow = Window.GetWindow(manager);
+			if (hostWindow == null || hostWindow.IsWindowHandleCreated())
+			{
+				Show();
+				return;
+			}
+
+			// Establishes the ownership as soon as the hosting window has created its window handle, which
+			// happens before the DockingManager is loaded.
+			UpdateOwnership();
+			DeferShow(manager);
+		}
+
+		/// <summary>
+		/// Shows this floating window as soon as <paramref name="manager"/> is loaded.
+		/// </summary>
+		/// <param name="manager">The docking manager owning this floating window.</param>
+		private void DeferShow(DockingManager manager)
+		{
+			if (ReferenceEquals(manager, _deferredShowManager))
+				return;
+
+			CancelDeferredShow();
+			_deferredShowManager = manager;
+			manager.Loaded += OnDeferredShowManagerLoaded;
+		}
+
+		/// <summary>
+		/// Stops waiting for the <see cref="DockingManager"/> to be loaded.
+		/// </summary>
+		private void CancelDeferredShow()
+		{
+			if (_deferredShowManager == null)
+				return;
+
+			_deferredShowManager.Loaded -= OnDeferredShowManagerLoaded;
+			_deferredShowManager = null;
+		}
+
+		private void OnDeferredShowManagerLoaded(object sender, RoutedEventArgs e)
+		{
+			CancelDeferredShow();
+			if (_isClosing)
+				return;
+
+			Show();
 		}
 
 		private const double KeyboardMoveStep = 10.0;

--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -2131,7 +2131,10 @@ namespace AvalonDock
 				{
 					// Activate only inactive document
 					if (startDrag) fwc.AttachDrag();
-					fwc.Show();
+
+					// Content can be floated before the window hosting this DockingManager has been shown,
+					// in which case the floating window is only shown once the hosting window is (issue #618).
+					fwc.ShowWhenHostWindowIsShown();
 					ContentFloated?.Invoke(this, new ContentFloatedEventArgs(content));
 					_coreContentFloated?.Invoke(this, new Core.Events.ContentEventArgs(content));
 				}), DispatcherPriority.Send);

--- a/source/Components/AvalonDock/WindowHelper.cs
+++ b/source/Components/AvalonDock/WindowHelper.cs
@@ -25,18 +25,44 @@ namespace AvalonDock
 		/// </summary>
 		/// <param name="window">The window.</param>
 		/// <param name="element">The element.</param>
-		public static void SetParentToMainWindowOf(this Window window, Visual element)
+		/// <returns>
+		/// true if the ownership could be established; false if the window hosting <paramref name="element"/>
+		/// has not been shown yet and the ownership has to be established at a later point in time.
+		/// </returns>
+		public static bool SetParentToMainWindowOf(this Window window, Visual element)
 		{
 			var wndParent = Window.GetWindow(element);
 			if (wndParent != null)
 			{
+				// WPF refuses to own a window by a window that has never been shown and throws
+				// InvalidOperationException("Cannot set Owner property to a Window that has not been shown
+				// previously.") instead. This happens whenever a layout element is floated before the window
+				// hosting the DockingManager is shown for the first time (issue #618).
+				if (!wndParent.IsWindowHandleCreated())
+					return false;
+
 				window.Owner = wndParent;
+				return true;
 			}
-			else
+
+			if (GetParentWindowHandle(element, out IntPtr parentHwnd))
 			{
-				if (GetParentWindowHandle(element, out IntPtr parentHwnd))
-					Win32Helper.SetOwner(new WindowInteropHelper(window).Handle, parentHwnd);
+				Win32Helper.SetOwner(new WindowInteropHelper(window).Handle, parentHwnd);
+				return true;
 			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// Determines whether the native window handle of <paramref name="window"/> has already been created,
+		/// which is the case as soon as the window has been shown once and until it is closed.
+		/// </summary>
+		/// <param name="window">The window.</param>
+		/// <returns>true if the window owns a native window handle; otherwise, false.</returns>
+		public static bool IsWindowHandleCreated(this Window window)
+		{
+			return window != null && new WindowInteropHelper(window).Handle != IntPtr.Zero;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Floating a layout element before the window hosting the DockingManager has
been shown crashed with

InvalidOperationException: Cannot set Owner property to a Window that has
not been shown previously. (#618)

WPF refuses to assign a Window as Owner as long as that window has not
created its native window handle, which is exactly the case when Float() is
called during construction of the hosting window.

WindowHelper.SetParentToMainWindowOf now reports whether the ownership could
be established instead of letting WPF throw, and
LayoutFloatingWindowControl.UpdateOwnership retries once the hosting window
raises SourceInitialized. The handler is detached again as soon as the
ownership is established or the floating window is closed.

Adds regression coverage for both the crash and the deferred ownership.