### PR TITLE
Additional null checks in AutoHideWindowManager

### DIFF
--- a/source/Components/AvalonDock/DockingManager.cs
+++ b/source/Components/AvalonDock/DockingManager.cs
@@ -2486,6 +2486,7 @@ namespace AvalonDock
 				fwc.EnableBindings();
 				if (fwc.KeepContentVisibleOnClose)
 				{
+					fwc.UpdateOwnership();
 					fwc.Show();
 					fwc.KeepContentVisibleOnClose = false;
 				}


### PR DESCRIPTION
We recorded the following exception stacktrace by a customer:

AvalonDock.Controls.LayoutAutoHideWindowControl.get_IsWin32MouseOver()
bei AvalonDock.Controls.AutoHideWindowManager.<SetupCloseTimer>b__6_0(Object s, EventArgs e)
bei System.Windows.Threading.DispatcherTimer.FireTick(Object unused)
bei System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
bei System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)

In order to avoid this exception I added additional null checks in AutoHideWindowManager: SetupCloseTimer and StopCloseTimer