### PR TITLE
[Feature] - [DockingManager] Add switches to turn floating and window creation on or off

### DIFF
--- a/docs/api-reference/docking-manager.md
+++ b/docs/api-reference/docking-manager.md
@@ -55,6 +55,8 @@ System.Windows.Controls.Control
 | Property | Type | Description |
 |:---------|:-----|:------------|
 | `AllowMixedOrientation` | `bool` | Allow panels with mixed horizontal/vertical orientation. |
+| `AllowFloatingWindows` | `bool` | Whether content can be torn off into floating windows at all. Default `true`. See [Floating Windows]({% link concepts/floating-windows.md %}). |
+| `AllowDetachedWindows` | `bool` | Whether anchorables can be moved into standalone top level windows ("Window" view mode). Default `true`. |
 | `ShowSystemMenu` | `bool` | Show system menu on floating windows. |
 | `AllowDrop` | `bool` | Enable drag-and-drop docking (inherited from WPF). |
 | `AutoHideDelay` | `int` | Delay in milliseconds before an auto-hidden tool window slides shut. |
@@ -73,6 +75,7 @@ System.Windows.Controls.Control
 | Method | Returns | Description |
 |:-------|:--------|:------------|
 | `GetFloatingWindows()` | `IEnumerable<LayoutFloatingWindowControl>` | Get all active floating windows. |
+| `DockAllFloatingWindows()` | `void` | Dock the content of every floating window back into the layout and close the windows. |
 | `DetachAnchorableToWindow(anchorable)` | `void` | Move the content of an anchorable into a standalone top level window. See [Floating Windows]({% link concepts/floating-windows.md %}). |
 | `ReattachAnchorable(anchorable)` | `void` | Close that window and return the content to the layout. |
 | `ReattachAllDetachedAnchorables()` | `void` | Return every detached anchorable to the layout. |

--- a/docs/concepts/floating-windows.md
+++ b/docs/concepts/floating-windows.md
@@ -50,6 +50,89 @@ Set `CanFloat` to `false` on any content to prevent it from being floated:
 </avalonDock:LayoutAnchorable>
 ```
 
+### Turn Floating Off Entirely
+
+{: .new }
+> New in v5.0.0
+
+`CanFloat` is a decision per piece of content. `DockingManager.AllowFloatingWindows` is the switch for
+the whole feature — an application that wants a fixed layout, or one that manages its own windows,
+turns it off once:
+
+```xml
+<avalonDock:DockingManager AllowFloatingWindows="False" />
+```
+
+While it is `False`:
+
+- dragging a tab or a tool window title out of its pane does nothing,
+- the **Float** menu entry and `LayoutItem.FloatCommand` report themselves as unavailable, so the
+  entry is greyed out rather than silently doing nothing,
+- `LayoutContent.Float()` and `DockingManager.CreateFloatingWindow(...)` create no window — the latter
+  returns `null`,
+- a layout that is loaded with floating windows in it has that content docked back, so restoring a
+  layout saved while floating was allowed is not a way around the setting.
+
+Setting it to `False` while floating windows are open docks their content back where it came from.
+Turning it on again does not reopen them.
+
+`DockAllFloatingWindows()` performs that dock-back on its own, which is useful for a "reset windows"
+menu entry even when floating stays allowed.
+
+### Turn Standalone Windows Off
+
+`DockingManager.AllowDetachedWindows` does the same for the standalone "Window" view mode described
+[below](#standalone-windows-window-view-mode):
+
+```xml
+<avalonDock:DockingManager AllowDetachedWindows="False" />
+```
+
+While it is `False`, `DetachAnchorableToWindow` does nothing, `DetachToWindowCommand` is unavailable
+so the **View Mode → Window** entry is disabled, and a layout that was saved with a detached tool
+window is restored with that window docked. Setting it to `False` returns anchorables that are
+already in standalone windows.
+
+The two switches are independent: floating windows can be allowed while standalone windows are not,
+and the other way round.
+
+### MVVM and Dependency Injection
+
+Both switches are also on the MVVM layout, so an application that builds its layout from view models
+never has to reach into the view:
+
+```csharp
+dockService.Layout.AllowFloatingWindows = false;
+dockService.Layout.AllowDetachedWindows = false;
+```
+
+`IRootDock` carries them and the `DockingManager` follows the layout it is bound to through
+`DockLayout`, including later changes.
+
+{: .warning }
+> The layout wins. Binding `DockLayout` applies the layout's values to the manager, so a
+> `DockingManager` that sets `AllowFloatingWindows="False"` in XAML *and* binds a `DockLayout` whose
+> root dock leaves it at the default has floating switched back on. Set the switches in one place —
+> either on the manager or on the layout, not both.
+
+With `AvalonDock.DependencyInjection` they are part of the registration, and are applied to the layout
+for you:
+
+```csharp
+services.AddDockLayoutService(dock =>
+{
+    dock.AddToolbox<ExplorerViewModel>();
+    dock.ConfigureDocking(o =>
+    {
+        o.AllowFloatingWindows = false;
+        o.AllowDetachedWindows = false;
+    });
+});
+```
+
+`ToggleDockOptions` derives from `DockingOptions`, so an application configuring the toggle docking
+manager sets them on that same options object via `ConfigureToggleDock`.
+
 ### Float Programmatically
 
 ```csharp
@@ -157,6 +240,7 @@ the content to the layout.
 | `ReattachAllDetachedAnchorables()` | `void` | Returns every detached anchorable. |
 | `IsDetached(anchorable)` | `bool` | Whether that anchorable is currently in a standalone window. |
 | `DetachedAnchorables` | `IEnumerable<LayoutAnchorable>` | The anchorables currently in standalone windows. |
