### PR TITLE
[Fix] #587 - [FloatingWindow] Stop drag overlay windows from piling up

### DIFF
--- a/docs/concepts/floating-windows.md
+++ b/docs/concepts/floating-windows.md
@@ -73,6 +73,21 @@ When a user drags a floating window over the main docking area, **docking indica
 
 The docking indicators are [defined in XAML](https://github.com/Dirkster99/AvalonDock/wiki/OverlayWindow), ensuring crisp rendering on all resolutions including 4K and 8K displays.
 
+### Overlay Window Lifetime
+
+The indicators live in an `OverlayWindow`: a borderless, transparent window that every drop target
+host — the `DockingManager` itself and each floating window — puts over its own area while a drag is
+in progress.
+
+Each host keeps one overlay window and shows and hides it again for every drag, rather than creating
+a new one per drag. A drag ends through a window message of the window being dragged, and that
+message does not always arrive — moving a window between monitors with different DPI scaling can end
+the modal move loop of Windows without one. Recreating the overlay window per drag turned every such
+drag into an empty window that stayed on screen for the rest of the session, so the count grew with
+every float. Reusing one window per host, and clearing the overlay windows of all hosts whenever a
+drag starts or ends, removes that possibility: an overlay window is only ever destroyed together with
+the host it belongs to.
+
 ---
 
 ## Events

--- a/source/AutomationTest/AvalonDockTest/FloatingWindowLifetimeTests.cs
+++ b/source/AutomationTest/AvalonDockTest/FloatingWindowLifetimeTests.cs
@@ -19,22 +19,29 @@ namespace AvalonDockTest
 	/// </summary>
 	/// <remarks>
 	/// The overlay windows of the reported scenario are only put on screen by a real mouse drag, which
-	/// these tests cannot perform. What they do cover is the other half of the report - the resources a
-	/// floating window leaves behind once it has been closed - and the plain bookkeeping of the windows
-	/// themselves over repeated float and dock cycles.
+	/// a unit test cannot perform. What is covered here is that repeating the float and dock cycle
+	/// reaches a steady state - neither the floating windows themselves nor the content hosts they
+	/// register with the <see cref="DockingManager"/> may grow with every float.
 	/// </remarks>
 	[TestFixture]
 	[Apartment(System.Threading.ApartmentState.STA)]
 	public class FloatingWindowLifetimeTests : AutomationTestBase
 	{
 		/// <summary>
-		/// The automation name that <see cref="AvalonDock.Controls.LayoutFloatingWindowControl"/> gives to
+		/// The automation name that <c>LayoutFloatingWindowControl.FloatingWindowContentHost</c> gives to
 		/// the presenter it registers as a logical child of the <see cref="DockingManager"/>.
 		/// </summary>
 		private const string FloatingWindowHostName = "FloatingWindowHost";
 
+		/// <summary>
+		/// The number of float and dock cycles that are run before the counts are taken as the baseline.
+		/// A docked anchorable keeps its floating window as the container to float back into, so the
+		/// first cycle is the one that establishes it and the ones after it have to change nothing.
+		/// </summary>
+		private const int WarmUpCycles = 2;
+
 		[Test]
-		public void RepeatedFloatAndDockKeepsExactlyOneFloatingWindow_Issue587()
+		public void RepeatedFloatAndDockDoesNotAccumulateWindows_Issue587()
 		{
 			var window = CreateHostingWindow(out var dockingManager, out var anchorable);
 			try
@@ -42,19 +49,25 @@ namespace AvalonDockTest
 				window.Show();
 				DoEvents();
 
-				for (var cycle = 1; cycle <= 3; cycle++)
+				for (var cycle = 1; cycle <= WarmUpCycles; cycle++)
+					RunFloatAndDockCycle(anchorable);
+
+				var floatingWindows = dockingManager.FloatingWindows.Count();
+				var contentHosts = FloatingWindowContentHostsOf(dockingManager).Count;
+
+				Assert.That(floatingWindows, Is.EqualTo(1),
+					"Floating a single anchorable has to end up with exactly one floating window.");
+
+				for (var cycle = WarmUpCycles + 1; cycle <= WarmUpCycles + 3; cycle++)
 				{
-					anchorable.Float();
-					DoEvents();
+					RunFloatAndDockCycle(anchorable);
 
-					Assert.That(dockingManager.FloatingWindows.Count(), Is.EqualTo(1),
-						$"Floating an anchorable has to create exactly one floating window (cycle {cycle}, Issue #587).");
+					Assert.That(dockingManager.FloatingWindows.Count(), Is.EqualTo(floatingWindows),
+						$"Floating an anchorable again must not add another floating window (cycle {cycle}, Issue #587).");
 
-					anchorable.Dock();
-					DoEvents();
-
-					Assert.That(dockingManager.FloatingWindows, Is.Empty,
-						$"Docking an anchorable back has to take its floating window down again (cycle {cycle}, Issue #587).");
+					Assert.That(FloatingWindowContentHostsOf(dockingManager).Count, Is.LessThanOrEqualTo(contentHosts),
+						"The content hosts registered with the DockingManager must not grow with every float, " +
+						$"they have to be handed back when a floating window goes away (cycle {cycle}, Issue #587).");
 				}
 			}
 			finally
@@ -63,40 +76,23 @@ namespace AvalonDockTest
 			}
 		}
 
