### PR TITLE
docs: fix internal links 404ing by prefixing baseurl

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,6 +5,18 @@ description: >-
 url: "https://dirkster99.github.io"
 baseurl: "/AvalonDock"
 
+# This is a GitHub Pages *project* site, so every internal URL must carry the
+# "/AvalonDock" baseurl above. The site is built by actions/jekyll-build-pages
+# (the github-pages gem => Jekyll 3.x), where {% link %} expands to the page's
+# bare url *without* the baseurl. In-page links must therefore be written as:
+#
+#     [Text]({{ site.baseurl }}{% link some/page.md %})
+#
+# NOTE: Jekyll 4 changed {% link %} to apply the relative_url filter itself, so
+# it already includes the baseurl. If .github/workflows/docs.yml is ever moved
+# to Jekyll 4, drop the {{ site.baseurl }} prefixes or every link will resolve
+# to "/AvalonDock/AvalonDock/...".
+
 remote_theme: just-the-docs/just-the-docs@v0.10.0
 
 permalink: pretty

--- a/docs/api-reference/docking-manager.md
+++ b/docs/api-reference/docking-manager.md
@@ -55,7 +55,7 @@ System.Windows.Controls.Control
 | Property | Type | Description |
 |:---------|:-----|:------------|
 | `AllowMixedOrientation` | `bool` | Allow panels with mixed horizontal/vertical orientation. |
-| `AllowFloatingWindows` | `bool` | Whether content can be torn off into floating windows at all. Default `true`. See [Floating Windows]({% link concepts/floating-windows.md %}). |
+| `AllowFloatingWindows` | `bool` | Whether content can be torn off into floating windows at all. Default `true`. See [Floating Windows]({{ site.baseurl }}{% link concepts/floating-windows.md %}). |
 | `AllowDetachedWindows` | `bool` | Whether anchorables can be moved into standalone top level windows ("Window" view mode). Default `true`. |
 | `ShowSystemMenu` | `bool` | Show system menu on floating windows. |
 | `AllowDrop` | `bool` | Enable drag-and-drop docking (inherited from WPF). |
@@ -76,7 +76,7 @@ System.Windows.Controls.Control
 |:-------|:--------|:------------|
 | `GetFloatingWindows()` | `IEnumerable<LayoutFloatingWindowControl>` | Get all active floating windows. |
 | `DockAllFloatingWindows()` | `void` | Dock the content of every floating window back into the layout and close the windows. |
-| `DetachAnchorableToWindow(anchorable)` | `void` | Move the content of an anchorable into a standalone top level window. See [Floating Windows]({% link concepts/floating-windows.md %}). |
+| `DetachAnchorableToWindow(anchorable)` | `void` | Move the content of an anchorable into a standalone top level window. See [Floating Windows]({{ site.baseurl }}{% link concepts/floating-windows.md %}). |
 | `ReattachAnchorable(anchorable)` | `void` | Close that window and return the content to the layout. |
 | `ReattachAllDetachedAnchorables()` | `void` | Return every detached anchorable to the layout. |
 | `IsDetached(anchorable)` | `bool` | Whether the anchorable is currently hosted by a standalone window. |

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -15,10 +15,10 @@ Reference documentation for AvalonDock's key classes, controls, and interfaces.
 
 | Section | Description |
 |:--------|:------------|
-| [DockingManager]({% link api-reference/docking-manager.md %}) | The root control and central entry point. |
-| [Layout Classes]({% link api-reference/layout-classes.md %}) | All layout model classes and interfaces. |
-| [Controls]({% link api-reference/controls.md %}) | WPF controls for rendering the docking UI. |
-| [Events]({% link api-reference/events.md %}) | Events raised during docking operations. |
+| [DockingManager]({{ site.baseurl }}{% link api-reference/docking-manager.md %}) | The root control and central entry point. |
+| [Layout Classes]({{ site.baseurl }}{% link api-reference/layout-classes.md %}) | All layout model classes and interfaces. |
+| [Controls]({{ site.baseurl }}{% link api-reference/controls.md %}) | WPF controls for rendering the docking UI. |
+| [Events]({{ site.baseurl }}{% link api-reference/events.md %}) | Events raised during docking operations. |
 
 ---
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -15,7 +15,7 @@ Understand the fundamental concepts behind AvalonDock's architecture, layout mod
 
 | Topic | Description |
 |:------|:------------|