+| `AllowDetachedWindows` | `bool` | Whether the mode is available at all. See [Turn Standalone Windows Off](#turn-standalone-windows-off). |
 
 ### What Happens to the Layout
 

--- a/docs/guides/dependency-injection.md
+++ b/docs/guides/dependency-injection.md
@@ -38,6 +38,7 @@ Used inside the `AddDockLayoutService(dock => { ... })` builder:
 
 | Method | Purpose |
 |:-------|:--------|
+| `ConfigureDocking(configure)` | Configure manager-wide behavior: whether floating windows and standalone windows are available |
 | `ConfigureToggleDock(configure)` | Configure sidebar button size, dock dimensions, layout priority |
 | `AddToolbox<T>()` | Register a toolbox VM as singleton |
 | `AddToolbox<T>(factory)` | Register a toolbox VM with a custom factory |
@@ -114,6 +115,37 @@ services.AddDockLayoutService(dock =>
 ```
 
 If `ConfigureToggleDock` is not called, default `ToggleDockOptions` are registered automatically.
+
+### DockingOptions
+
+{: .new }
+> New in v5.0.0
+
+`ToggleDockOptions` derives from `DockingOptions`, which carries the switches that apply to any
+docking manager. Configure them with `ConfigureDocking` — or on the same options object through
+`ConfigureToggleDock`, since both configure methods share one instance:
+
+```csharp
+services.AddDockLayoutService(dock =>
+{
+    dock.ConfigureDocking(o =>
+    {
+        o.AllowFloatingWindows = false;   // No tear-off into floating windows
+        o.AllowDetachedWindows = false;   // No standalone "Window" view mode
+    });
+});
+```
+
+| Option | Type | Default | Description |
+|:-------|:-----|:--------|:------------|
+| `AllowFloatingWindows` | `bool` | `true` | Whether content can be torn off into floating windows. |
+| `AllowDetachedWindows` | `bool` | `true` | Whether anchorables can be moved into standalone top level windows. |
+
+These are applied to the layout of `IDockLayoutService`, so a `DockingManager` bound to that layout
+through `DockLayout` picks them up on its own — nothing has to be copied over in the code-behind of
+the window. Both `DockingOptions` and `ToggleDockOptions` resolve to the same registered instance.
+
+See [Floating Windows]({% link concepts/floating-windows.md %}) for what each switch turns off.
 
 ### Layout Priority Modes
 

--- a/docs/guides/mvvm.md
+++ b/docs/guides/mvvm.md
@@ -208,6 +208,24 @@ public partial class MainViewModel : ObservableObject
 
 See [ToggleDockingManager]({% link guides/toggle-docking-manager.md %}) for the full guide on zones, button customization, and layout priority.
 
+### Window Policy from the Layout
+
+{: .new }
+> New in v5.0.0
+
+`IRootDock` carries the two manager-wide window switches, so an application decides them in the view
+model rather than in the view:
+
+```csharp
+dockService.Layout.AllowFloatingWindows = false;   // No tear-off into floating windows
+dockService.Layout.AllowDetachedWindows = false;   // No standalone "Window" view mode
+```
+
+A `DockingManager` bound through `DockLayout` applies them when the layout is bound and follows any
+later change. With `AvalonDock.DependencyInjection` you can set them at registration instead — see
+[Dependency Injection]({% link guides/dependency-injection.md %}). For what each switch turns off, see
+[Floating Windows]({% link concepts/floating-windows.md %}).
+
 ---
 
 ## Classic Approach: DocumentsSource + AnchorablesSource

--- a/docs/migration/breaking-changes.md
+++ b/docs/migration/breaking-changes.md
@@ -56,6 +56,20 @@ The layout calculation logic has been formalized behind the `ILayoutEngine` inte
 | **Affected** | Custom layout calculations using internal APIs |
 | **Fix** | Implement `ILayoutEngine` for custom layout behavior. |
 
+### Window Policy Members on Core Interfaces
+
+**Impact:** Low — only affects custom implementations of the core interfaces.
+
+`IDockingManager` and `IRootDock` each gained `AllowFloatingWindows` and `AllowDetachedWindows`. The
+shipped implementations (`DockingManager`, `AvalonDock.Mvvm.RootDock`) provide them; a hand-written
+implementation of either interface has to add them.
+
+| Change | Details |
+|:-------|:--------|
+| **Added** | `IDockingManager.AllowFloatingWindows`, `IDockingManager.AllowDetachedWindows` |
+| **Added** | `IRootDock.AllowFloatingWindows`, `IRootDock.AllowDetachedWindows` |
+| **Fix** | Add both `bool` properties, defaulting to `true` to keep the previous behavior. |
+
 ---
 
 ## Target Framework Changes
@@ -103,6 +117,7 @@ These additions are new in v5.0.0 and do not break existing code:
 |:--------|:--------|:------------|
 | ToggleDockingManager | `AvalonDock` | VS Code / Rider-style sidebar with toggle buttons. |
 | Standalone Windows | `AvalonDock` | `DetachAnchorableToWindow` moves a tool window into an ordinary top level window with its own taskbar entry ("Window" view mode). Survives layout serialization. |
+| Window Policy | `AvalonDock` | `DockingManager.AllowFloatingWindows` and `AllowDetachedWindows` turn floating windows and the standalone "Window" view mode off for the whole manager. Also on `IRootDock` (MVVM) and `DockingOptions` (DI). |
 | Toolbox Shortcuts | `AvalonDock` | `IToolbox.Shortcut` registers a key binding that toggles the toolbox and shows up in its tooltip. |
 | Arc Theme | `AvalonDock.Themes.Arc` | Modern theme with dark/light variants. |
 | VS Themes | `AvalonDock.Themes.VS` | `.vstheme` based Visual Studio themes with VS2015, VS2022 and VS2026 variants, plus loading of custom theme files. |
@@ -208,6 +223,7 @@ on read, so existing layout files still load.
 | Packages | Serializers separated | High | Install serializer package |
 | Namespaces | Serializer namespace moved | High | Update `using` statements |
 | Architecture | `ILayoutEngine` added | Low | No action for default behavior |
+| Architecture | Window policy members on `IDockingManager` / `IRootDock` | Low | Add both properties to custom implementations |
 | Frameworks | .NET < 4.8 dropped | High | Upgrade target framework |
 | Frameworks | .NET Core 3.x / 5 dropped | High | Upgrade target framework |
 | Themes | Arc theme added | None | Optional adoption |

--- a/source/AutomationTest/AvalonDockTest/DependencyInjectionTests.cs
+++ b/source/AutomationTest/AvalonDockTest/DependencyInjectionTests.cs
@@ -161,6 +161,120 @@ namespace AvalonDockTest
 			Assert.That(options.DefaultDockHeight, Is.EqualTo(200));
 		}
 
+		/// <summary>
+		/// Configuring a builder registers the options, even when the builder is driven directly rather
+		/// than through <c>AddDockLayoutService</c>.
+		/// </summary>
+		/// <remarks>
+		/// <see cref="DockLayoutBuilder"/> is public and has a public constructor, so this has to keep
+		/// working the way it did before the options object was shared between the configure methods.
+		/// </remarks>
+		[Test]
+		public void DockLayoutBuilder_UsedDirectly_ConfigureToggleDock_RegistersOptions()
+		{
+			var services = new ServiceCollection();
+			var builder = new DockLayoutBuilder(services);
+
+			builder.ConfigureToggleDock(opts => opts.ButtonSize = 42);
+
+			var provider = services.BuildServiceProvider();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(provider.GetRequiredService<ToggleDockOptions>().ButtonSize, Is.EqualTo(42));
+				Assert.That(provider.GetRequiredService<DockingOptions>(), Is.SameAs(provider.GetRequiredService<ToggleDockOptions>()));
+			});
+		}
+
+		[Test]
+		public void AddDockLayoutService_Builder_ConfigureToggleDock_RegistersOptionsOnlyOnce()
+		{
+			var services = new ServiceCollection();
+			services.AddDockLayoutService(dock =>
+			{
+				dock.ConfigureToggleDock(opts => opts.ButtonSize = 32);
+				dock.ConfigureDocking(o => o.AllowFloatingWindows = false);
+			});
+
+			var provider = services.BuildServiceProvider();
+
+			// Both configure calls plus AddDockLayoutService feed one instance, so resolving the whole
+			// set has to come back with exactly that one.
+			Assert.That(provider.GetServices<ToggleDockOptions>().Count(), Is.EqualTo(1));
+		}
+
+		[Test]
+		public void AddDockLayoutService_Builder_ConfigureDocking_AppliesWindowPolicyToLayout()
+		{
+			var services = new ServiceCollection();
+			services.AddDockLayoutService(dock =>
+			{
+				dock.AddToolbox<DiTestToolbox>();
+				dock.ConfigureDocking(o =>
+				{
+					o.AllowFloatingWindows = false;
+					o.AllowDetachedWindows = false;
+				});
+			});
+
+			var provider = services.BuildServiceProvider();
+			var options = provider.GetRequiredService<DockingOptions>();
+			var layout = provider.GetRequiredService<IDockLayoutService>().Layout;
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(options.AllowFloatingWindows, Is.False);
+				Assert.That(options.AllowDetachedWindows, Is.False);
+
+				// The layout is what a DockingManager binds to, so this is what makes the options take
+				// effect without any code in the window.
+				Assert.That(layout.AllowFloatingWindows, Is.False);
+				Assert.That(layout.AllowDetachedWindows, Is.False);
+			});
+		}
+
+		[Test]
+		public void AddDockLayoutService_Builder_ConfigureToggleDock_SharesTheDockingOptions()
+		{
+			var services = new ServiceCollection();
+			services.AddDockLayoutService(dock =>
+			{
+				dock.ConfigureToggleDock(opts =>
+				{
+					opts.ButtonSize = 32;
+					opts.AllowFloatingWindows = false;
+				});
+			});
+
+			var provider = services.BuildServiceProvider();
+			var toggleOptions = provider.GetRequiredService<ToggleDockOptions>();
+			var dockingOptions = provider.GetRequiredService<DockingOptions>();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(dockingOptions, Is.SameAs(toggleOptions),
+					"Both types have to resolve to one object, or the two configure calls would disagree.");
+				Assert.That(toggleOptions.AllowFloatingWindows, Is.False);
+				Assert.That(toggleOptions.AllowDetachedWindows, Is.True);
+			});
+		}
+
+		[Test]
+		public void AddDockLayoutService_Builder_WithoutConfiguring_LeavesBothWindowKindsAvailable()
+		{
+			var services = new ServiceCollection();
+			services.AddDockLayoutService(dock => dock.AddToolbox<DiTestToolbox>());
+
+			var provider = services.BuildServiceProvider();
+			var layout = provider.GetRequiredService<IDockLayoutService>().Layout;
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(layout.AllowFloatingWindows, Is.True);
+				Assert.That(layout.AllowDetachedWindows, Is.True);
+			});
+		}
+
 		[Test]
 		public void AddDockLayoutService_Builder_ReturnsSameServiceCollection_ForChaining()
 		{
@@ -600,6 +714,8 @@ namespace AvalonDockTest
 		public int AutoHideDelay { get; set; }
 		public bool SupportsAutoHideFlyout => true;
 		public bool AllowMixedOrientation { get; set; }
+		public bool AllowFloatingWindows { get; set; } = true;
+		public bool AllowDetachedWindows { get; set; } = true;
 		public ISerializableLayoutRoot? Layout
 		{
 			get => null;

--- a/source/AutomationTest/AvalonDockTest/FactoryBaseTests.cs
+++ b/source/AutomationTest/AvalonDockTest/FactoryBaseTests.cs
@@ -71,6 +71,8 @@ namespace AvalonDockTest
 		public IList<IDockable>? FloatingDockables { get; set; }
 		public IList<IDockable>? PinnedDockables { get; set; }
 		public IDockable? DefaultLayout { get; set; }
+		public bool AllowFloatingWindows { get; set; } = true;
+		public bool AllowDetachedWindows { get; set; } = true;
 		public void ShowWindows() { }
 		public void HideWindows() { }
 	}

--- a/source/AutomationTest/AvalonDockTest/MvvmTests.cs
+++ b/source/AutomationTest/AvalonDockTest/MvvmTests.cs
@@ -276,6 +276,33 @@ namespace AvalonDockTest
 		}
 
 		[Test]
+		public void RootDock_AllowsBothWindowKinds_ByDefault()
+		{
+			var root = new RootDock();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(root.AllowFloatingWindows, Is.True);
+				Assert.That(root.AllowDetachedWindows, Is.True);
+			});
+		}
+
+		[Test]
+		public void RootDock_WindowPolicy_RaisesPropertyChanged()
+		{
+			var root = new RootDock();
+			var changed = new List<string?>();
+			root.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+			root.AllowFloatingWindows = false;
+			root.AllowDetachedWindows = false;
+
+			// The docking manager listens for these to follow the layout while it stays bound.
+			Assert.That(changed, Does.Contain(nameof(RootDock.AllowFloatingWindows)));
+			Assert.That(changed, Does.Contain(nameof(RootDock.AllowDetachedWindows)));
+		}
+
+		[Test]
 		public void Factory_CreateRootDock_ReturnsRootDock()
 		{
 			var factory = new Factory();

--- a/source/AutomationTest/AvalonDockTest/WindowPolicyTests.cs
+++ b/source/AutomationTest/AvalonDockTest/WindowPolicyTests.cs
@@ -1,0 +1,528 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using AvalonDock;
+using AvalonDock.Layout;
+using AvalonDockTest.TestHelpers;
+using NUnit.Framework;
+using UnitTests;
+
+namespace AvalonDockTest;
+
+/// <summary>
+/// Covers the two manager wide switches that take floating windows and standalone windows away from
+/// the user: <see cref="DockingManager.AllowFloatingWindows"/> and
+/// <see cref="DockingManager.AllowDetachedWindows"/>.
+/// </summary>
+/// <remarks>
+/// Both are meant to be absolute - an application that turns them off must not be able to end up with
+/// such a window through any route, including loading a layout that was saved while they were still
+/// allowed. That last case is what the restore tests here pin down.
+/// </remarks>
+[TestFixture]
+[Apartment(ApartmentState.STA)]
+public class WindowPolicyTests : AutomationTestBase
+{
+	/// <summary>Both switches are on unless the application says otherwise.</summary>
+	[Test]
+	public void Defaults_AllowBothWindowKinds()
+	{
+		var allowFloating = false;
+		var allowDetached = false;
+
+		var failure = RunOnStaThread(() =>
+		{
+			var manager = new DockingManager();
+			allowFloating = manager.AllowFloatingWindows;
+			allowDetached = manager.AllowDetachedWindows;
+		});
+
+		Assert.That(failure, Is.Null, failure?.ToString());
+		Assert.Multiple(() =>
+		{
+			Assert.That(allowFloating, Is.True, "Floating has to stay available by default.");
+			Assert.That(allowDetached, Is.True, "Standalone windows have to stay available by default.");
+		});
+	}
+
+	/// <summary>Floating an anchorable does nothing while floating is switched off.</summary>
+	[Test]
+	public void FloatingDisabled_FloatCreatesNoWindow()
+	{
+		var floatingWindows = -1;
+		var stillDocked = false;
+
+		var failure = RunOnStaThread(() =>
+		{
+			var manager = CreateManager(out var anchorable);
+			manager.AllowFloatingWindows = false;
+
+			var host = HostInWindow(manager);
+			try
+			{
+				anchorable.Float();
+				Pump();
+
+				floatingWindows = manager.FloatingWindows.Count();
+				stillDocked = anchorable.FindParent<LayoutFloatingWindow>() == null;
+			}
+			finally
+			{
+				host.Close();
+			}
+		});
+
+		Assert.That(failure, Is.Null, failure?.ToString());
+		Assert.Multiple(() =>
+		{
+			Assert.That(floatingWindows, Is.Zero, "No floating window may be created while floating is off.");
+			Assert.That(stillDocked, Is.True, "The anchorable has to stay where it was docked.");
+		});
+	}
+
+	/// <summary>The factory method reports the refusal rather than handing out a window.</summary>
+	[Test]
+	public void FloatingDisabled_CreateFloatingWindowReturnsNull()
+	{
+		object? created = new object();
+
+		var failure = RunOnStaThread(() =>
+		{
+			var manager = CreateManager(out var anchorable);
+			manager.AllowFloatingWindows = false;
+
+			var host = HostInWindow(manager);
+			try
+			{
+				created = manager.CreateFloatingWindow(anchorable, false);
+			}
+			finally
+			{
+				host.Close();
+			}
+		});
+
+		Assert.That(failure, Is.Null, failure?.ToString());
+		Assert.That(created, Is.Null, "CreateFloatingWindow has to refuse while floating is off.");
+	}
+
+	/// <summary>
+	/// Switching floating off docks the windows that are already open, even when the pane the content
+	/// came from is long gone.
+	/// </summary>
+	/// <remarks>
+	/// Floating the only anchorable of a pane leaves that pane empty, and garbage collection removes it
+	/// along with the record of where the content belongs. What is left has to end up in the layout all
+	/// the same, and not back in the window it is being taken out of.
+	/// </remarks>
+	[Test]
+	public void DisablingFloating_DocksOpenFloatingWindowsBack()
+	{
+		var floatingWhileAllowed = -1;
+		var floatingAfterDisabling = -1;
+		var backInLayout = false;
+
+		var failure = RunOnStaThread(() =>
+		{
+			var manager = CreateManager(out var anchorable);
+			var host = HostInWindow(manager);
+			try
+			{
+				anchorable.Float();
+				Pump();
+				floatingWhileAllowed = manager.FloatingWindows.Count();
+
+				manager.AllowFloatingWindows = false;
+				Pump();
+
+				floatingAfterDisabling = manager.FloatingWindows.Count();
+				backInLayout = anchorable.FindParent<LayoutFloatingWindow>() == null
+					&& anchorable.Root == manager.Layout;
+			}
+			finally
+			{
+				host.Close();
+			}
+		});
+
+		Assert.That(failure, Is.Null, failure?.ToString());
+		Assert.Multiple(() =>
+		{
+			Assert.That(floatingWhileAllowed, Is.EqualTo(1), "Floating should have produced one window.");
+			Assert.That(floatingAfterDisabling, Is.Zero, "Switching floating off has to close the open windows.");
+			Assert.That(backInLayout, Is.True, "The content has to end up in the layout, not be lost with the window.");
+		});
+	}
+
+	/// <summary>
+	/// Content that still knows the pane it was floated from is returned to exactly that pane.
+	/// </summary>
+	/// <remarks>
+	/// The counterpart of <see cref="DisablingFloating_DocksOpenFloatingWindowsBack"/>: a pane that keeps
+	/// a second anchorable survives the float, so the record of where the floated one belongs survives
+	/// with it and has to be honoured rather than the content being dropped somewhere plausible.
+	/// </remarks>
+	[Test]
+	public void DisablingFloating_ReturnsContentToThePaneItCameFrom()
+	{
+		var floatingAfterDisabling = -1;
+		var backInOriginalPane = false;
+
+		var failure = RunOnStaThread(() =>
+		{
+			var layout = BuildLayoutWithTwoAnchorables(out var floated, out var stays);
+			var manager = new DockingManager { Layout = layout };
+			var host = HostInWindow(manager);
+			try
+			{
+				var originalPane = floated.Parent;
+
+				floated.Float();
+				Pump();
+
+				manager.AllowFloatingWindows = false;
+				Pump();
+
+				floatingAfterDisabling = manager.FloatingWindows.Count();
+				backInOriginalPane = ReferenceEquals(floated.Parent, originalPane)
+					&& ReferenceEquals(stays.Parent, originalPane);
+			}
+			finally
+			{
+				host.Close();
+			}
+		});
+
+		Assert.That(failure, Is.Null, failure?.ToString());
+		Assert.Multiple(() =>
+		{
+			Assert.That(floatingAfterDisabling, Is.Zero, "Switching floating off has to close the open windows.");
+			Assert.That(backInOriginalPane, Is.True, "The content has to return to the pane it was floated from.");
+		});
+	}
+
+	/// <summary>A layout carrying floating windows is docked flat when floating is off.</summary>
+	/// <remarks>
+	/// Restoring a layout saved before the switch was turned off would otherwise be a way around it.
+	/// </remarks>
+	[Test]
+	public void FloatingDisabled_LoadedLayoutWithFloatingWindowsIsDocked()
+	{
+		var floatingWindows = -1;
+		var floatingModels = -1;
+
+		var failure = RunOnStaThread(() =>
+		{
+			var manager = new DockingManager { AllowFloatingWindows = false };
+			var host = HostInWindow(manager);
+			try
+			{
+				manager.Layout = BuildLayoutWithFloatingAnchorable();
+				Pump();
+
+				floatingWindows = manager.FloatingWindows.Count();
+				floatingModels = manager.Layout.FloatingWindows.Count;
+			}
+			finally
+			{
+				host.Close();
+			}
+		});
+
+		Assert.That(failure, Is.Null, failure?.ToString());
+		Assert.Multiple(() =>
+		{
+			Assert.That(floatingWindows, Is.Zero, "No window may be created for a restored floating layout.");
+			Assert.That(floatingModels, Is.Zero, "The restored floating windows have to be docked away.");
+		});
+	}
+
+	/// <summary>Detaching an anchorable does nothing while standalone windows are switched off.</summary>
+	[Test]
+	public void DetachedWindowsDisabled_DetachDoesNothing()
+	{
+		var detached = true;
+		var openWindows = -1;
+
+		var failure = RunOnStaThread(() =>
+		{
+			var manager = CreateManager(out var anchorable);
+			manager.AllowDetachedWindows = false;
+
+			var host = HostInWindow(manager);
+			try
+			{
+				manager.DetachAnchorableToWindow(anchorable);
+				Pump();
+
+				detached = manager.IsDetached(anchorable);
+				openWindows = manager.DetachedAnchorables.Count();
+			}
+			finally
+			{
+				manager.ReattachAllDetachedAnchorables();
+				host.Close();
+			}
+		});
+
+		Assert.That(failure, Is.Null, failure?.ToString());
+		Assert.Multiple(() =>
+		{
+			Assert.That(detached, Is.False, "The anchorable must not be marked detached.");
+			Assert.That(openWindows, Is.Zero, "No standalone window may be opened.");
+		});
+	}
+
+	/// <summary>Switching standalone windows off returns the ones that are already open.</summary>
+	[Test]
+	public void DisablingDetachedWindows_ReattachesOpenWindows()
+	{
+		var detachedWhileAllowed = false;
+		var detachedAfterDisabling = true;
+		var openWindows = -1;
+
+		var failure = RunOnStaThread(() =>
+		{
+			var manager = CreateManager(out var anchorable);
+			var host = HostInWindow(manager);
+			try
+			{
+				manager.DetachAnchorableToWindow(anchorable);
+				Pump();
+				detachedWhileAllowed = manager.IsDetached(anchorable);
+
+				manager.AllowDetachedWindows = false;
+				Pump();
+
+				detachedAfterDisabling = manager.IsDetached(anchorable);
+				openWindows = manager.DetachedAnchorables.Count();
+			}
+			finally
+			{
+				manager.ReattachAllDetachedAnchorables();
+				host.Close();
+			}
+		});
+
+		Assert.That(failure, Is.Null, failure?.ToString());
+		Assert.Multiple(() =>
+		{
+			Assert.That(detachedWhileAllowed, Is.True, "The anchorable should be detached to begin with.");
+			Assert.That(detachedAfterDisabling, Is.False, "Switching the mode off has to return the anchorable.");
+			Assert.That(openWindows, Is.Zero, "Switching the mode off has to close the standalone windows.");
+		});
+	}
+
+	/// <summary>A layout that asks for standalone windows is restored docked when they are off.</summary>
+	[Test]
+	public void DetachedWindowsDisabled_RestoredLayoutStaysDocked()
+	{
+		var openWindows = -1;
+		var stillFlagged = true;
+
+		var failure = RunOnStaThread(() =>
+		{
+			var manager = new DockingManager { AllowDetachedWindows = false };
+			var host = HostInWindow(manager);
+			try
+			{
+				var layout = BuildLayout(out var anchorable);
+				anchorable.IsDetached = true;
+
+				manager.Layout = layout;
+				Pump();
+
+				openWindows = manager.DetachedAnchorables.Count();
+				stillFlagged = anchorable.IsDetached;
+			}
+			finally
+			{
+				manager.ReattachAllDetachedAnchorables();
+				host.Close();
+			}
+		});
+
+		Assert.That(failure, Is.Null, failure?.ToString());
+		Assert.Multiple(() =>
+		{
+			Assert.That(openWindows, Is.Zero, "A saved standalone window must not be recreated while the mode is off.");
+			Assert.That(stillFlagged, Is.False, "The model must not keep claiming to be detached without a window.");
+		});
+	}
+
+	/// <summary>The MVVM layout decides the policy for the manager it is bound to.</summary>
+	[Test]
+	public void DockLayout_PushesWindowPolicyToTheManager()
+	{
+		var allowFloatingAfterBinding = true;
+		var allowDetachedAfterBinding = true;
+		var allowFloatingAfterChange = false;
+
+		var failure = RunOnStaThread(() =>
+		{
+			var manager = new DockingManager();
+			var host = HostInWindow(manager);
+			try
+			{
+				var root = new AvalonDock.Mvvm.RootDock
+				{
+					Id = "Root",
+					AllowFloatingWindows = false,
+					AllowDetachedWindows = false,
+				};
+
+				manager.DockLayout = root;
+				Pump();
+
+				allowFloatingAfterBinding = manager.AllowFloatingWindows;
+				allowDetachedAfterBinding = manager.AllowDetachedWindows;
+
+				root.AllowFloatingWindows = true;
+				Pump();
+
+				allowFloatingAfterChange = manager.AllowFloatingWindows;
+			}
+			finally
+			{
+				host.Close();
+			}
+		});
+
+		Assert.That(failure, Is.Null, failure?.ToString());
+		Assert.Multiple(() =>
+		{
+			Assert.That(allowFloatingAfterBinding, Is.False, "Binding a layout has to apply its floating policy.");
+			Assert.That(allowDetachedAfterBinding, Is.False, "Binding a layout has to apply its standalone window policy.");
+			Assert.That(allowFloatingAfterChange, Is.True, "A later change of the layout has to reach the manager too.");
+		});
+	}
+
+	/// <summary>Builds a layout holding a single dockable anchorable.</summary>
+	/// <param name="anchorable">Receives the anchorable in the layout.</param>
+	/// <returns>The layout root.</returns>
+	private static LayoutRoot BuildLayout(out LayoutAnchorable anchorable)
+	{
+		anchorable = new LayoutAnchorable { Title = "Tool", ContentId = "tool", Content = new Grid() };
+
+		var pane = new LayoutAnchorablePane(anchorable);
+		var panel = new LayoutPanel { Orientation = Orientation.Horizontal };
+		panel.Children.Add(new LayoutAnchorablePaneGroup(pane));
+
+		return new LayoutRoot { RootPanel = panel };
+	}
+
+	/// <summary>
+	/// Builds a layout with two anchorables in one pane, so that floating one of them leaves the pane
+	/// standing and the record of where it belongs intact.
+	/// </summary>
+	/// <param name="floated">Receives the anchorable the test floats.</param>
+	/// <param name="stays">Receives the anchorable that keeps the pane alive.</param>
+	/// <returns>The layout root.</returns>
+	private static LayoutRoot BuildLayoutWithTwoAnchorables(out LayoutAnchorable floated, out LayoutAnchorable stays)
+	{
+		floated = new LayoutAnchorable { Title = "Floated", ContentId = "floated", Content = new Grid() };
+		stays = new LayoutAnchorable { Title = "Stays", ContentId = "stays", Content = new Grid() };
+
+		var pane = new LayoutAnchorablePane(floated);
+		pane.Children.Add(stays);
+
+		var panel = new LayoutPanel { Orientation = Orientation.Horizontal };
+		panel.Children.Add(new LayoutAnchorablePaneGroup(pane));
+
+		return new LayoutRoot { RootPanel = panel };
+	}
+
+	/// <summary>
+	/// Builds a layout whose anchorable sits in a floating window, the shape a layout saved with a
+	/// floating tool window has.
+	/// </summary>
+	/// <returns>The layout root.</returns>
+	private static LayoutRoot BuildLayoutWithFloatingAnchorable()
+	{
+		var docked = new LayoutAnchorable { Title = "Docked", ContentId = "docked", Content = new Grid() };
+		var panel = new LayoutPanel { Orientation = Orientation.Horizontal };
+		panel.Children.Add(new LayoutAnchorablePaneGroup(new LayoutAnchorablePane(docked)));
+
+		var layout = new LayoutRoot { RootPanel = panel };
+
+		var floated = new LayoutAnchorable { Title = "Floated", ContentId = "floated", Content = new Grid() };
+		layout.FloatingWindows.Add(new LayoutAnchorableFloatingWindow
+		{
+			RootPanel = new LayoutAnchorablePaneGroup(new LayoutAnchorablePane(floated))
+			{
+				DockWidth = new System.Windows.GridLength(200),
+				DockHeight = new System.Windows.GridLength(200),
+			},
+		});
+
+		return layout;
+	}
+
+	/// <summary>Creates a docking manager holding a single anchorable.</summary>
+	/// <param name="anchorable">Receives the anchorable in the manager's layout.</param>
+	/// <returns>The manager.</returns>
+	private static DockingManager CreateManager(out LayoutAnchorable anchorable)
+	{
+		var manager = new DockingManager();
+		manager.Layout = BuildLayout(out anchorable);
+		return manager;
+	}
+
+	/// <summary>Puts the manager into a window and shows it, so the loaded paths under test run.</summary>
+	/// <param name="manager">The manager to host.</param>
+	/// <returns>The host window.</returns>
+	private static Window HostInWindow(DockingManager manager)
+	{
+		var host = new Window
+		{
+			Content = manager,
+			Width = 800,
+			Height = 600,
+			ShowInTaskbar = false,
+			WindowStartupLocation = WindowStartupLocation.Manual,
+
+			// Kept off screen: these tests are about behaviour, not about what is drawn.
+			Left = SystemParameters.VirtualScreenLeft - 10000,
+			Top = SystemParameters.VirtualScreenTop - 10000,
+		};
+
+		host.Show();
+		Pump();
+		return host;
+	}
+
+	/// <summary>Lets the dispatcher run pending work before anything is asserted.</summary>
+	private static void Pump()
+	{
+		System.Windows.Threading.Dispatcher.CurrentDispatcher.Invoke(
+			System.Windows.Threading.DispatcherPriority.ContextIdle,
+			new Action(() => { }));
+	}
+
+	/// <summary>Runs the given code on an STA thread and returns any exception it raised.</summary>
+	/// <param name="action">The code to run.</param>
+	/// <returns>The exception, or <see langword="null"/> when the code completed.</returns>
+	private Exception? RunOnStaThread(Action action)
+	{
+		Exception? failure = null;
+		ThreadExecutor.RunCodeAsSTA(
+			_are,
+			() =>
+			{
+				try
+				{
+					action();
+				}
+				catch (Exception ex)
+				{
+					failure = ex;
+				}
+			});
+
+		_are.WaitOne();
+		return failure;
+	}
+}

--- a/source/AutomationTest/AvalonDockTest/XmlLayoutSerializerTests.cs
+++ b/source/AutomationTest/AvalonDockTest/XmlLayoutSerializerTests.cs
@@ -47,6 +47,8 @@ namespace AvalonDockTest
 			public int AutoHideDelay { get; set; }
 			public bool SupportsAutoHideFlyout => true;
 			public bool AllowMixedOrientation { get; set; }
+			public bool AllowFloatingWindows { get; set; } = true;
+			public bool AllowDetachedWindows { get; set; } = true;
 
 			public event EventHandler ActiveContentChanged;
 			public event EventHandler LayoutChanged;

--- a/source/Components/AvalonDock.Core/Interfaces/IDockingManager.cs
+++ b/source/Components/AvalonDock.Core/Interfaces/IDockingManager.cs
@@ -48,6 +48,37 @@ namespace AvalonDock.Core
 		/// <summary>Gets or sets a value indicating whether mixed orientation (horizontal + vertical splits) is allowed.</summary>
 		bool AllowMixedOrientation { get; set; }
 
+		/// <summary>
+		/// Gets or sets a value indicating whether content may be torn off into floating windows.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// This is the global switch that turns the whole floating feature off, as opposed to
+		/// <see cref="IDockable.CanFloat"/>, which decides it for a single piece of content. When it is
+		/// <see langword="false"/> no floating window is ever created: dragging a tab out of its pane,
+		/// the Float command and a programmatic float all do nothing, and a layout that is loaded with
+		/// floating windows in it has their content docked back where it came from.
+		/// </para>
+		/// <para>Defaults to <see langword="true"/>.</para>
+		/// </remarks>
+		bool AllowFloatingWindows { get; set; }
+
+		/// <summary>
+		/// Gets or sets a value indicating whether anchorables may be moved into standalone top level
+		/// windows - the "Window" view mode that IDEs offer for their tool windows.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// Unlike a floating window, a standalone window is an ordinary operating system window: it owns
+		/// a taskbar entry, minimizes on its own and may be moved behind the main window. When this is
+		/// <see langword="false"/> no such window is ever created, the menu entry that offers the mode is
+		/// disabled, and any window that is already open is closed with its content returned to the
+		/// layout.
+		/// </para>
+		/// <para>Defaults to <see langword="true"/>.</para>
+		/// </remarks>
+		bool AllowDetachedWindows { get; set; }
+
 		/// <summary>Raised when the active content changes.</summary>
 		event EventHandler ActiveContentChanged;
 

--- a/source/Components/AvalonDock.Core/Interfaces/IRootDock.cs
+++ b/source/Components/AvalonDock.Core/Interfaces/IRootDock.cs
@@ -16,6 +16,23 @@ namespace AvalonDock.Core
 		/// <summary>Gets or sets the default layout to restore when resetting.</summary>
 		IDockable? DefaultLayout { get; set; }
 
+		/// <summary>
+		/// Gets or sets a value indicating whether content of this layout may be torn off into floating
+		/// windows. Applied to <see cref="IDockingManager.AllowFloatingWindows"/> of the docking manager
+		/// this layout is bound to, and kept in sync while it stays bound.
+		/// </summary>
+		/// <remarks>Defaults to <see langword="true"/>.</remarks>
+		bool AllowFloatingWindows { get; set; }
+
+		/// <summary>
+		/// Gets or sets a value indicating whether anchorables of this layout may be moved into
+		/// standalone top level windows. Applied to
+		/// <see cref="IDockingManager.AllowDetachedWindows"/> of the docking manager this layout is
+		/// bound to, and kept in sync while it stays bound.
+		/// </summary>
+		/// <remarks>Defaults to <see langword="true"/>.</remarks>
+		bool AllowDetachedWindows { get; set; }
+
 		/// <summary>Shows all floating windows.</summary>
 		void ShowWindows();
 

--- a/source/Components/AvalonDock.DependencyInjection/DockLayoutBuilder.cs
+++ b/source/Components/AvalonDock.DependencyInjection/DockLayoutBuilder.cs
@@ -12,8 +12,19 @@ namespace AvalonDock.DependencyInjection
 	{
 		private readonly IServiceCollection _services;
 
-		/// <summary>Gets a value indicating whether <see cref="ConfigureToggleDock"/> was called.</summary>
-		internal bool ToggleDockConfigured { get; private set; }
+		/// <summary>
+		/// The single options object of this builder.
+		/// </summary>
+		/// <remarks>
+		/// There is one instance rather than one per configure method, because
+		/// <see cref="ToggleDockOptions"/> is a <see cref="DockingOptions"/>: keeping them apart would
+		/// let an application configure two objects and leave the order of the calls deciding which of
+		/// them the layout ends up following.
+		/// </remarks>
+		private readonly ToggleDockOptions _options = new ToggleDockOptions();
+
+		/// <summary>Whether <see cref="_options"/> has already been put into the service collection.</summary>
+		private bool _optionsRegistered;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="DockLayoutBuilder"/> class.
@@ -25,16 +36,67 @@ namespace AvalonDock.DependencyInjection
 		}
 
 		/// <summary>
+		/// Registers the options, so that they can be resolved even when no configure method was called.
+		/// </summary>
+		internal void RegisterOptions() => EnsureOptionsRegistered();
+
+		/// <summary>
+		/// Puts the options into the service collection, once, under both the type the toggle docking
+		/// manager asks for and the base type carrying the manager wide switches.
+		/// </summary>
+		/// <remarks>
+		/// Done from the configure methods rather than only from
+		/// <see cref="ServiceCollectionExtensions.AddDockLayoutService(IServiceCollection, Action{DockLayoutBuilder})"/>,
+		/// because this builder is public: an application may drive it itself, and configuring it has
+		/// always been what registered the options.
+		/// </remarks>
+		private void EnsureOptionsRegistered()
+		{
+			if (_optionsRegistered) return;
+			_optionsRegistered = true;
+
+			_services.AddSingleton(_options);
+			_services.AddSingleton<DockingOptions>(_options);
+		}
+
+		/// <summary>
+		/// Configures the manager wide docking behaviour - whether floating windows and standalone
+		/// windows are available at all.
+		/// </summary>
+		/// <param name="configure">Optional delegate to configure the options.</param>
+		/// <returns>This builder for chaining.</returns>
+		/// <remarks>
+		/// The settings are applied to the layout of <c>IDockLayoutService</c>, so a docking manager
+		/// bound to that layout follows them without any further wiring.
+		/// </remarks>
+		/// <example>
+		/// <code>
+		/// services.AddDockLayoutService(dock =>
+		/// {
+		///     dock.ConfigureDocking(o =>
+		///     {
+		///         o.AllowFloatingWindows = false;
+		///         o.AllowDetachedWindows = false;
+		///     });
+		/// });
+		/// </code>
+		/// </example>
+		public DockLayoutBuilder ConfigureDocking(Action<DockingOptions>? configure = null)
+		{
+			configure?.Invoke(_options);
+			EnsureOptionsRegistered();
+			return this;
+		}
+
+		/// <summary>
 		/// Configures <see cref="ToggleDockOptions"/> for the toggle docking manager.
 		/// </summary>
 		/// <param name="configure">Optional delegate to configure the options.</param>
 		/// <returns>This builder for chaining.</returns>
 		public DockLayoutBuilder ConfigureToggleDock(Action<ToggleDockOptions>? configure = null)
 		{
-			var options = new ToggleDockOptions();
-			configure?.Invoke(options);
-			_services.AddSingleton(options);
-			ToggleDockConfigured = true;
+			configure?.Invoke(_options);
+			EnsureOptionsRegistered();
 			return this;
 		}
 

--- a/source/Components/AvalonDock.DependencyInjection/DockingOptions.cs
+++ b/source/Components/AvalonDock.DependencyInjection/DockingOptions.cs
@@ -1,0 +1,41 @@
+namespace AvalonDock.DependencyInjection
+{
+	/// <summary>
+	/// Configuration options that apply to any docking manager, regardless of which one is used.
+	/// Register via <see cref="DockLayoutBuilder.ConfigureDocking"/>.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// These are applied to the layout built by <c>IDockLayoutService</c>, so a docking manager bound to
+	/// that layout picks them up by itself - there is nothing to copy over in the code-behind of the
+	/// window.
+	/// </para>
+	/// <para>
+	/// <see cref="ToggleDockOptions"/> derives from this class, so an application that configures the
+	/// toggle docking manager sets these on the very same options object.
+	/// </para>
+	/// </remarks>
+	public class DockingOptions
+	{
+		/// <summary>
+		/// Gets or sets a value indicating whether content may be torn off into floating windows.
+		/// Default is <see langword="true"/>.
+		/// </summary>
+		/// <remarks>
+		/// When <see langword="false"/> no floating window is created at all: dragging content out of its
+		/// pane and the Float command both do nothing, and a loaded layout has its floating content
+		/// docked back.
+		/// </remarks>
+		public bool AllowFloatingWindows { get; set; } = true;
+
+		/// <summary>
+		/// Gets or sets a value indicating whether anchorables may be moved into standalone top level
+		/// windows - the "Window" view mode. Default is <see langword="true"/>.
+		/// </summary>
+		/// <remarks>
+		/// When <see langword="false"/> the menu entry offering the mode is disabled and no such window
+		/// is created, not even for a layout that was saved with one open.
+		/// </remarks>
+		public bool AllowDetachedWindows { get; set; } = true;
+	}
+}

--- a/source/Components/AvalonDock.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/source/Components/AvalonDock.DependencyInjection/ServiceCollectionExtensions.cs
@@ -142,22 +142,38 @@ namespace AvalonDock.DependencyInjection
 			this IServiceCollection services,
 			Action<DockLayoutBuilder> configure)
 		{
+			if (configure == null) throw new ArgumentNullException(nameof(configure));
+
 			var builder = new DockLayoutBuilder(services);
 			configure(builder);
 
-			if (!builder.ToggleDockConfigured)
-			{
-				services.AddSingleton(new ToggleDockOptions());
-			}
+			// No-op when a configure method already did it; this covers a builder that was only used to
+			// add toolboxes, which still has to leave resolvable options behind.
+			builder.RegisterOptions();
 
 			services.AddSingleton<IDockLayoutService>(sp =>
 			{
 				var toolboxes = sp.GetService<IEnumerable<IToolbox>>()
 					?? System.Array.Empty<IToolbox>();
-				return new Mvvm.DockLayoutService(toolboxes);
+				var service = new Mvvm.DockLayoutService(toolboxes);
+				ApplyDockingOptions(service, sp.GetService<DockingOptions>());
+				return service;
 			});
 			services.AddSingleton<Mvvm.SideToggleManager>();
 			return services;
+		}
+
+		/// <summary>
+		/// Copies the manager wide switches onto the layout, from where the docking manager reads them.
+		/// </summary>
+		/// <param name="service">The layout service whose layout is configured.</param>
+		/// <param name="options">The options to apply, may be <see langword="null"/>.</param>
+		private static void ApplyDockingOptions(IDockLayoutService? service, DockingOptions? options)
+		{
+			if (options == null || service?.Layout == null) return;
+
+			service.Layout.AllowFloatingWindows = options.AllowFloatingWindows;
+			service.Layout.AllowDetachedWindows = options.AllowDetachedWindows;
 		}
 
 		/// <summary>
@@ -172,7 +188,11 @@ namespace AvalonDock.DependencyInjection
 			{
 				var toolboxes = sp.GetService<IEnumerable<IToolbox>>()
 					?? System.Array.Empty<IToolbox>();
-				return new Mvvm.DockLayoutService(toolboxes);
+				var service = new Mvvm.DockLayoutService(toolboxes);
+
+				// Honoured when the application registered them itself; this overload registers none.
+				ApplyDockingOptions(service, sp.GetService<DockingOptions>());
+				return service;
 			});
 			services.AddSingleton<Mvvm.SideToggleManager>();
 			return services;

--- a/source/Components/AvalonDock.DependencyInjection/ToggleDockOptions.cs
+++ b/source/Components/AvalonDock.DependencyInjection/ToggleDockOptions.cs
@@ -5,7 +5,11 @@ namespace AvalonDock.DependencyInjection
 	/// Register via <see cref="DockLayoutBuilder.ConfigureToggleDock"/>
 	/// and resolve in your window to apply settings.
 	/// </summary>
-	public class ToggleDockOptions
+	/// <remarks>
+	/// Inherits the manager wide switches of <see cref="DockingOptions"/>, which are applied to the
+	/// layout automatically and therefore need no code in the window.
+	/// </remarks>
+	public class ToggleDockOptions : DockingOptions
 	{
 		/// <summary>Gets or sets the sidebar toggle button size. Default is 25.</summary>
 		public double ButtonSize { get; set; } = 25;

--- a/source/Components/AvalonDock.Mvvm/DockViewModels.cs
+++ b/source/Components/AvalonDock.Mvvm/DockViewModels.cs
@@ -14,6 +14,8 @@ namespace AvalonDock.Mvvm
 		private IList<IDockable>? _floatingDockables;
 		private IList<IDockable>? _pinnedDockables;
 		private IDockable? _defaultLayout;
+		private bool _allowFloatingWindows = true;
+		private bool _allowDetachedWindows = true;
 
 		/// <summary>
 		/// Gets or sets the floating dockables owned by the root dock.
@@ -43,6 +45,44 @@ namespace AvalonDock.Mvvm
 		{
 			get => _defaultLayout;
 			set => SetProperty(ref _defaultLayout, value);
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether content of this layout may be torn off into
+		/// floating windows. Pushed to the docking manager this layout is bound to.
+		/// </summary>
+		[DataMember(IsRequired = false, EmitDefaultValue = true)]
+		public bool AllowFloatingWindows
+		{
+			get => _allowFloatingWindows;
+			set => SetProperty(ref _allowFloatingWindows, value);
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether anchorables of this layout may be moved into
+		/// standalone top level windows. Pushed to the docking manager this layout is bound to.
+		/// </summary>
+		[DataMember(IsRequired = false, EmitDefaultValue = true)]
+		public bool AllowDetachedWindows
+		{
+			get => _allowDetachedWindows;
+			set => SetProperty(ref _allowDetachedWindows, value);
+		}
+
+		/// <summary>
+		/// Restores the defaults of the window policy before a stored layout is read back into it.
+		/// </summary>
+		/// <param name="context">The streaming context, unused.</param>
+		/// <remarks>
+		/// <c>DataContractSerializer</c> does not run field initializers, so a layout stored before these
+		/// two switches existed carries neither of them and would come back with both off - turning
+		/// floating and standalone windows off for an application that never asked for that.
+		/// </remarks>
+		[OnDeserializing]
+		protected void OnDeserializingWindowPolicy(StreamingContext context)
+		{
+			_allowFloatingWindows = true;
+			_allowDetachedWindows = true;
 		}
 
 		/// <summary>

--- a/source/Components/AvalonDock/Controls/LayoutAnchorableItem.cs
+++ b/source/Components/AvalonDock/Controls/LayoutAnchorableItem.cs
@@ -108,7 +108,10 @@ namespace AvalonDock.Controls
 		private static object CoerceDetachToWindowCommandValue(DependencyObject d, object value) => value;
 
 		private bool CanExecuteDetachToWindowCommand(object parameter) =>
-			LayoutElement != null && _anchorable?.Root?.Manager != null && _anchorable.CanFloat;
+			LayoutElement != null
+			&& _anchorable?.Root?.Manager != null
+			&& _anchorable.Root.Manager.AllowDetachedWindows
+			&& _anchorable.CanFloat;
 
 		private void ExecuteDetachToWindowCommand(object parameter)
 		{

--- a/source/Components/AvalonDock/Controls/LayoutItem.cs
+++ b/source/Components/AvalonDock/Controls/LayoutItem.cs
@@ -362,7 +362,11 @@ namespace AvalonDock.Controls
 		/// <summary>Coerces the <see cref="FloatCommand"/> value.</summary>
 		private static object CoerceFloatCommandValue(DependencyObject d, object value) => value;
 
-		private bool CanExecuteFloatCommand(object anchorable) => LayoutElement != null && LayoutElement.CanFloat && LayoutElement.FindParent<LayoutFloatingWindow>() == null;
+		private bool CanExecuteFloatCommand(object anchorable) =>
+			LayoutElement != null
+			&& LayoutElement.CanFloat
+			&& LayoutElement.Root?.Manager?.AllowFloatingWindows != false
+			&& LayoutElement.FindParent<LayoutFloatingWindow>() == null;
 
 		/// <summary>Executes to float the content of this LayoutItem in a separate <see cref="LayoutFloatingWindowControl"/>.</summary>
 		/// <param name="parameter">The command parameter.</param>

--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -469,6 +469,10 @@ namespace AvalonDock
 			AttachDocumentsSource(newLayout, DocumentsSource);
 			AttachAnchorablesSource(newLayout, AnchorablesSource);
 
+			// A layout saved while floating was allowed still carries its floating windows. Dock them
+			// before any window is created for them, so loading a layout cannot bring the feature back.
+			if (!AllowFloatingWindows) DockAllFloatingWindows();
+
 			if (IsLoaded)
 			{
 				LayoutRootPanel = CreateUIElementForModel(Layout.RootPanel) as LayoutPanelControl;
@@ -551,6 +555,11 @@ namespace AvalonDock
 			// leave the model claiming to be detached without a window.
 			foreach (var anchorable in toDetach)
 				anchorable.IsDetached = false;
+
+			// A layout saved while standalone windows were allowed still asks for them. Leaving the
+			// anchorables docked is the whole point of the switch, and the flags cleared above already
+			// put the models back in agreement with that.
+			if (!AllowDetachedWindows) return;
 
 			Dispatcher.BeginInvoke(
 				DispatcherPriority.Loaded,
@@ -1165,6 +1174,169 @@ namespace AvalonDock
 		[Category("FloatingWindow")]
 		public IEnumerable<LayoutFloatingWindowControl> FloatingWindows => _fwList;
 
+		/// <summary>
+		/// Docks the content of every floating window back into the layout and closes the windows.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// Each piece of content goes back to the pane it was floated from, the same way the Dock command
+		/// of a single floating window does. Content that no longer knows that pane - it was created
+		/// inside a floating window, or the pane it came from was collected when it left - is placed the
+		/// way a newly added anchorable or document is.
+		/// </para>
+		/// <para>
+		/// This runs automatically when <see cref="AllowFloatingWindows"/> is turned off, which is what
+		/// makes that switch retroactive; it is public because emptying the desktop of floating windows
+		/// is also useful on its own, for a "reset windows" menu entry, say.
+		/// </para>
+		/// </remarks>
+		public void DockAllFloatingWindows()
+		{
+			var layout = Layout;
+			if (layout == null) return;
+
+			// Materialised before anything moves: docking mutates both the floating window collection and
+			// the trees hanging off it.
+			var floatingContents = layout.FloatingWindows
+				.SelectMany(fw => fw.Descendents().OfType<LayoutContent>())
+				.ToArray();
+
+			foreach (var content in floatingContents)
+			{
+				// Docking one piece of content can carry others with it, so only what is still floating
+				// is worth moving - and only that still has a Root for Dock to work with.
+				if (content.Root != layout) continue;
+				if (content.FindParent<LayoutFloatingWindow>() == null) continue;
+
+				if (HasDockablePreviousContainer(content))
+					content.Dock();
+				else
+					DockOutsideFloatingWindows(content);
+			}
+
+			layout.CollectGarbage();
+			CloseEmptiedFloatingWindows(layout);
+
+			// Runs again because closing the windows disconnects the panes that content may still name as
+			// the one to float back into, and those references have to go with them.
+			layout.CollectGarbage();
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether <see cref="LayoutContent.Dock"/> can be trusted to take the
+		/// given content out of its floating window.
+		/// </summary>
+		/// <param name="content">The floating content to test.</param>
+		/// <returns><see langword="true"/> when the content still knows a pane to go back to.</returns>
+		/// <remarks>
+		/// <see cref="LayoutContent.Dock"/> returns content to the pane it was floated from when that
+		/// pane is still known. Without one it searches the layout instead, and that search does not
+		/// exclude the panes inside floating windows, so it can put the content straight back into the
+		/// window it is being taken out of. That happens whenever floating emptied the pane the content
+		/// came from and garbage collection then removed it - in a layout with a single pane, always.
+		/// </remarks>
+		private static bool HasDockablePreviousContainer(LayoutContent content) =>
+			((ILayoutPreviousContainer)content).PreviousContainer is ILayoutElement previous
+			&& previous.Root == content.Root
+			&& previous.FindParent<LayoutFloatingWindow>() == null;
+
+		/// <summary>
+		/// Moves content out of its floating window and into a pane of the main layout by hand.
+		/// </summary>
+		/// <param name="content">The content to place.</param>
+		/// <remarks>
+		/// Used by <see cref="DockAllFloatingWindows"/> for content that no longer knows where it was
+		/// floated from. The pane is chosen the way the layout chooses one for newly added content, only
+		/// with the panes inside floating windows barred, and one is created when the layout has none
+		/// left to offer.
+		/// </remarks>
+		private void DockOutsideFloatingWindows(LayoutContent content)
+		{
+			var layout = Layout;
+			if (layout == null) return;
+
+			var wasFloating = content.IsFloating;
+
+			if (content is LayoutAnchorable anchorable)
+			{
+				var anchorablePane = layout.Descendents().OfType<LayoutAnchorablePane>()
+					.FirstOrDefault(pane => pane.FindParent<LayoutFloatingWindow>() == null);
+
+				if (anchorablePane == null)
+				{
+					anchorablePane = new LayoutAnchorablePane { DockWidth = new GridLength(200.0, GridUnitType.Pixel) };
+					EnsureRootPanel(layout).Children.Add(anchorablePane);
+				}
+
+				content.Parent?.RemoveChild(content);
+				anchorablePane.Children.Add(anchorable);
+			}
+			else
+			{
+				var documentPane = layout.Descendents().OfType<LayoutDocumentPane>()
+					.FirstOrDefault(pane => pane.FindParent<LayoutFloatingWindow>() == null);
+
+				if (documentPane == null)
+				{
+					documentPane = new LayoutDocumentPane();
+					EnsureRootPanel(layout).Children.Add(new LayoutDocumentPaneGroup(documentPane));
+				}
+
+				content.Parent?.RemoveChild(content);
+				documentPane.Children.Add(content);
+			}
+
+			// The pane it came from is inside a window that is about to close, so it is no place to
+			// float back into.
+			((ILayoutPreviousContainer)content).PreviousContainer = null;
+			content.PreviousContainerIndex = -1;
+			content.IsSelected = true;
+
+			// Docking through LayoutContent.Dock raises this, and callers must not be able to tell which
+			// of the two routes a piece of content took.
+			if (wasFloating && !content.IsFloating) RaiseContentDocked(content);
+		}
+
+		/// <summary>Returns the root panel of the layout, creating it when the layout has none.</summary>
+		/// <param name="layout">The layout to inspect.</param>
+		/// <returns>The root panel.</returns>
+		/// <remarks>
+		/// A layout that was never given a root panel has none, and there is nothing to add a pane to.
+		/// </remarks>
+		private static LayoutPanel EnsureRootPanel(LayoutRoot layout)
+		{
+			if (layout.RootPanel != null) return layout.RootPanel;
+
+			var panel = new LayoutPanel { Orientation = Orientation.Horizontal };
+			layout.RootPanel = panel;
+			return panel;
+		}
+
+		/// <summary>Closes the floating windows that no longer hold any content.</summary>
+		/// <param name="layout">The layout the windows belong to.</param>
+		/// <remarks>
+		/// <see cref="LayoutRoot.CollectGarbage"/> deliberately keeps an emptied floating window when a
+		/// content still names its pane as the one to float back into - that is what lets a docked
+		/// anchorable be floated again into the same window. Here that would leave the caller with the
+		/// very windows it asked to be rid of, so they are closed explicitly.
+		/// </remarks>
+		private void CloseEmptiedFloatingWindows(LayoutRoot layout)
+		{
+			foreach (var fwc in _fwList.ToArray())
+			{
+				if (fwc.Model == null || fwc.Model.Descendents().OfType<LayoutContent>().Any()) continue;
+				fwc.InternalClose();
+			}
+
+			// Models without a control of their own - a layout can be loaded with floating windows while
+			// AllowFloatingWindows is off, in which case no control was ever created for them.
+			foreach (var fw in layout.FloatingWindows.ToArray())
+			{
+				if (fw.Descendents().OfType<LayoutContent>().Any()) continue;
+				layout.FloatingWindows.Remove(fw);
+			}
+		}
+
 		/// <summary><see cref="LayoutItemTemplate"/> dependency property.</summary>
 		public static readonly DependencyProperty LayoutItemTemplateProperty = DependencyProperty.Register(nameof(LayoutItemTemplate), typeof(DataTemplate), typeof(DockingManager),
 				new FrameworkPropertyMetadata((DataTemplate)null, OnLayoutItemTemplateChanged));
@@ -1698,6 +1870,96 @@ namespace AvalonDock
 			set { SetValue(AllowMovingFloatingWindowWithKeyboardProperty, value); }
 		}
 
+		/// <summary><see cref="AllowFloatingWindows"/> dependency property.</summary>
+		public static readonly DependencyProperty AllowFloatingWindowsProperty = DependencyProperty.Register(nameof(AllowFloatingWindows), typeof(bool), typeof(DockingManager),
+				new FrameworkPropertyMetadata(true, OnAllowFloatingWindowsChanged));
+
+		/// <summary>
+		/// Gets or sets a value indicating whether content may be torn off into floating windows.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// This is the global switch for the whole feature, as opposed to
+		/// <see cref="LayoutContent.CanFloat"/>, which decides it for a single piece of content. While it
+		/// is <see langword="false"/> no floating window is created at all: dragging a tab or a tool
+		/// window title out of its pane, the Float command and <see cref="LayoutContent.Float"/> all do
+		/// nothing, and the command is reported as unavailable so the menu entries offering it are
+		/// disabled.
+		/// </para>
+		/// <para>
+		/// Setting it to <see langword="false"/> while floating windows are open docks their content
+		/// back into the layout, and a layout that is loaded afterwards is treated the same way, so the
+		/// setting cannot be circumvented by restoring a layout that was saved with floating windows in
+		/// it. Turning it back on does not reopen them.
+		/// </para>
+		/// </remarks>
+		[Bindable(true)]
+		[Description("Gets or sets a value indicating whether content can be torn off into floating windows.")]
+		[Category("FloatingWindow")]
+		public bool AllowFloatingWindows
+		{
+			get => (bool)GetValue(AllowFloatingWindowsProperty);
+			set => SetValue(AllowFloatingWindowsProperty, value);
+		}
+
+		/// <summary>Handles changes to the <see cref="AllowFloatingWindows"/> property.</summary>
+		private static void OnAllowFloatingWindowsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) => ((DockingManager)d).OnAllowFloatingWindowsChanged(e);
+
+		/// <summary>Provides derived classes an opportunity to handle changes to the <see cref="AllowFloatingWindows"/> property.</summary>
+		/// <param name="e">The event data for the property change.</param>
+		protected virtual void OnAllowFloatingWindowsChanged(DependencyPropertyChangedEventArgs e)
+		{
+			if (!(bool)e.NewValue) DockAllFloatingWindows();
+
+			// The Float command reports itself unavailable while this is off, so every menu that offers
+			// it has to be asked again.
+			CommandManager.InvalidateRequerySuggested();
+		}
+
+		/// <summary><see cref="AllowDetachedWindows"/> dependency property.</summary>
+		public static readonly DependencyProperty AllowDetachedWindowsProperty = DependencyProperty.Register(nameof(AllowDetachedWindows), typeof(bool), typeof(DockingManager),
+				new FrameworkPropertyMetadata(true, OnAllowDetachedWindowsChanged));
+
+		/// <summary>
+		/// Gets or sets a value indicating whether anchorables may be moved into standalone top level
+		/// windows - the "Window" view mode that IDEs offer for their tool windows.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// Unlike a floating window, a standalone <see cref="DetachedAnchorableWindow"/> is an ordinary
+		/// operating system window: it owns a taskbar entry, minimizes on its own and may be moved behind
+		/// the main window. While this is <see langword="false"/>,
+		/// <see cref="DetachAnchorableToWindow(LayoutAnchorable)"/> does nothing and
+		/// <see cref="LayoutAnchorableItem.DetachToWindowCommand"/> is reported as unavailable, so the
+		/// menu entry offering the mode is disabled.
+		/// </para>
+		/// <para>
+		/// Setting it to <see langword="false"/> returns every anchorable that is already in a standalone
+		/// window to the layout, and a layout that is loaded afterwards has its detached anchorables
+		/// restored docked rather than in windows.
+		/// </para>
+		/// </remarks>
+		[Bindable(true)]
+		[Description("Gets or sets a value indicating whether anchorables can be moved into standalone top level windows.")]
+		[Category("Anchorable")]
+		public bool AllowDetachedWindows
+		{
+			get => (bool)GetValue(AllowDetachedWindowsProperty);
+			set => SetValue(AllowDetachedWindowsProperty, value);
+		}
+
+		/// <summary>Handles changes to the <see cref="AllowDetachedWindows"/> property.</summary>
+		private static void OnAllowDetachedWindowsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) => ((DockingManager)d).OnAllowDetachedWindowsChanged(e);
+
+		/// <summary>Provides derived classes an opportunity to handle changes to the <see cref="AllowDetachedWindows"/> property.</summary>
+		/// <param name="e">The event data for the property change.</param>
+		protected virtual void OnAllowDetachedWindowsChanged(DependencyPropertyChangedEventArgs e)
+		{
+			if (!(bool)e.NewValue) ReattachAllDetachedAnchorables();
+
+			CommandManager.InvalidateRequerySuggested();
+		}
+
 		/// <summary><see cref="ShowNavigator"/> dependency property.</summary>
 		public static readonly DependencyProperty ShowNavigatorProperty = DependencyProperty.Register(nameof(ShowNavigator), typeof(bool), typeof(DockingManager),
 				new FrameworkPropertyMetadata(true));
@@ -1976,8 +2238,11 @@ namespace AvalonDock
 		/// <param name="contentModel">The layout content to host in the floating window.</param>
 		/// <param name="isContentImmutable">if set to <c>true</c>, the content cannot be changed while floating.</param>
 		/// <returns>The created floating window control, or <see langword="null"/> if no floating window can be created.</returns>
+		/// <remarks>Returns <see langword="null"/> while <see cref="AllowFloatingWindows"/> is <see langword="false"/>.</remarks>
 		public LayoutFloatingWindowControl CreateFloatingWindow(LayoutContent contentModel, bool isContentImmutable)
 		{
+			if (!AllowFloatingWindows) return null;
+
 			if (contentModel is LayoutAnchorable anchorable)
 			{
 				if (!(contentModel.Parent is ILayoutPane))
@@ -2046,6 +2311,7 @@ namespace AvalonDock
 			if (model is LayoutAnchorableFloatingWindow)
 			{
 				if (DesignerProperties.GetIsInDesignMode(this)) return null;
+				if (!AllowFloatingWindows) return null;
 				var modelFW = model as LayoutAnchorableFloatingWindow;
 				var newFW = new LayoutAnchorableFloatingWindowControl(modelFW)
 				{
@@ -2092,6 +2358,7 @@ namespace AvalonDock
 			{
 				if (DesignerProperties.GetIsInDesignMode(this))
 					return null;
+				if (!AllowFloatingWindows) return null;
 				var modelFW = model as LayoutDocumentFloatingWindow;
 				var newFW = new LayoutDocumentFloatingWindowControl(modelFW)
 				{
@@ -2157,6 +2424,7 @@ namespace AvalonDock
 		{
 			// Ensure window can float only if corresponding property is set accordingly
 			if (contentModel == null) return;
+			if (!AllowFloatingWindows) return;
 			if (!contentModel.CanFloat) return;
 
 			var floatingArgs = new ContentFloatingEventArgs(contentModel);
@@ -2217,6 +2485,8 @@ namespace AvalonDock
 		/// <param name="paneModel">The pane to float.</param>
 		internal virtual void StartDraggingFloatingWindowForPane(LayoutAnchorablePane paneModel)
 		{
+			if (!AllowFloatingWindows) return;
+
 			var firstContent = paneModel.Children.FirstOrDefault();
 			if (firstContent != null)
 			{
@@ -2581,9 +2851,11 @@ namespace AvalonDock
 		/// Closing the window returns the anchorable to the layout, as does
 		/// <see cref="ReattachAnchorable(LayoutAnchorable)"/>.
 		/// </para>
+		/// <para>Does nothing while <see cref="AllowDetachedWindows"/> is <see langword="false"/>.</para>
 		/// </remarks>
 		public void DetachAnchorableToWindow(LayoutAnchorable anchorable)
 		{
+			if (!AllowDetachedWindows) return;
 			if (anchorable == null || IsDetached(anchorable)) return;
 			if (!(GetLayoutItemFromModel(anchorable) is LayoutAnchorableItem layoutItem)) return;
 
@@ -3613,6 +3885,8 @@ namespace AvalonDock
 
 		private LayoutFloatingWindowControl CreateFloatingWindowForLayoutAnchorableWithoutParent(LayoutAnchorablePane paneModel, bool isContentImmutable)
 		{
+			if (!AllowFloatingWindows)
+				return null;
 			if (paneModel.Children.Any(c => !c.CanFloat))
 				return null;
 			var paneAsPositionableElement = paneModel as ILayoutPositionableElement;
@@ -3689,6 +3963,7 @@ namespace AvalonDock
 
 		private LayoutFloatingWindowControl CreateFloatingWindowCore(LayoutContent contentModel, bool isContentImmutable)
 		{
+			if (!AllowFloatingWindows) return null;
 			if (!contentModel.CanFloat) return null;
 			if (contentModel is LayoutAnchorable contentModelAsAnchorable && contentModelAsAnchorable.IsAutoHidden)
 				contentModelAsAnchorable.ToggleAutoHide();

--- a/source/Components/AvalonDock/LayoutSyncBridge.cs
+++ b/source/Components/AvalonDock/LayoutSyncBridge.cs
@@ -51,6 +51,7 @@ namespace AvalonDock
 			_manager.DocumentsSource = _documentModels;
 			_manager.AnchorablesSource = _anchorableModels;
 
+			SyncWindowPolicyToWpf();
 			SyncActiveContentToWpf();
 
 			SubscribeToMvvm();
@@ -242,6 +243,26 @@ namespace AvalonDock
 			{
 				SyncActiveContentToWpf();
 			}
+			else if (e.PropertyName == nameof(IRootDock.AllowFloatingWindows)
+				|| e.PropertyName == nameof(IRootDock.AllowDetachedWindows))
+			{
+				SyncWindowPolicyToWpf();
+			}
+		}
+
+		/// <summary>
+		/// Pushes the window policy declared by the view model layout onto the docking manager.
+		/// </summary>
+		/// <remarks>
+		/// One way by design: these are a decision the application makes about its layout, so the manager
+		/// follows the view model and never writes back. It lets an application built with
+		/// <c>AvalonDock.Mvvm</c> or the dependency injection package switch floating and standalone
+		/// windows off without touching the view.
+		/// </remarks>
+		private void SyncWindowPolicyToWpf()
+		{
+			_manager.AllowFloatingWindows = _rootDock.AllowFloatingWindows;
+			_manager.AllowDetachedWindows = _rootDock.AllowDetachedWindows;
 		}
 
 		private void OnWpfActiveContentChanged(object sender, EventArgs e)

--- a/source/Components/AvalonDock/ToggleDockingManager.cs
+++ b/source/Components/AvalonDock/ToggleDockingManager.cs
@@ -886,7 +886,9 @@ public class ToggleDockingManager : DockingManager
 		// "View Mode" submenu
 		var viewModeItem = new MenuItem { Header = "View Mode" };
 
-		var floatItem = new MenuItem { Header = "Float" };
+		// This menu is built by hand rather than from the commands, so the two manager wide switches
+		// have to be honoured here as well - see DockingManager.AllowFloatingWindows/AllowDetachedWindows.
+		var floatItem = new MenuItem { Header = "Float", IsEnabled = AllowFloatingWindows };
 		floatItem.Click += (s, e) =>
 		{
 			ReattachAnchorable(anchorable);
@@ -906,7 +908,8 @@ public class ToggleDockingManager : DockingManager
 		var windowItem = new MenuItem
 		{
 			Header = "Window",
-			IsChecked = IsDetached(anchorable)
+			IsChecked = IsDetached(anchorable),
+			IsEnabled = AllowDetachedWindows
 		};
 		windowItem.Click += (s, e) =>
 		{


### PR DESCRIPTION
Adds two manager wide switches next to the existing per content CanFloat:

- DockingManager.AllowFloatingWindows turns tear off into floating windows off entirely. Dragging a tab or tool window title, the Float command and LayoutContent.Float() all stop creating windows, CreateFloatingWindow returns null, and the Float command reports itself unavailable so the menu entries offering it are disabled.
- DockingManager.AllowDetachedWindows does the same for the standalone "Window" view mode: DetachAnchorableToWindow does nothing and DetachToWindowCommand is unavailable.

Both are retroactive so they cannot be circumvented: switching them off docks open floating windows back and returns detached anchorables, and a layout that is loaded afterwards is treated the same way rather than recreating the windows it was saved with. DockAllFloatingWindows() exposes that dock back on its own.

Both are also on Core.IDockingManager and on Core.IRootDock, so an MVVM application declares them on its layout and LayoutSyncBridge pushes them to the manager, including later changes. In the DI package the new DockingOptions carries them, ToggleDockOptions derives from it so both configure calls share one options object, and AddDockLayoutService applies them to the layout - no wiring in the window.