-		[Test]
-		public void ClosedFloatingWindowReleasesItsContentHost_Issue587()
+		/// <summary>Floats the given anchorable and docks it back again.</summary>
+		/// <param name="anchorable">The anchorable to float and dock.</param>
+		private static void RunFloatAndDockCycle(LayoutAnchorable anchorable)
 		{
-			var window = CreateHostingWindow(out var dockingManager, out var anchorable);
-			try
-			{
-				window.Show();
-				DoEvents();
+			anchorable.Float();
+			DoEvents();
 
-				for (var cycle = 1; cycle <= 3; cycle++)
-				{
-					anchorable.Float();
-					DoEvents();
-
-					anchorable.Dock();
-					DoEvents();
-
-					Assert.That(FloatingWindowContentHostsOf(dockingManager), Is.Empty,
-						"A closed floating window has to hand its content host back to the DockingManager, " +
-						$"otherwise every float leaves one behind for the rest of the session (cycle {cycle}, Issue #587).");
-				}
-			}
-			finally
-			{
-				window.Close();
-			}
+			anchorable.Dock();
+			DoEvents();
 		}
 
 		/// <summary>
-		/// Collects the content hosts of floating windows that are still registered as logical children of
-		/// the given <see cref="DockingManager"/>.
+		/// Collects the content hosts of floating windows that are registered as logical children of the
+		/// given <see cref="DockingManager"/>.
 		/// </summary>
 		/// <param name="manager">The docking manager to inspect.</param>