-| [Architecture]({% link concepts/architecture.md %}) | High-level architecture and component layers. |
-| [Layout Model]({% link concepts/layout-model.md %}) | The tree-based layout model that drives docking. |
-| [Documents & Anchorables]({% link concepts/documents-and-anchorables.md %}) | The two content types and when to use each. |
-| [Floating Windows]({% link concepts/floating-windows.md %}) | How floating windows work and are managed. |
+| [Architecture]({{ site.baseurl }}{% link concepts/architecture.md %}) | High-level architecture and component layers. |
+| [Layout Model]({{ site.baseurl }}{% link concepts/layout-model.md %}) | The tree-based layout model that drives docking. |
+| [Documents & Anchorables]({{ site.baseurl }}{% link concepts/documents-and-anchorables.md %}) | The two content types and when to use each. |
+| [Floating Windows]({{ site.baseurl }}{% link concepts/floating-windows.md %}) | How floating windows work and are managed. |

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -19,9 +19,9 @@ Get up and running with AvalonDock in minutes. This section covers installation,
 
 | Guide | Description |
 |:------|:------------|
-| [Installation]({% link getting-started/installation.md %}) | Install AvalonDock via NuGet and configure your project. |
-| [Quick Start]({% link getting-started/quick-start.md %}) | Build your first docking layout in 5 minutes. |
-| [Building from Source]({% link getting-started/building-from-source.md %}) | Clone, build, and run the project from source code. |
+| [Installation]({{ site.baseurl }}{% link getting-started/installation.md %}) | Install AvalonDock via NuGet and configure your project. |
+| [Quick Start]({{ site.baseurl }}{% link getting-started/quick-start.md %}) | Build your first docking layout in 5 minutes. |
+| [Building from Source]({{ site.baseurl }}{% link getting-started/building-from-source.md %}) | Clone, build, and run the project from source code. |
 
 </div>
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -87,7 +87,7 @@ After installing, add the AvalonDock namespace to your XAML:
 </Window>
 ```
 
-If the project builds without errors, you're ready to go. Head to the [Quick Start]({% link getting-started/quick-start.md %}) guide to build your first layout.
+If the project builds without errors, you're ready to go. Head to the [Quick Start]({{ site.baseurl }}{% link getting-started/quick-start.md %}) guide to build your first layout.
 
 ---
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -137,6 +137,6 @@ Try dragging panels around, floating them, and docking them to different positio
 
 ## What's Next?
 
-- Learn about the [Layout Model]({% link concepts/layout-model.md %}) to understand how AvalonDock organizes content.
-- Explore [MVVM Integration]({% link guides/mvvm.md %}) to bind docking layouts to view models.
-- Browse the [Themes]({% link themes/index.md %}) to find the right look for your app.
+- Learn about the [Layout Model]({{ site.baseurl }}{% link concepts/layout-model.md %}) to understand how AvalonDock organizes content.
+- Explore [MVVM Integration]({{ site.baseurl }}{% link guides/mvvm.md %}) to bind docking layouts to view models.
+- Browse the [Themes]({{ site.baseurl }}{% link themes/index.md %}) to find the right look for your app.

--- a/docs/guides/dependency-injection.md
+++ b/docs/guides/dependency-injection.md
@@ -11,7 +11,7 @@ description: "Register AvalonDock services with dependency injection."
 AvalonDock v5 provides built-in support for `Microsoft.Extensions.DependencyInjection` through the `AvalonDock.DependencyInjection` package.
 
 {: .tip }
-For a full walkthrough, see [Tutorial: Dependency Injection Deep Dive]({% link tutorials/dependency-injection-app.md %}). The `AvalonDockCodeApp` sample project demonstrates all DI patterns.
+For a full walkthrough, see [Tutorial: Dependency Injection Deep Dive]({{ site.baseurl }}{% link tutorials/dependency-injection-app.md %}). The `AvalonDockCodeApp` sample project demonstrates all DI patterns.
 
 ---
 
@@ -145,7 +145,7 @@ These are applied to the layout of `IDockLayoutService`, so a `DockingManager` b
 through `DockLayout` picks them up on its own — nothing has to be copied over in the code-behind of
 the window. Both `DockingOptions` and `ToggleDockOptions` resolve to the same registered instance.
 
-See [Floating Windows]({% link concepts/floating-windows.md %}) for what each switch turns off.
+See [Floating Windows]({{ site.baseurl }}{% link concepts/floating-windows.md %}) for what each switch turns off.
 
 ### Layout Priority Modes
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -15,9 +15,9 @@ Practical how-to guides for integrating AvalonDock with MVVM, dependency injecti
 
 | Guide | Description |
 |:------|:------------|
-| [MVVM Integration]({% link guides/mvvm.md %}) | Bind documents and anchorables to view models. |
-| [ToggleDockingManager]({% link guides/toggle-docking-manager.md %}) | VS Code / Rider-style sidebar toggle docking. |
-| [Dependency Injection]({% link guides/dependency-injection.md %}) | Register AvalonDock services with DI containers. |
-| [Theming]({% link guides/theming.md %}) | Apply and switch themes at runtime. |
-| [Layout Serialization]({% link guides/serialization.md %}) | Save and restore layouts in XML or JSON. |
-| [Custom Themes]({% link guides/custom-themes.md %}) | Create your own theme from scratch. |
+| [MVVM Integration]({{ site.baseurl }}{% link guides/mvvm.md %}) | Bind documents and anchorables to view models. |
+| [ToggleDockingManager]({{ site.baseurl }}{% link guides/toggle-docking-manager.md %}) | VS Code / Rider-style sidebar toggle docking. |
+| [Dependency Injection]({{ site.baseurl }}{% link guides/dependency-injection.md %}) | Register AvalonDock services with DI containers. |
+| [Theming]({{ site.baseurl }}{% link guides/theming.md %}) | Apply and switch themes at runtime. |
+| [Layout Serialization]({{ site.baseurl }}{% link guides/serialization.md %}) | Save and restore layouts in XML or JSON. |
+| [Custom Themes]({{ site.baseurl }}{% link guides/custom-themes.md %}) | Create your own theme from scratch. |

--- a/docs/guides/mvvm.md
+++ b/docs/guides/mvvm.md
@@ -11,7 +11,7 @@ description: "How to use AvalonDock with the MVVM pattern."
 AvalonDock v5 provides first-class support for the MVVM pattern through the `AvalonDock.Mvvm` and `AvalonDock.Core` packages. This guide covers both the **v5 recommended approach** (using `IDockLayoutService` + DI) and the **classic approach** (using `DocumentsSource`/`AnchorablesSource`).
 
 {: .tip }
-For a full step-by-step tutorial, see [Tutorial: MVVM IDE Application]({% link tutorials/mvvm-ide.md %}). The `AvalonDockCodeApp` sample project in the repository is the reference implementation.
+For a full step-by-step tutorial, see [Tutorial: MVVM IDE Application]({{ site.baseurl }}{% link tutorials/mvvm-ide.md %}). The `AvalonDockCodeApp` sample project in the repository is the reference implementation.
 
 ---
 
@@ -206,7 +206,7 @@ public partial class MainViewModel : ObservableObject
 </avalonDock:ToggleDockingManager>
 ```
 
