### PR TITLE
[Fix] - [ToggleDockingManager] Honour IToolbox.IsOpen set before load

### DIFF
--- a/docs/guides/toggle-docking-manager.md
+++ b/docs/guides/toggle-docking-manager.md
@@ -131,6 +131,26 @@ public class ExplorerToolbox : ToolboxBase
 }
 ```
 
+### Visibility on startup
+
+`IsOpenByDefault` is the declarative default and seeds `IsOpen`; from then on `IsOpen` is the single
+answer to whether a toolbox is showing. Both are read when the manager applies a layout, so a view
+model built by a DI container may set `IsOpen` in its constructor — long before the manager exists —
+and the toolbox still comes up docked:
+
+```csharp
+services.AddDockLayoutService(dock => dock.AddToolbox<ExplorerToolbox>());
+// ExplorerToolbox sets IsOpen = true in its constructor: it is showing once the window loads.
+```
+
+A zone shows one toolbox at a time, so giving two toolboxes in the same zone `IsOpenByDefault = true`
+docks only the last of them; the other is collapsed onto its stripe and reports `IsOpen == false`.
+`IsOpen` always reports what the layout actually shows, whether the state was changed by a sidebar
+button, a keyboard shortcut, or a sibling toolbox taking the zone.
+
+An anchorable detached into its own window counts as open: setting `IsOpen = false` on it brings that
+window forward rather than closing it. Dock it back first if you want it collapsed.
+
 ### Keyboard Shortcuts
 
 Setting `IToolbox.Shortcut` to a WPF gesture string registers a `KeyBinding` on the host window that

--- a/source/AutomationTest/AvalonDockTest/AutoHideFlyoutGuardTests.cs
+++ b/source/AutomationTest/AvalonDockTest/AutoHideFlyoutGuardTests.cs
@@ -18,7 +18,7 @@ namespace AvalonDockTest;
 /// anchorables through its sidebar toggle buttons, see
 /// <see cref="DockingManager.SupportsAutoHideFlyout"/>), and must not crash when the
 /// anchorable's parent chain is detached while the layout is being restructured
-/// (e.g. by the ToggleLayoutEngine during OpenDefaultToolboxes).
+/// (e.g. by the ToggleLayoutEngine during ApplyInitialToolboxState).
 /// </summary>
 [TestFixture]
 [Apartment(ApartmentState.STA)]

--- a/source/AutomationTest/AvalonDockTest/ToggleDockToolboxStateTests.cs
+++ b/source/AutomationTest/AvalonDockTest/ToggleDockToolboxStateTests.cs
@@ -1,0 +1,334 @@
+namespace AvalonDockTest
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using System.Reflection;
+	using System.Windows;
+	using System.Windows.Threading;
+
+	using NUnit.Framework;
+
+	using AvalonDock;
+	using AvalonDock.Core;
+	using AvalonDock.Layout;
+	using AvalonDock.Mvvm;
+	using AvalonDockTest.TestHelpers;
+
+	/// <summary>
+	/// Tests for the state a <see cref="ToggleDockingManager"/> and its <see cref="IToolbox"/> view
+	/// models agree on.
+	/// </summary>
+	/// <remarks>
+	/// The manager only learns about a toolbox once it is loaded and registers it. A view model built
+	/// by a dependency injection container exists long before that, so whatever it decided about its
+	/// own visibility was decided while nobody was listening. These tests pin down that such a decision
+	/// is still honoured, and that the two sides never end up disagreeing: a toolbox left holding a
+	/// value the layout does not show cannot ask for that value again, because a property that does not
+	/// change raises no notification.
+	/// </remarks>
+	[TestFixture]
+	[Apartment(System.Threading.ApartmentState.STA)]
+	public class ToggleDockToolboxStateTests : AutomationTestBase
+	{
+		/// <summary>A toolbox view model that can be placed in any zone.</summary>
+		private sealed class TestToolbox : ToolboxBase
+		{
+			/// <summary>Initializes a new instance of the <see cref="TestToolbox"/> class.</summary>
+			/// <param name="id">The content id, also used as the title.</param>
+			/// <param name="zone">The zone to place the toolbox in.</param>
+			public TestToolbox(string id, DockZone zone)
+			{
+				Id = id;
+				Title = id;
+				Zone = zone;
+			}
+		}
+
+		/// <summary>
+		/// A toolbox that asked to be open before the manager ever saw it has to be showing once the
+		/// manager is loaded. This is the shape a dependency injection container produces: the view
+		/// model is constructed at container build time, the manager loads later.
+		/// </summary>
+		[Test]
+		public void IsOpenSetBeforeTheManagerLoads_ShowsTheToolbox()
+		{
+			var toolbox = new TestToolbox("explorer", DockZone.LeftTop) { IsOpen = true };
+			var window = CreateHostingWindow(out var manager, toolbox);
+
+			try
+			{
+				window.Show();
+				DoEvents();
+
+				Assert.That(IsDocked(manager, toolbox), Is.True,
+					"An IsOpen set before the manager was loaded has to be applied once it loads.");
+				Assert.That(toolbox.IsOpen, Is.True);
+			}
+			finally
+			{
+				window.Close();
+			}
+		}
+
+		/// <summary>
+		/// IsOpenByDefault seeds IsOpen, so an application can read back from a single property whether
+		/// a toolbox is showing, whichever of the two put it there.
+		/// </summary>
+		[Test]
+		public void IsOpenByDefault_SeedsIsOpen()
+		{
+			var toolbox = new TestToolbox("explorer", DockZone.LeftTop) { IsOpenByDefault = true };
+			var window = CreateHostingWindow(out var manager, toolbox);
+
+			try
+			{
+				window.Show();
+				DoEvents();
+
+				Assert.That(IsDocked(manager, toolbox), Is.True);
+				Assert.That(toolbox.IsOpen, Is.True,
+					"IsOpenByDefault has to leave IsOpen reporting what the layout shows.");
+			}
+			finally
+			{
+				window.Close();
+			}
+		}
+
+		/// <summary>
+		/// One zone shows one toolbox at a time, so of two that both want to open on startup only one
+		/// ends up docked - and the other has to say so, rather than keep claiming it is open.
+		/// </summary>
+		[Test]
+		public void TwoToolboxesInOneZone_LeaveTheCollapsedOneReportingClosed()
+		{
+			var first = new TestToolbox("first", DockZone.LeftTop) { IsOpenByDefault = true };
+			var second = new TestToolbox("second", DockZone.LeftTop) { IsOpenByDefault = true };
+			var window = CreateHostingWindow(out var manager, first, second);
+
+			try
+			{
+				window.Show();
+				DoEvents();
+
+				var toolboxes = new[] { first, second };
+				Assert.That(toolboxes.Count(t => IsDocked(manager, t)), Is.EqualTo(1),
+					"A zone shows one toolbox at a time.");
+				Assert.That(toolboxes.Single(t => !IsDocked(manager, t)).IsOpen, Is.False,
+					"A toolbox collapsed to make room for a sibling may not keep reporting itself as open.");
+			}
+			finally
+			{
+				window.Close();
+			}
+		}
+
+		/// <summary>
+		/// The regression this fixture exists for: a toolbox collapsed by a sibling used to keep
+		/// IsOpen == true, so assigning true again changed nothing, raised no notification, and left the
+		/// toolbox impossible to reopen from the view model.
+		/// </summary>
+		[Test]
+		public void AToolboxCollapsedByASibling_CanBeReopenedFromTheViewModel()
+		{
+			var first = new TestToolbox("first", DockZone.LeftTop) { IsOpenByDefault = true };
+			var second = new TestToolbox("second", DockZone.LeftTop) { IsOpenByDefault = true };
+			var window = CreateHostingWindow(out var manager, first, second);
+
+			try
+			{
+				window.Show();
+				DoEvents();
+
+				var toolboxes = new[] { first, second };
+				var collapsed = toolboxes.Single(t => !IsDocked(manager, t));
+				var showing = toolboxes.Single(t => IsDocked(manager, t));
+
+				collapsed.IsOpen = true;
+				DoEvents();
+
+				Assert.That(IsDocked(manager, collapsed), Is.True,
+					"Setting IsOpen = true has to bring the collapsed toolbox back.");
+				Assert.That(IsDocked(manager, showing), Is.False);
+				Assert.That(showing.IsOpen, Is.False,
+					"Reopening one toolbox has to collapse the sibling and tell that sibling about it.");
+			}
+			finally
+			{
+				window.Close();
+			}
+		}
+
+		/// <summary>
+		/// Closing from the view model still works now that the open and close paths run through the
+		/// same toggle implementation.
+		/// </summary>
+		[Test]
+		public void SettingIsOpenToFalse_CollapsesTheToolbox()
+		{
+			var toolbox = new TestToolbox("explorer", DockZone.LeftTop) { IsOpenByDefault = true };
+			var window = CreateHostingWindow(out var manager, toolbox);
+
+			try
+			{
+				window.Show();
+				DoEvents();
+				Assert.That(IsDocked(manager, toolbox), Is.True);
+
+				toolbox.IsOpen = false;
+				DoEvents();
+
+				Assert.That(IsDocked(manager, toolbox), Is.False);
+			}
+			finally
+			{
+				window.Close();
+			}
+		}
+
+		/// <summary>
+		/// The reconciliation runs again whenever the bars are rebuilt - the manager is re-attached to
+		/// the visual tree, the theme changes - so it must never toggle a showing toolbox back off.
+		/// </summary>
+		[Test]
+		public void ApplyingTheInitialState_IsIdempotent()
+		{
+			var toolbox = new TestToolbox("explorer", DockZone.LeftTop) { IsOpenByDefault = true };
+			var window = CreateHostingWindow(out var manager, toolbox);
+
+			try
+			{
+				window.Show();
+				DoEvents();
+				Assert.That(IsDocked(manager, toolbox), Is.True);
+
+				ApplyInitialToolboxStateAgain(manager);
+				DoEvents();
+
+				Assert.That(IsDocked(manager, toolbox), Is.True,
+					"Re-applying the startup state may not close what is already open.");
+			}
+			finally
+			{
+				window.Close();
+			}
+		}
+
+		/// <summary>
+		/// Builds an off screen window hosting a <see cref="ToggleDockingManager"/> whose layout already
+		/// holds the given toolboxes, which is the order an application declaring its layout in XAML
+		/// produces: the layout is in place before the manager is loaded.
+		/// </summary>
+		/// <param name="manager">Receives the hosted manager.</param>
+		/// <param name="toolboxes">The toolboxes to place in the layout.</param>
+		/// <returns>The window, not yet shown.</returns>
+		private static Window CreateHostingWindow(out ToggleDockingManager manager, params TestToolbox[] toolboxes)
+		{
+			manager = new ToggleDockingManager
+			{
+				Layout = BuildLayout(toolboxes),
+			};
+
+			return new Window
+			{
+				Width = 800,
+				Height = 600,
+				ShowInTaskbar = false,
+				ShowActivated = false,
+				WindowStartupLocation = WindowStartupLocation.Manual,
+				Left = -10000,
+				Top = -10000,
+				Content = manager,
+			};
+		}
+
+		/// <summary>
+		/// Builds a layout holding one auto hidden anchorable per toolbox, which is the state the toggle
+		/// docking manager keeps them in while their sidebar button is not toggled on.
+		/// </summary>
+		/// <param name="toolboxes">The toolboxes to place.</param>
+		/// <returns>The layout root.</returns>
+		private static LayoutRoot BuildLayout(IEnumerable<TestToolbox> toolboxes)
+		{
+			var layout = new LayoutRoot
+			{
+				RootPanel = new LayoutPanel(new LayoutDocumentPaneGroup(new LayoutDocumentPane())),
+			};
+
+			foreach (var toolbox in toolboxes)
+			{
+				var group = new LayoutAnchorGroup();
+				group.Children.Add(new LayoutAnchorable
+				{
+					Title = toolbox.Title,
+					ContentId = toolbox.Id,
+					Content = toolbox,
+				});
+
+				SideFor(layout, toolbox.Zone).Children.Add(group);
+			}
+
+			return layout;
+		}
+
+		/// <summary>Gets the layout side a zone belongs to.</summary>
+		/// <param name="layout">The layout.</param>
+		/// <param name="zone">The zone.</param>
+		/// <returns>The side of the layout holding that zone.</returns>
+		private static LayoutAnchorSide SideFor(LayoutRoot layout, DockZone zone)
+		{
+			switch (zone)
+			{
+				case DockZone.RightTop:
+				case DockZone.RightBottom:
+					return layout.RightSide;
+				case DockZone.BottomLeft:
+				case DockZone.BottomRight:
+					return layout.BottomSide;
+				default:
+					return layout.LeftSide;
+			}
+		}
+
+		/// <summary>Gets a value indicating whether the given toolbox is showing in the dock area.</summary>
+		/// <param name="manager">The manager holding the layout.</param>
+		/// <param name="toolbox">The toolbox to check.</param>
+		/// <returns>True when the toolbox is docked rather than collapsed onto its stripe.</returns>
+		private static bool IsDocked(ToggleDockingManager manager, TestToolbox toolbox)
+		{
+			var anchorable = manager.Layout.Descendents()
+				.OfType<LayoutAnchorable>()
+				.First(a => ReferenceEquals(a.Content, toolbox));
+
+			return !anchorable.IsAutoHidden;
+		}
+
+		/// <summary>
+		/// Runs the startup reconciliation a second time. It is private because applications never call
+		/// it themselves; the manager runs it whenever it rebuilds the sidebar bars.
+		/// </summary>
+		/// <param name="manager">The manager to run it on.</param>
+		private static void ApplyInitialToolboxStateAgain(ToggleDockingManager manager)
+		{
+			var method = typeof(ToggleDockingManager).GetMethod(
+				"ApplyInitialToolboxState", BindingFlags.Instance | BindingFlags.NonPublic);
+
+			Assert.That(method, Is.Not.Null, "ApplyInitialToolboxState is the seam these tests rely on.");
+			method.Invoke(manager, null);
+		}
+
+		/// <summary>
+		/// Drains the dispatcher queue down to <see cref="DispatcherPriority.Background"/>, which also
+		/// executes every pending <see cref="DispatcherPriority.Loaded"/> operation.
+		/// </summary>
+		private static void DoEvents()
+		{
+			var frame = new DispatcherFrame();
+			Dispatcher.CurrentDispatcher.BeginInvoke(
+				DispatcherPriority.Background,
+				new Action(() => frame.Continue = false));
+			Dispatcher.PushFrame(frame);
+		}
+	}
+}

--- a/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -185,8 +185,18 @@ namespace AvalonDock.Controls
 		protected override void OnInitialized(EventArgs e)
 		{
 			base.OnInitialized(e);
-			var manager = _model.Root.Manager;
-			Content = manager.CreateUIElementForModel(_model.RootPanel);
+
+			// The window reaches the screen through a deferred dispatcher operation, so its model can
+			// have left the layout tree before this runs - the window hosting the docking manager was
+			// closed in the meantime, say. There is no manager to build the content from then, and a
+			// window with no content is what an already detached model should produce. OnClosed and
+			// OnRootUpdated expect a model without a root for the same reason.
+			var manager = _model.Root?.Manager;
+			if (manager != null)
+			{
+				Content = manager.CreateUIElementForModel(_model.RootPanel);
+			}
+
 			// SetBinding(VisibilityProperty, new Binding("IsVisible") { Source = _model, Converter = new BoolToVisibilityConverter(), Mode = BindingMode.OneWay, ConverterParameter = Visibility.Hidden });
 
 			// Issue: http://avalondock.codeplex.com/workitem/15036

--- a/source/Components/AvalonDock/ToggleDockingManager.cs
+++ b/source/Components/AvalonDock/ToggleDockingManager.cs
@@ -124,6 +124,19 @@ public class ToggleDockingManager : DockingManager
 	/// </summary>
 	private Button _showHiddenButton;
 
+	/// <summary>
+	/// The toggle style, cached per thread rather than process wide.
+	/// </summary>
+	/// <remarks>
+	/// A <see cref="Style"/> is a <see cref="System.Windows.Threading.DispatcherObject"/> and keeps the
+	/// affinity of the thread that created it until it is sealed, which WPF only does once it is first
+	/// applied. Handing one instance to managers on several UI threads therefore lets the layout pass
+	/// of the second thread throw "The calling thread cannot access this object because a different
+	/// thread owns it" out of <c>Style.CheckTargetType</c>, from where nothing catches it. Caching per
+	/// thread keeps the saving this field is here for - the pack URI is parsed once per UI thread
+	/// rather than once per manager - without sharing an object that cannot be shared.
+	/// </remarks>
+	[ThreadStatic]
 	private static Style _staticToggleStyle;
 
 	private static Style LoadToggleStyle()

--- a/source/Components/AvalonDock/ToggleDockingManager.cs
+++ b/source/Components/AvalonDock/ToggleDockingManager.cs
@@ -294,7 +294,7 @@ public class ToggleDockingManager : DockingManager
 				System.Windows.Threading.DispatcherPriority.Loaded,
 				new System.Action(() =>
 				{
-					OpenDefaultToolboxes();
+					ApplyInitialToolboxState();
 					RefreshButtonStates();
 					UpdatePinButtonsToMinimize();
 				}));
@@ -357,6 +357,8 @@ public class ToggleDockingManager : DockingManager
 			}
 		}
 
+		SyncToolboxStateToLayout();
+
 		Dispatcher.BeginInvoke(
 			System.Windows.Threading.DispatcherPriority.Loaded,
 			new System.Action(() =>
@@ -417,6 +419,11 @@ public class ToggleDockingManager : DockingManager
 	{
 		ApplyToggleAnchorableStyle();
 		SetupToggleDockButtonBars();
+
+		// Rebuilding the bars collapses every docked anchorable onto its stripe. The toolboxes still
+		// carry the state they were in, so re-applying it brings the open ones back instead of
+		// leaving a theme switch to close them.
+		ApplyInitialToolboxState();
 		RefreshButtonStates();
 		Dispatcher.BeginInvoke(
 			System.Windows.Threading.DispatcherPriority.Loaded,
@@ -441,6 +448,12 @@ public class ToggleDockingManager : DockingManager
 		if (IsDetached(anchorable))
 		{
 			ActivateDetachedWindow(anchorable);
+
+			// The content stays on screen, so the toolbox stays open. Writing that back keeps a view
+			// model that asked for the opposite from holding a value this manager never applied -
+			// which, because change notifications are raised on change only, would leave it unable to
+			// ask again.
+			SetToolboxIsOpen(anchorable);
 			return;
 		}
 
@@ -646,26 +659,78 @@ public class ToggleDockingManager : DockingManager
 	{
 		ApplyToggleAnchorableStyle();
 		SetupToggleDockButtonBars();
-		OpenDefaultToolboxes();
+		ApplyInitialToolboxState();
 		RefreshShortcuts();
 		Dispatcher.BeginInvoke(
 			System.Windows.Threading.DispatcherPriority.Loaded,
 			new System.Action(UpdatePinButtonsToMinimize));
 	}
 
-	private void OpenDefaultToolboxes()
+	/// <summary>
+	/// Docks the toolboxes that ask to be showing, and reconciles the state of the ones that do not.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// <see cref="IToolbox.IsOpenByDefault"/> is the declarative default and seeds
+	/// <see cref="IToolbox.IsOpen"/>, which from then on is the single answer to whether a toolbox is
+	/// showing. Reading <see cref="IToolbox.IsOpen"/> here is what lets a value the application set
+	/// before this manager was loaded take effect - a view model built by a dependency injection
+	/// container is constructed long before <see cref="RegisterToolbox"/> subscribes to it, so an
+	/// assignment made back then raised a change notification no one was listening for.
+	/// </para>
+	/// <para>
+	/// Anchorables that already show are left where they are, so running this again - the manager is
+	/// re-attached to the visual tree, a new dock layout arrives, the theme changes - never collapses
+	/// what is open.
+	/// </para>
+	/// </remarks>
+	private void ApplyInitialToolboxState()
 	{
 		if (Layout == null)
 		{
 			return;
 		}
 
-		foreach (var anc in Layout.Descendents().OfType<LayoutAnchorable>().ToList())
+		foreach (var anchorable in Layout.Descendents().OfType<LayoutAnchorable>().ToList())
 		{
-			if (anc.Content is IToolbox toolbox && toolbox.IsOpenByDefault)
+			if (!(anchorable.Content is IToolbox toolbox))
 			{
-				ToggleAnchorable(anc, toolbox.Zone);
+				continue;
 			}
+
+			if (!toolbox.IsOpen && !toolbox.IsOpenByDefault)
+			{
+				continue;
+			}
+
+			if (anchorable.IsAutoHidden && !IsDetached(anchorable))
+			{
+				ToggleAnchorable(anchorable, toolbox.Zone);
+			}
+			else
+			{
+				// Already on screen - only the toolbox still has to be told, which is what turns
+				// IsOpenByDefault into an IsOpen the application can read back.
+				SetToolboxIsOpen(anchorable);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Writes the state every registered anchorable is actually in back onto its toolbox.
+	/// </summary>
+	/// <remarks>
+	/// Rebuilding the bars collapses the anchorables onto their stripes and a restored layout decides
+	/// on its own which of them are docked again, neither of which passes through the toggle path
+	/// that maintains <see cref="IToolbox.IsOpen"/>. Without this the toolboxes of the replaced layout
+	/// keep reporting the state they were left in, and since a property that does not change raises no
+	/// notification, asking for that state again would do nothing.
+	/// </remarks>
+	private void SyncToolboxStateToLayout()
+	{
+		foreach (var anchorable in _toolboxToAnchorable.Values.ToList())
+		{
+			SetToolboxIsOpen(anchorable);
 		}
 	}
 
@@ -1429,6 +1494,12 @@ public class ToggleDockingManager : DockingManager
 			if (item is ToggleDockButton btn && btn.Anchorable != null && !btn.Anchorable.IsAutoHidden)
 			{
 				AutoHideFromDock(btn.Anchorable, bar.Zone);
+
+				// This collapse is a side effect of opening a sibling, so nothing else writes it back.
+				// Leaving it out is what used to strand a toolbox at IsOpen == true while it sat on
+				// its stripe, after which setting IsOpen = true again raised no change and the
+				// toolbox could not be reopened from the view model at all.
+				SetToolboxIsOpen(btn.Anchorable);
 			}
 		}
 	}
@@ -1844,51 +1915,23 @@ public class ToggleDockingManager : DockingManager
 			return;
 		}
 
-		bool wantOpen = toolbox.IsOpen;
-		bool isOpen = !anchorable.IsAutoHidden;
+		// A detached anchorable sits collapsed on its stripe while its content is on screen in a
+		// standalone window, so IsAutoHidden on its own does not say whether the toolbox is showing.
+		bool isOpen = !anchorable.IsAutoHidden || IsDetached(anchorable);
 
-		if (wantOpen == isOpen)
+		if (toolbox.IsOpen == isOpen)
 		{
 			return;
 		}
 
+		// ToggleAnchorable is the one implementation of this transition: it carries the zone
+		// bookkeeping, the layout priority handling and the detached window case, and it writes the
+		// resulting state back onto the toolbox. Duplicating it here is what let the two paths drift
+		// apart. The _syncDepth guard keeps that write-back from re-entering this handler.
 		_syncDepth++;
 		try
 		{
-			if (wantOpen)
-			{
-				var zone = GetAnchorableZone(anchorable);
-				HideDockedInBar(GetBarForZone(zone));
-				DockFromAutoHide(anchorable, zone);
-				FixSplitOrientation(anchorable, zone);
-
-				if (ToggleLayoutEngine.IsBottomZone(zone))
-				{
-					EnsureBottomZoneOrder();
-				}
-
-				switch (LayoutPriority)
-				{
-					case DockLayoutPriority.BottomFullWidth:
-						EnsureBottomFullWidth();
-						break;
-					case DockLayoutPriority.SidesFullHeight:
-						EnsureSidesFullHeight();
-						break;
-				}
-
-				ActiveContent = anchorable.Content;
-			}
-			else
-			{
-				var zone = GetAnchorableZone(anchorable);
-				AutoHideFromDock(anchorable, zone);
-			}
-
-			RefreshButtonStates();
-			Dispatcher.BeginInvoke(
-				System.Windows.Threading.DispatcherPriority.Loaded,
-				new System.Action(UpdatePinButtonsToMinimize));
+			ToggleAnchorable(anchorable, GetAnchorableZone(anchorable));
 		}
 		finally
 		{


### PR DESCRIPTION
The manager learns about a toolbox when it registers it, which happens once it is loaded. A view model built by a dependency injection container is constructed long before that, so an IsOpen it set was decided while nobody was listening: the manager only applied IsOpenByDefault, and the value was dropped. Because a property that does not change raises no notification, the toolbox was then stuck - it already held true, so asking for true again did nothing and it could not be opened from the view model at all.

The same drift arose without any startup involvement. A zone shows one toolbox at a time, so opening one collapses its sibling, and that collapse never wrote back onto the sibling's toolbox. Two toolboxes with IsOpenByDefault in one zone reproduced the stuck state on the first frame.

- Replace OpenDefaultToolboxes with ApplyInitialToolboxState, which reads IsOpen as well as IsOpenByDefault and leaves what already shows alone, so running it again never collapses an open toolbox.
- Write the state back when a toolbox is collapsed to make room for a sibling, and when a detached window is brought forward instead of docked.
- Reconcile the toolboxes against the layout after a stored layout replaced the tree.
- Fold the view model driven open path into ToggleAnchorable rather than repeating it. The duplicate had drifted: it missed the detached window case, so setting IsOpen = true on a detached toolbox tried to dock it.
- Re-apply the state after a theme change, which rebuilds the bars and collapsed every open toolbox on the way.

IsOpenByDefault now seeds IsOpen, which from then on is the single answer to whether a toolbox is showing