-		/// <returns>The content hosts the manager still holds.</returns>
+		/// <returns>The content hosts the manager holds.</returns>
 		private static IReadOnlyList<object> FloatingWindowContentHostsOf(DockingManager manager)
 		{
 			var hosts = new List<object>();

--- a/source/AutomationTest/AvalonDockTest/FloatingWindowLifetimeTests.cs
+++ b/source/AutomationTest/AvalonDockTest/FloatingWindowLifetimeTests.cs
@@ -1,0 +1,154 @@
+namespace AvalonDockTest
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using System.Windows;
+	using System.Windows.Automation;
+	using System.Windows.Threading;
+
+	using NUnit.Framework;
+
+	using AvalonDock;
+	using AvalonDock.Layout;
+	using AvalonDockTest.TestHelpers;
+
+	/// <summary>
+	/// Regression coverage for issue #587: floating an anchorable over and over left empty windows
+	/// behind that could not be closed individually and only disappeared with the application.
+	/// </summary>
+	/// <remarks>
+	/// The overlay windows of the reported scenario are only put on screen by a real mouse drag, which
+	/// these tests cannot perform. What they do cover is the other half of the report - the resources a
+	/// floating window leaves behind once it has been closed - and the plain bookkeeping of the windows
+	/// themselves over repeated float and dock cycles.
+	/// </remarks>
+	[TestFixture]
+	[Apartment(System.Threading.ApartmentState.STA)]
+	public class FloatingWindowLifetimeTests : AutomationTestBase
+	{
+		/// <summary>
+		/// The automation name that <see cref="AvalonDock.Controls.LayoutFloatingWindowControl"/> gives to
+		/// the presenter it registers as a logical child of the <see cref="DockingManager"/>.
+		/// </summary>
+		private const string FloatingWindowHostName = "FloatingWindowHost";
+
+		[Test]
+		public void RepeatedFloatAndDockKeepsExactlyOneFloatingWindow_Issue587()
+		{
+			var window = CreateHostingWindow(out var dockingManager, out var anchorable);
+			try
+			{
+				window.Show();
+				DoEvents();
+
+				for (var cycle = 1; cycle <= 3; cycle++)
+				{
+					anchorable.Float();
+					DoEvents();
+
+					Assert.That(dockingManager.FloatingWindows.Count(), Is.EqualTo(1),
+						$"Floating an anchorable has to create exactly one floating window (cycle {cycle}, Issue #587).");
+
+					anchorable.Dock();
+					DoEvents();
+
+					Assert.That(dockingManager.FloatingWindows, Is.Empty,
+						$"Docking an anchorable back has to take its floating window down again (cycle {cycle}, Issue #587).");
+				}
+			}
+			finally
+			{
+				window.Close();
+			}
+		}
+
+		[Test]
+		public void ClosedFloatingWindowReleasesItsContentHost_Issue587()
+		{
+			var window = CreateHostingWindow(out var dockingManager, out var anchorable);
+			try
+			{
+				window.Show();
+				DoEvents();
+
+				for (var cycle = 1; cycle <= 3; cycle++)
+				{
+					anchorable.Float();
+					DoEvents();
+
+					anchorable.Dock();
+					DoEvents();
+
+					Assert.That(FloatingWindowContentHostsOf(dockingManager), Is.Empty,
+						"A closed floating window has to hand its content host back to the DockingManager, " +
+						$"otherwise every float leaves one behind for the rest of the session (cycle {cycle}, Issue #587).");
+				}
+			}
+			finally
+			{
+				window.Close();
+			}
+		}
+
+		/// <summary>
+		/// Collects the content hosts of floating windows that are still registered as logical children of
+		/// the given <see cref="DockingManager"/>.
+		/// </summary>
+		/// <param name="manager">The docking manager to inspect.</param>
+		/// <returns>The content hosts the manager still holds.</returns>
+		private static IReadOnlyList<object> FloatingWindowContentHostsOf(DockingManager manager)
+		{
+			var hosts = new List<object>();
+			foreach (var child in LogicalTreeHelper.GetChildren(manager))
+			{
+				if (child is DependencyObject dependencyObject &&
+					AutomationProperties.GetName(dependencyObject) == FloatingWindowHostName)
+				{
+					hosts.Add(child);
+				}
+			}
+
+			return hosts;
+		}
+
+		/// <summary>
+		/// Creates a window hosting a <see cref="DockingManager"/> with a single floatable anchorable
+		/// without showing the window.
+		/// </summary>
+		/// <param name="dockingManager">The docking manager hosted by the window.</param>
+		/// <param name="anchorable">The anchorable that can be floated.</param>
+		/// <returns>The window that has not been shown yet.</returns>
+		private static Window CreateHostingWindow(out DockingManager dockingManager, out LayoutAnchorable anchorable)
+		{
+			dockingManager = new DockingManager();
+			anchorable = new LayoutAnchorable { Title = "Anchorable" };
+			dockingManager.Layout.RootPanel.Children.Add(new LayoutAnchorablePane(anchorable));
+
+			return new Window
+			{
+				Width = 400,
+				Height = 300,
+				ShowInTaskbar = false,
+				ShowActivated = false,
+				WindowStartupLocation = WindowStartupLocation.Manual,
+				Left = -10000,
+				Top = -10000,
+				Content = dockingManager,
+			};
+		}
+
+		/// <summary>
+		/// Drains the dispatcher queue down to <see cref="DispatcherPriority.Background"/>, which also
+		/// executes every pending <see cref="DispatcherPriority.Loaded"/> operation.
+		/// </summary>
+		private static void DoEvents()
+		{
+			var frame = new DispatcherFrame();
+			Dispatcher.CurrentDispatcher.BeginInvoke(
+				DispatcherPriority.Background,
+				new Action(() => frame.Continue = false));
+			Dispatcher.PushFrame(frame);
+		}
+	}
+}