-See [ToggleDockingManager]({% link guides/toggle-docking-manager.md %}) for the full guide on zones, button customization, and layout priority.
+See [ToggleDockingManager]({{ site.baseurl }}{% link guides/toggle-docking-manager.md %}) for the full guide on zones, button customization, and layout priority.
 
 ### Window Policy from the Layout
 
@@ -223,8 +223,8 @@ dockService.Layout.AllowDetachedWindows = false;   // No standalone "Window" vie
 
 A `DockingManager` bound through `DockLayout` applies them when the layout is bound and follows any
 later change. With `AvalonDock.DependencyInjection` you can set them at registration instead — see
-[Dependency Injection]({% link guides/dependency-injection.md %}). For what each switch turns off, see
-[Floating Windows]({% link concepts/floating-windows.md %}).
+[Dependency Injection]({{ site.baseurl }}{% link guides/dependency-injection.md %}). For what each switch turns off, see
+[Floating Windows]({{ site.baseurl }}{% link concepts/floating-windows.md %}).
 
 ---
 

--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -151,4 +151,4 @@ var resourceDict = new ResourceDictionary
 dockManager.Theme = new DictionaryTheme(resourceDict);
 ```
 
-See the [Custom Themes]({% link guides/custom-themes.md %}) guide for more details on creating your own theme from scratch.
+See the [Custom Themes]({{ site.baseurl }}{% link guides/custom-themes.md %}) guide for more details on creating your own theme from scratch.

--- a/docs/guides/toggle-docking-manager.md
+++ b/docs/guides/toggle-docking-manager.md
@@ -175,7 +175,7 @@ services.AddDockLayoutService(dock =>
 });
 ```
 