--- a/source/Components/AvalonDock/Controls/DragService.cs
+++ b/source/Components/AvalonDock/Controls/DragService.cs
@@ -44,6 +44,11 @@ namespace AvalonDock.Controls
 			// TODO - pass in without DPI adjustment, screen co-ords, adjust inside the target window
 			if (!_isDrag)
 			{
+				// A previous drag that never reported its end - Windows can drop the modal move loop
+				// without a WM_EXITSIZEMOVE when a window crosses monitors of a different DPI - may still
+				// have an overlay window on screen. Clearing them here keeps them from accumulating into
+				// empty windows that only disappear with the application (issue #587).
+				_manager?.HideAllOverlayWindows();
 				GetOverlayWindowHosts();
 				_isDrag = true;
 			}
@@ -193,6 +198,10 @@ namespace AvalonDock.Controls
 			_currentWindow = null;
 			_currentHost = null;
 			_isDrag = false;
+
+			// The host tracked above is not necessarily the only one that has been asked to show an
+			// overlay window during this drag, so every host is cleared (issue #587).
+			_manager?.HideAllOverlayWindows();
 		}
 
 		/// <summary>
@@ -200,22 +209,31 @@ namespace AvalonDock.Controls
 		/// </summary>
 		internal void Abort()
 		{
-			var floatingWindowModel = _floatingWindow.Model as LayoutFloatingWindow;
-
-			_currentWindowAreas.ForEach(a => _currentWindow.DragLeave(a));
-
-			if (_currentDropTarget != null)
-				_currentWindow.DragLeave(_currentDropTarget);
-
+			// An abort also runs when the dragged window is closed while the drag is still in progress,
+			// where there may be no overlay window to leave any more (issue #587).
 			if (_currentWindow != null)
-				_currentWindow.DragLeave(_floatingWindow);
+			{
+				_currentWindowAreas.ForEach(a => _currentWindow.DragLeave(a));
 
+				if (_currentDropTarget != null)
+					_currentWindow.DragLeave(_currentDropTarget);
+
+				_currentWindow.DragLeave(_floatingWindow);
+			}
+
+			_currentWindowAreas.Clear();
+			_currentDropTarget = null;
 			_currentWindow = null;
 
 			if (_currentHost != null)
 				_currentHost.HideOverlayWindow();
 
 			_currentHost = null;
+			_isDrag = false;
+
+			// The host tracked above is not necessarily the only one that has been asked to show an
+			// overlay window during this drag, so every host is cleared (issue #587).
+			_manager?.HideAllOverlayWindows();
 		}
 
 		private void BringWindowToTop2(Window window)

--- a/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -152,10 +152,10 @@ namespace AvalonDock.Controls
 		void IOverlayWindowHost.HideOverlayWindow()
 		{
 			_dropAreas = null;
-			_overlayWindow.Owner = null;
-			_overlayWindow.HideDropTargets();
-			_overlayWindow.Close();
-			_overlayWindow = null;
+
+			// Hidden and kept for the next drag rather than closed, so that an interrupted drag cannot
+			// pile up empty windows (issue #587). It is closed together with this window in OnClosed.
+			_overlayWindow?.HideOverlay();
 		}
 
 		/// <inheritdoc/>
@@ -173,7 +173,11 @@ namespace AvalonDock.Controls
 			if (_dropAreas != null) return _dropAreas;
 			_dropAreas = new List<IDropArea>();
 			if (draggingWindow.Model is LayoutDocumentFloatingWindow) return _dropAreas;
-			var rootVisual = (Content as FloatingWindowContentHost).RootVisual;
+
+			// A window whose content has already been released offers nothing to drop onto (issue #587).
+			var rootVisual = (Content as FloatingWindowContentHost)?.RootVisual;
+			if (rootVisual == null) return _dropAreas;
+
 			foreach (var areaHost in rootVisual.FindVisualChildren<LayoutAnchorablePaneControl>())
 				_dropAreas.Add(new DropArea<LayoutAnchorablePaneControl>(areaHost, DropAreaType.AnchorablePane));
 			foreach (var areaHost in rootVisual.FindVisualChildren<LayoutDocumentPaneControl>())

--- a/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
@@ -254,10 +254,10 @@ namespace AvalonDock.Controls
 		public void HideOverlayWindow()
 		{
 			_dropAreas = null;
-			_overlayWindow.Owner = null;
-			_overlayWindow.HideDropTargets();
-			_overlayWindow.Close();
-			_overlayWindow = null;
+
+			// Hidden and kept for the next drag rather than closed, so that an interrupted drag cannot
+			// pile up empty windows (issue #587). It is closed together with this window in OnClosed.
+			_overlayWindow?.HideOverlay();
 		}
 
 		/// <summary>
@@ -286,7 +286,9 @@ namespace AvalonDock.Controls
 				}
 			}
 
-			var rootVisual = ((FloatingWindowContentHost)Content).RootVisual;
+			// A window whose content has already been released offers nothing to drop onto (issue #587).
+			var rootVisual = (Content as FloatingWindowContentHost)?.RootVisual;
+			if (rootVisual == null) return _dropAreas;
 
 			foreach (var areaHost in rootVisual.FindVisualChildren<LayoutAnchorablePaneControl>())
 				_dropAreas.Add(new DropArea<LayoutAnchorablePaneControl>(areaHost, DropAreaType.AnchorablePane));

--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -459,12 +459,7 @@ namespace AvalonDock.Controls
 					break;
 
 				case Win32Helper.WM_LBUTTONUP: // set as handled right button click on title area (after showing context menu)
-					if (_dragService != null && Mouse.LeftButton == MouseButtonState.Released)
-					{
-						_dragService.Abort();
-						_dragService = null;
-						SetIsDragging(false);
-					}
+					if (_dragService != null && Mouse.LeftButton == MouseButtonState.Released) AbortDrag();
 
 					break;
 
@@ -616,15 +611,26 @@ namespace AvalonDock.Controls
 			SizeChanged -= OnSizeChanged;
 			DetachDeferredOwnershipUpdate();
 			CancelDeferredShow();
-			if (Content != null)
+
+			// A drag that is still running would keep the overlay window of its current host on screen
+			// for the rest of the session, because the window that drives the drag is gone (issue #587).
+			AbortDrag();
+
+			if (Content is FloatingWindowContentHost contentHost)
 			{
-				(Content as FloatingWindowContentHost)?.Dispose();
-				if (_hwndSrc != null)
-				{
-					_hwndSrc.RemoveHook(_hwndSrcHook);
-					_hwndSrc.Dispose();
-					_hwndSrc = null;
-				}
+				contentHost.Dispose();
+
+				// Closing this window has already destroyed the native window hosting the content, so
+				// HwndHost skips DestroyWindowCore and neither the HwndSource nor the logical child that
+				// the DockingManager holds would ever be released (issue #587).
+				contentHost.ReleaseHostedContent();
+			}
+
+			if (_hwndSrc != null)
+			{
+				_hwndSrc.RemoveHook(_hwndSrcHook);
+				_hwndSrc.Dispose();
+				_hwndSrc = null;
 			}
 
 			base.OnClosed(e);