-See [MVVM Integration]({% link guides/mvvm.md %}) for the full pattern.
+See [MVVM Integration]({{ site.baseurl }}{% link guides/mvvm.md %}) for the full pattern.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ permalink: /
 A powerful WPF Document and Tool Window layout container for building Visual Studio-like docking interfaces.
 {: .fs-6 .fw-300 }
 
-[Get Started]({% link getting-started/index.md %}){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Get Started]({{ site.baseurl }}{% link getting-started/index.md %}){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [View on GitHub](https://github.com/Dirkster99/AvalonDock){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 ---
@@ -104,7 +104,7 @@ AvalonDock is a WPF library and runs exclusively on Windows.
 
 ## Upgrading from v4?
 
-If you are migrating from AvalonDock v4.x, see the [Migration Guide]({% link migration/index.md %}) for a complete list of breaking changes and step-by-step upgrade instructions.
+If you are migrating from AvalonDock v4.x, see the [Migration Guide]({{ site.baseurl }}{% link migration/index.md %}) for a complete list of breaking changes and step-by-step upgrade instructions.
 
 ---
 

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -183,7 +183,7 @@ After making all changes:
 
 ## Breaking Changes Summary
 
-See the detailed [Breaking Changes]({% link migration/breaking-changes.md %}) page for a complete list.
+See the detailed [Breaking Changes]({{ site.baseurl }}{% link migration/breaking-changes.md %}) page for a complete list.
 
 ---
 

--- a/docs/themes/index.md
+++ b/docs/themes/index.md
@@ -17,13 +17,13 @@ AvalonDock ships with six polished theme packages. Each theme is a separate NuGe
 
 | Theme                                         | Variants | Style                            |
 |:----------------------------------------------|:---------|:---------------------------------|
-| [Arc]({% link themes/arc.md %})               | Dark, Light | Modern, compact, rounded corners |
-| [VS]({% link themes/vs.md %})                 | Dark, Light, Blue | .vstheme based Visual Studio |
-| [VS2013]({% link themes/vs2013.md %})         | Dark, Light, Blue | Classic Visual Studio 2013       |
-| [VS2010]({% link themes/vs2010.md %})         | Single | Visual Studio 2010               |
-| [Expression]({% link themes/expression.md %}) | Dark, Light | Expression Blend inspired        |
-| [Metro]({% link themes/metro.md %})           | Single | Flat Metro / WinUI               |
-| [Aero]({% link themes/aero.md %})             | Single | Classic Windows Aero             |
+| [Arc]({{ site.baseurl }}{% link themes/arc.md %})               | Dark, Light | Modern, compact, rounded corners |
+| [VS]({{ site.baseurl }}{% link themes/vs.md %})                 | Dark, Light, Blue | .vstheme based Visual Studio |
+| [VS2013]({{ site.baseurl }}{% link themes/vs2013.md %})         | Dark, Light, Blue | Classic Visual Studio 2013       |
+| [VS2010]({{ site.baseurl }}{% link themes/vs2010.md %})         | Single | Visual Studio 2010               |
+| [Expression]({{ site.baseurl }}{% link themes/expression.md %}) | Dark, Light | Expression Blend inspired        |
+| [Metro]({{ site.baseurl }}{% link themes/metro.md %})           | Single | Flat Metro / WinUI               |
+| [Aero]({{ site.baseurl }}{% link themes/aero.md %})             | Single | Classic Windows Aero             |
 
 ---
 
@@ -48,4 +48,4 @@ dockManager.Theme = new ArcDarkTheme();
 </avalonDock:DockingManager.Theme>
 ```
 
-Themes can be switched at runtime — see the [Theming Guide]({% link guides/theming.md %}) for details.
+Themes can be switched at runtime — see the [Theming Guide]({{ site.baseurl }}{% link guides/theming.md %}) for details.

--- a/docs/themes/vs2013.md
+++ b/docs/themes/vs2013.md
@@ -54,7 +54,7 @@ byte[] lightBytes = VsThemeResources.Light;
 byte[] blueBytes = VsThemeResources.Blue;
 ```
 
-These are parsed at runtime through `VsThemeParser.ParseGZip()` and mapped to AvalonDock resource keys via `VsThemePaletteFactory`. See the [VS Theme]({% link themes/vs.md %}) page for details on the `.vstheme` parsing API.
+These are parsed at runtime through `VsThemeParser.ParseGZip()` and mapped to AvalonDock resource keys via `VsThemePaletteFactory`. See the [VS Theme]({{ site.baseurl }}{% link themes/vs.md %}) page for details on the `.vstheme` parsing API.
 
 ---
 

--- a/docs/tutorials/dependency-injection-app.md
+++ b/docs/tutorials/dependency-injection-app.md
@@ -8,7 +8,7 @@ description: "Build a modern AvalonDock application using the v5 DI architecture
 
 # Tutorial: Dependency Injection Deep Dive
 
-This tutorial builds on the [MVVM IDE tutorial]({% link tutorials/mvvm-ide.md %}) and provides a detailed walkthrough of every DI extension method, registration pattern, and configuration option available in AvalonDock v5. Use this as a reference when scaling your application.
+This tutorial builds on the [MVVM IDE tutorial]({{ site.baseurl }}{% link tutorials/mvvm-ide.md %}) and provides a detailed walkthrough of every DI extension method, registration pattern, and configuration option available in AvalonDock v5. Use this as a reference when scaling your application.
 
 {: .tip }
 This tutorial covers the same DI patterns used in the `AvalonDockCodeApp` sample project — the reference implementation for AvalonDock v5.
@@ -354,8 +354,8 @@ public void OpenFile_CreatesDocument()
 
 ## Next Steps
 
-- Follow the [MVVM IDE tutorial]({% link tutorials/mvvm-ide.md %}) for a complete step-by-step walkthrough
-- Add [Layout Persistence]({% link tutorials/layout-persistence.md %}) to save and restore layouts
-- Apply [Custom Themes]({% link tutorials/styling-and-theming.md %}) to match your brand
+- Follow the [MVVM IDE tutorial]({{ site.baseurl }}{% link tutorials/mvvm-ide.md %}) for a complete step-by-step walkthrough
+- Add [Layout Persistence]({{ site.baseurl }}{% link tutorials/layout-persistence.md %}) to save and restore layouts
+- Apply [Custom Themes]({{ site.baseurl }}{% link tutorials/styling-and-theming.md %}) to match your brand
 - See the `AvalonDockCodeApp` project in the repository for the complete reference implementation
-- Review all [DI extension methods]({% link guides/dependency-injection.md %}) in the reference guide
+- Review all [DI extension methods]({{ site.baseurl }}{% link guides/dependency-injection.md %}) in the reference guide

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -12,7 +12,7 @@ permalink: /tutorials/
 Hands-on, step-by-step tutorials that walk you through building real applications with AvalonDock. Each tutorial builds a complete, working example from scratch.
 
 {: .note }
-These tutorials assume you have already completed the [Quick Start]({% link getting-started/quick-start.md %}) guide and are familiar with WPF basics.
+These tutorials assume you have already completed the [Quick Start]({{ site.baseurl }}{% link getting-started/quick-start.md %}) guide and are familiar with WPF basics.
 
 ---
 
@@ -20,10 +20,10 @@ These tutorials assume you have already completed the [Quick Start]({% link gett
 
 | Tutorial | What You'll Build | Key Topics |
 |:---------|:------------------|:-----------|
-| [MVVM IDE Application]({% link tutorials/mvvm-ide.md %}) | A VS Code-style IDE with sidebar toggles | ToolboxBase, Document, IDockLayoutService, ToggleDockingManager, DockZone, DI |
-| [Dependency Injection Deep Dive]({% link tutorials/dependency-injection-app.md %}) | DI patterns and APIs in depth | AddDockLayoutService builder, DockLayoutBuilder, ConfigureToggleDock, factory registration, testing |
-| [Styling & Theming]({% link tutorials/styling-and-theming.md %}) | A theme-switchable app with custom branding | Runtime theme switching, brush overrides, custom theme classes, application-wide theming |
-| [Layout Persistence]({% link tutorials/layout-persistence.md %}) | An app that remembers its window layout | XML/JSON serialization, MVVM serialization callbacks, auto-save, layout reset |
+| [MVVM IDE Application]({{ site.baseurl }}{% link tutorials/mvvm-ide.md %}) | A VS Code-style IDE with sidebar toggles | ToolboxBase, Document, IDockLayoutService, ToggleDockingManager, DockZone, DI |
+| [Dependency Injection Deep Dive]({{ site.baseurl }}{% link tutorials/dependency-injection-app.md %}) | DI patterns and APIs in depth | AddDockLayoutService builder, DockLayoutBuilder, ConfigureToggleDock, factory registration, testing |
+| [Styling & Theming]({{ site.baseurl }}{% link tutorials/styling-and-theming.md %}) | A theme-switchable app with custom branding | Runtime theme switching, brush overrides, custom theme classes, application-wide theming |
+| [Layout Persistence]({{ site.baseurl }}{% link tutorials/layout-persistence.md %}) | An app that remembers its window layout | XML/JSON serialization, MVVM serialization callbacks, auto-save, layout reset |
 
 ---
 

--- a/docs/tutorials/layout-persistence.md
+++ b/docs/tutorials/layout-persistence.md
@@ -407,7 +407,7 @@ The `ContentId` is the key that links serialized layout items to your applicatio
 
 ## Next Steps
 
-- See the [Layout Serialization Guide]({% link guides/serialization.md %}) for a complete API reference
-- Combine with [MVVM]({% link tutorials/mvvm-ide.md %}) for a full IDE experience
+- See the [Layout Serialization Guide]({{ site.baseurl }}{% link guides/serialization.md %}) for a complete API reference
+- Combine with [MVVM]({{ site.baseurl }}{% link tutorials/mvvm-ide.md %}) for a full IDE experience
 - Explore the `MVVMTestApp` sample for a working implementation with save/restore
 - Explore the `TestApp` sample for layout reload/unload patterns

--- a/docs/tutorials/mvvm-ide.md
+++ b/docs/tutorials/mvvm-ide.md
@@ -669,8 +669,8 @@ That's it — `DockLayoutService` automatically places it in the layout based on
 
 ## Next Steps
 
-- Add [Layout Persistence]({% link tutorials/layout-persistence.md %}) to save and restore the user's panel arrangement
-- Apply a [Custom Theme]({% link tutorials/styling-and-theming.md %}) to match your application's branding
+- Add [Layout Persistence]({{ site.baseurl }}{% link tutorials/layout-persistence.md %}) to save and restore the user's panel arrangement
+- Apply a [Custom Theme]({{ site.baseurl }}{% link tutorials/styling-and-theming.md %}) to match your application's branding
 - See the `AvalonDockCodeApp` project in the repository for the full reference implementation with a terminal, file icons, and syntax highlighting
-- Review the [MVVM Guide]({% link guides/mvvm.md %}) for additional patterns (template selectors, style selectors)
-- Review the [DI Guide]({% link guides/dependency-injection.md %}) for all available DI extension methods
+- Review the [MVVM Guide]({{ site.baseurl }}{% link guides/mvvm.md %}) for additional patterns (template selectors, style selectors)
+- Review the [DI Guide]({{ site.baseurl }}{% link guides/dependency-injection.md %}) for all available DI extension methods

--- a/docs/tutorials/styling-and-theming.md
+++ b/docs/tutorials/styling-and-theming.md
@@ -444,7 +444,7 @@ DockingManager
 
 ## Next Steps
 
-- See the [Custom Themes Guide]({% link guides/custom-themes.md %}) for a reference of all customization points
-- See the [Theming Guide]({% link guides/theming.md %}) for a complete list of themes and their variants
+- See the [Custom Themes Guide]({{ site.baseurl }}{% link guides/custom-themes.md %}) for a reference of all customization points
+- See the [Theming Guide]({{ site.baseurl }}{% link guides/theming.md %}) for a complete list of themes and their variants
 - Explore the `TestApp` sample for all 11 theme variants with runtime switching
 - Explore the `MLibTest` sample for MLib + AvalonDock unified theming


### PR DESCRIPTION
All 61 in-page links in the documentation used a bare `{% link %}` tag, which resolved to URLs without the site's `/AvalonDock` baseurl. The "Get Started" button on the home page pointed at
https://dirkster99.github.io/getting-started/ instead of https://dirkster99.github.io/AvalonDock/getting-started/, and every other in-text cross-reference 404'd the same way.

The site is built by actions/jekyll-build-pages (the github-pages gem, Jekyll 3.x), where the `link` tag returns the page's bare `url` with no baseurl applied. Jekyll 4 later changed this tag to run `relative_url` itself, which is why the markup looks correct at first glance.

Prefix all 61 occurrences with `{{ site.baseurl }}` and document the convention (and the Jekyll 4 caveat) in _config.yml.

Verified by building docs/ with Jekyll 3.10.0 and checking every generated internal href against the produced files: 61/61 now resolve, previously 61/61 were broken. Link targets themselves were all correct and needed no path changes.