@@ -1090,6 +1096,24 @@ namespace AvalonDock.Controls
 		}
 
 		/// <summary>
+		/// Ends a drag operation that is still in progress without dropping anything.
+		/// </summary>
+		/// <remarks>
+		/// The overlay windows that the drag has put on screen belong to the drop target hosts, not to
+		/// this window, so they have to be taken down explicitly whenever a drag ends by any other means
+		/// than a regular drop (issue #587).
+		/// </remarks>
+		private void AbortDrag()
+		{
+			if (_dragService == null) return;
+
+			var dragService = _dragService;
+			_dragService = null;
+			dragService.Abort();
+			SetIsDragging(false);
+		}
+
+		/// <summary>
 		/// Enable bindings.
 		/// </summary>
 		public virtual void EnableBindings()
@@ -1190,6 +1214,10 @@ namespace AvalonDock.Controls
 			/// <inheritdoc/>
 			protected override HandleRef BuildWindowCore(HandleRef hwndParent)
 			{
+				// A rebuild must never orphan the native window of a previous build - its HWND would
+				// stay alive until the process ends (issue #587).
+				ReleaseHostedContent();
+
 				_wpfContentHost = new HwndSource(new HwndSourceParameters
 				{
 					ParentWindow = hwndParent.Handle,
@@ -1209,9 +1237,30 @@ namespace AvalonDock.Controls
 			}
 
 			/// <inheritdoc/>
-			protected override void DestroyWindowCore(HandleRef hwnd)
+			protected override void DestroyWindowCore(HandleRef hwnd) => ReleaseHostedContent();
+
+			/// <summary>
+			/// Releases the native window hosting the content of the floating window together with the
+			/// logical child that the <see cref="DockingManager"/> keeps on its behalf.
+			/// </summary>
+			/// <remarks>
+			/// <see cref="HwndHost"/> only calls <see cref="DestroyWindowCore"/> while the hosted window is
+			/// still alive. Closing a <see cref="Window"/> destroys its native window - and with it every
+			/// child window - before <see cref="Window.Closed"/> is raised, so that call is skipped and both
+			/// the <see cref="HwndSource"/> and the logical child would survive every floating window for
+			/// the rest of the session (issue #587). The clean up is therefore also driven explicitly by
+			/// the floating window when it has been closed, and is idempotent.
+			/// </remarks>
+			internal void ReleaseHostedContent()
 			{
-				_manager.InternalRemoveLogicalChild(_rootPresenter);
+				if (_rootPresenter != null)
+				{
+					_manager?.InternalRemoveLogicalChild(_rootPresenter);
+					_rootPresenter = null;
+				}
+
+				_manager = null;
+
 				if (_wpfContentHost == null) return;
 				_wpfContentHost.Dispose();
 				_wpfContentHost = null;

--- a/source/Components/AvalonDock/Controls/OverlayWindow.cs
+++ b/source/Components/AvalonDock/Controls/OverlayWindow.cs
@@ -202,6 +202,35 @@ namespace AvalonDock.Controls
 		}
 
 		/// <summary>
+		/// Takes this overlay window off the screen and discards the state of the drag operation it was
+		/// showing drop targets for.
+		/// </summary>
+		/// <remarks>
+		/// An overlay window is reused for every drag over its host instead of being closed and recreated,
+		/// so that an interrupted drag can never leave an ever growing number of empty, non interactive
+		/// windows behind (issue #587). Reuse requires the state of the previous drag to be dropped here.
+		/// </remarks>
+		internal void HideOverlay()
+		{
+			HideDropTargets();
+
+			if (_gridDockingManagerDropTargets != null)
+				_gridDockingManagerDropTargets.Visibility = System.Windows.Visibility.Hidden;
+			if (_gridAnchorablePaneDropTargets != null)
+				_gridAnchorablePaneDropTargets.Visibility = System.Windows.Visibility.Hidden;
+			if (_gridDocumentPaneDropTargets != null)
+				_gridDocumentPaneDropTargets.Visibility = System.Windows.Visibility.Hidden;
+			if (_gridDocumentPaneFullDropTargets != null)
+				_gridDocumentPaneFullDropTargets.Visibility = System.Windows.Visibility.Hidden;
+
+			// The reference to the dragged window is deliberately kept. The drag service hides this overlay
+			// window before it hands the drop over and before it leaves the drop areas again, and all of
+			// those steps still need to know which window is being dragged.
+			_visibleAreas.Clear();
+			Hide();
+		}
+
+		/// <summary>
 		/// Sets the set Drop Target Into Visibility.
 		/// </summary>
 		/// <param name="positionableElement">The positionable Element.</param>

--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -1858,10 +1858,28 @@ namespace AvalonDock
 		void IOverlayWindowHost.HideOverlayWindow()
 		{
 			_areas = null;
-			_overlayWindow.Owner = null;
-			_overlayWindow.HideDropTargets();
-			_overlayWindow.Close();
-			_overlayWindow = null;
+
+			// The overlay window is hidden and kept for the next drag instead of being closed, so that a
+			// drag which never reports its end cannot leave a growing number of empty windows behind
+			// (issue #587). It is closed together with this manager in DestroyOverlayWindow.
+			_overlayWindow?.HideOverlay();
+		}
+
+		/// <summary>
+		/// Takes every overlay window of this manager and of its floating windows off the screen.
+		/// </summary>
+		/// <remarks>
+		/// A drag ends by a message of the window being dragged, and that message does not always arrive -
+		/// a drag across monitors of different DPI can end the modal move loop of Windows without one.
+		/// Every start and every end of a drag therefore clears the overlay windows of all hosts, and not
+		/// only the one of the host the drag happens to know about (issue #587).
+		/// </remarks>
+		internal void HideAllOverlayWindows()
+		{
+			((IOverlayWindowHost)this).HideOverlayWindow();
+
+			foreach (var host in _fwList.OfType<IOverlayWindowHost>().ToArray())
+				host.HideOverlayWindow();
 		}
 
 		/// <inheritdoc/>


### PR DESCRIPTION
Fixes #587
Dragging an anchorable out into a floating window left an empty, borderless window behind on a mixed-DPI multi-monitor setup, and one more with every float. They could not be closed individually and only went away with the application.

Those windows are OverlayWindows: every drop target host - the DockingManager and each floating window - puts one over its own area while a drag is running and shows the docking indicators in it. It was created per drag and closed again when the drag reported its end. A drag reports its end through a window message of the window being dragged, and that message does not always arrive: moving a window between monitors with different DPI scaling can end the modal move loop of Windows without one. Every such drag then left its overlay window on screen for the rest of the session - transparent, owned by the main window, and swallowing the clicks that landed on the area it covered.

Each host now keeps one overlay window and hides and shows it again instead of recreating it, so an overlay window is only ever destroyed together with the host it belongs to and can no longer accumulate. In addition every start and every end of a drag clears the overlay windows of all hosts, not only of the one the drag service happens to know about, and closing a floating window while it is still being dragged aborts that drag.

Also releases the resources a closed floating window used to keep. HwndHost only calls DestroyWindowCore while the hosted window is still alive, and closing a Window destroys its native window - and with it every child window - before Closed is raised, so the HwndSource hosting the content and the logical child registered with the DockingManager were never released. The clean up is now driven explicitly by the floating window and is idempotent.